### PR TITLE
BLD: New HDF5 autoconf check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,9 +196,10 @@ fi
 
 # HDF5
 if test "$enable_hdf5" = "yes" ; then
-  CIT_HDF5_HEADER
-  CIT_HDF5_LIB
-  CIT_HDF5_LIB_PARALLEL
+  AX_LIB_HDF5([parallel])
+  if test "$with_hdf5" = "no"; then
+    AC_MSG_ERROR([HDF5 library not found; try --with-hdf5=<path>])
+  fi
 fi
 
 # Full-scale testing with h5py


### PR DESCRIPTION
I have suggested in [autoconf_cig](https://github.com/geodynamics/autoconf_cig/pull/8) to use the HDF5 check from the autoconf archive. It actually seems to work whereas the other two fail in some cases.

This PR adjusts pylith to use the same macro. However, I really don't understand why pylith checks for it since it does nothing with the result. Is it simply to check early?

Anyway, please don't merge until the PR on autoconf_cig is also merged so that we can be on one consistent HEAD.
