### PR TITLE
Improve error message when SWIG is needed but is not enabled

### DIFF
--- a/modulesrc/bc/Makefile.am
+++ b/modulesrc/bc/Makefile.am
@@ -54,6 +54,9 @@ endif
 if ENABLE_SWIG
 $(srcdir)/bc_wrap.cxx $(srcdir)/bc.py: $(swig_sources)
 	$(SWIG) $(PETSC_CC_INCLUDES) -Wall -c++ -python $<
+else
+$(srcdir)/bc_wrap.cxx $(srcdir)/bc.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 

--- a/modulesrc/faults/Makefile.am
+++ b/modulesrc/faults/Makefile.am
@@ -55,6 +55,9 @@ endif
 if ENABLE_SWIG
 $(srcdir)/faults_wrap.cxx $(srcdir)/faults.py: $(swig_sources)
 	$(SWIG) $(PETSC_CC_INCLUDES) -Wall -c++ -python $<
+else
+$(srcdir)/faults_wrap.cxx $(srcdir)/faults.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 

--- a/modulesrc/feassemble/Makefile.am
+++ b/modulesrc/feassemble/Makefile.am
@@ -48,6 +48,9 @@ endif
 if ENABLE_SWIG
 $(srcdir)/feassemble_wrap.cxx $(srcdir)/feassemble.py: $(swig_sources)
 	$(SWIG) $(PETSC_CC_INCLUDES) -Wall -c++ -python $<
+else
+$(srcdir)/feassemble_wrap.cxx $(srcdir)/feassemble.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 

--- a/modulesrc/friction/Makefile.am
+++ b/modulesrc/friction/Makefile.am
@@ -53,6 +53,9 @@ endif
 if ENABLE_SWIG
 $(srcdir)/friction_wrap.cxx $(srcdir)/friction.py: $(swig_sources)
 	$(SWIG) $(PETSC_CC_INCLUDES) -Wall -c++ -python $<
+else
+$(srcdir)/friction_wrap.cxx $(srcdir)/friction.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 

--- a/modulesrc/materials/Makefile.am
+++ b/modulesrc/materials/Makefile.am
@@ -64,6 +64,9 @@ endif
 if ENABLE_SWIG
 $(srcdir)/materials_wrap.cxx $(srcdir)/materials.py: $(swig_sources)
 	$(SWIG) $(PETSC_CC_INCLUDES) -Wall -c++ -python $<
+else
+$(srcdir)/materials_wrap.cxx $(srcdir)/materials.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 

--- a/modulesrc/meshio/Makefile.am
+++ b/modulesrc/meshio/Makefile.am
@@ -69,6 +69,9 @@ endif
 if ENABLE_SWIG
 $(srcdir)/meshio_wrap.cxx $(srcdir)/meshio.py: $(swig_sources)
 	$(SWIG) $(PETSC_CC_INCLUDES) $(PYLITH_SWIG_CPPFLAGS) -Wall -c++ -python $<
+else
+$(srcdir)/meshio_wrap.cxx $(srcdir)/meshio.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 if ENABLE_HDF5

--- a/modulesrc/mpi/Makefile.am
+++ b/modulesrc/mpi/Makefile.am
@@ -48,6 +48,9 @@ _mpimodule_la_LIBADD = \
 if ENABLE_SWIG
 $(srcdir)/mpi_wrap.cxx $(srcdir)/mpi.py: $(swig_sources)
 	$(SWIG) $(PETSC_CC_INCLUDES) -Wall -c++ -python $<
+else
+$(srcdir)/mpi_wrap.cxx $(srcdir)/mpi.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 

--- a/modulesrc/problems/Makefile.am
+++ b/modulesrc/problems/Makefile.am
@@ -64,6 +64,9 @@ endif
 if ENABLE_SWIG
 $(srcdir)/problems_wrap.cxx $(srcdir)/problems.py: $(swig_sources)
 	$(SWIG) $(PETSC_CC_INCLUDES) -Wall -c++ -python $<
+else
+$(srcdir)/problems_wrap.cxx $(srcdir)/problems.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 

--- a/modulesrc/topology/Makefile.am
+++ b/modulesrc/topology/Makefile.am
@@ -53,6 +53,9 @@ _topologymodule_la_LIBADD = \
 if ENABLE_SWIG
 $(srcdir)/topology_wrap.cxx $(srcdir)/topology.py: $(swig_sources)
 	$(SWIG) $(PETSC_CC_INCLUDES) -Wall -c++ -python $<
+else
+$(srcdir)/topology_wrap.cxx $(srcdir)/topology.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 

--- a/modulesrc/utils/Makefile.am
+++ b/modulesrc/utils/Makefile.am
@@ -87,6 +87,9 @@ $(srcdir)/petsc_wrap.cxx $(srcdir)/petsc.py: $(petsc_swig_sources)
 
 $(srcdir)/utils_wrap.cxx $(srcdir)/utils.py: $(utils_swig_sources)
 	$(SWIG) $(PETSC_CC_INCLUDES) -Wall -c++ -python $<
+else
+$(srcdir)/petsc_wrap.cxx $(srcdir)/petsc.py $(srcdir)/utils_wrap.cxx $(srcdir)/utils.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 


### PR DESCRIPTION
Add error message to Makefile if SWIG is disabled and SWIG generated files are not present.

Previously, the error message during "make" was that Make didn't know how to generate the SWIG generated files.