### PR TITLE
Change bool tensorBasis to more flexible cellBasis enum.

### DIFF
--- a/libsrc/pylith/faults/FaultCohesiveKin.cc
+++ b/libsrc/pylith/faults/FaultCohesiveKin.cc
@@ -278,8 +278,8 @@ pylith::faults::FaultCohesiveKin::createAuxiliaryField(const pylith::topology::F
     // Set default discretization of auxiliary subfields to match lagrange_multiplier_fault subfield in solution.
     assert(_auxiliaryFactory);
     const pylith::topology::FieldBase::Discretization& discretization = solution.subfieldInfo("lagrange_multiplier_fault").fe;
-    _auxiliaryFactory->setSubfieldDiscretization("default", discretization.tensorBasis, discretization.basisOrder, discretization.quadOrder, -1,
-                                                 discretization.isBasisContinuous, discretization.feSpace);
+    _auxiliaryFactory->setSubfieldDiscretization("default", discretization.basisOrder, discretization.quadOrder, -1,
+                                                 discretization.cellBasis, discretization.isBasisContinuous, discretization.feSpace);
 
     assert(_auxiliaryFactory);
     assert(_normalizer);

--- a/libsrc/pylith/faults/KinSrc.cc
+++ b/libsrc/pylith/faults/KinSrc.cc
@@ -113,8 +113,8 @@ pylith::faults::KinSrc::initialize(const pylith::topology::Field& faultAuxField,
     // Set default discretization of auxiliary subfields to match slip subfield in integrator auxiliary field.
     assert(_auxFactory);
     const pylith::topology::FieldBase::Discretization& discretization = faultAuxField.subfieldInfo("slip").fe;
-    _auxFactory->setSubfieldDiscretization("default", discretization.tensorBasis, discretization.basisOrder, discretization.quadOrder,
-                                           discretization.dimension, discretization.isBasisContinuous,
+    _auxFactory->setSubfieldDiscretization("default", discretization.basisOrder, discretization.quadOrder,
+                                           discretization.dimension, discretization.cellBasis, discretization.isBasisContinuous,
                                            discretization.feSpace);
 
     delete _auxField;_auxField = new pylith::topology::Field(faultAuxField.mesh());assert(_auxField);

--- a/libsrc/pylith/meshio/DataWriterHDF5.cc
+++ b/libsrc/pylith/meshio/DataWriterHDF5.cc
@@ -177,7 +177,6 @@ pylith::meshio::DataWriterHDF5::open(const pylith::topology::Mesh& mesh,
         const PetscInt *gvertex = NULL;
         PetscVec cellVec = NULL;
         PetscScalar *vertices = NULL;
-        const PetscInt dim = mesh.dimension();
 
         err = DMPlexGetVertexNumbering(dmMesh, &globalVertexNumbers);PYLITH_CHECK_ERROR(err);
         err = ISGetIndices(globalVertexNumbers, &gvertex);PYLITH_CHECK_ERROR(err);

--- a/libsrc/pylith/meshio/DataWriterHDF5Ext.cc
+++ b/libsrc/pylith/meshio/DataWriterHDF5Ext.cc
@@ -206,7 +206,6 @@ pylith::meshio::DataWriterHDF5Ext::open(const pylith::topology::Mesh& mesh,
         const PetscInt *gvertex = NULL;
         PetscVec cellVec = NULL;
         PetscScalar *vertices = NULL;
-        const PetscInt meshDim = mesh.dimension();
 
         err = DMPlexGetVertexNumbering(dmMesh, &globalVertexNumbers);PYLITH_CHECK_ERROR(err);
         err = ISGetIndices(globalVertexNumbers, &gvertex);PYLITH_CHECK_ERROR(err);

--- a/libsrc/pylith/meshio/FieldFilterProject.cc
+++ b/libsrc/pylith/meshio/FieldFilterProject.cc
@@ -154,7 +154,7 @@ pylith::meshio::FieldFilterProject::filter(pylith::topology::Field* fieldIn) {
             feP1.feSpace = infoIn.fe.feSpace;
             feP1.quadOrder = infoIn.fe.quadOrder;
             feP1.dimension = infoIn.fe.dimension;
-            feP1.tensorBasis = infoIn.fe.tensorBasis;
+            feP1.cellBasis = infoIn.fe.cellBasis;
 
             if (infoIn.fe.quadOrder < _basisOrder) {
                 PYLITH_COMPONENT_WARNING(

--- a/libsrc/pylith/problems/Physics.cc
+++ b/libsrc/pylith/problems/Physics.cc
@@ -102,17 +102,17 @@ pylith::problems::Physics::setAuxiliaryFieldDB(spatialdata::spatialdb::SpatialDB
 // Set discretization information for auxiliary subfield.
 void
 pylith::problems::Physics::setAuxiliarySubfieldDiscretization(const char* subfieldName,
-                                                              const bool tensorBasis,
                                                               const int basisOrder,
                                                               const int quadOrder,
                                                               const int dimension,
+                                                              const pylith::topology::FieldBase::CellBasis cellBasis,
                                                               const bool isBasisContinuous,
                                                               const pylith::topology::FieldBase::SpaceEnum feSpace) {
     PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("setAuxiliarySubfieldDiscretization(subfieldName="<<subfieldName<<", tensorBasis="<<tensorBasis<<", basisOrder="<<basisOrder<<", quadOrder="<<quadOrder<<", dimension="<<dimension<<", isBasisContinuous="<<isBasisContinuous<<")");
+    PYLITH_COMPONENT_DEBUG("setAuxiliarySubfieldDiscretization(subfieldName="<<subfieldName<<", basisOrder="<<basisOrder<<", quadOrder="<<quadOrder<<", dimension="<<dimension<<", cellBasis="<<cellBasis<<", isBasisContinuous="<<isBasisContinuous<<")");
 
     pylith::feassemble::AuxiliaryFactory* factory = _getAuxiliaryFactory();assert(factory);
-    factory->setSubfieldDiscretization(subfieldName, tensorBasis, basisOrder, quadOrder, dimension, isBasisContinuous, feSpace);
+    factory->setSubfieldDiscretization(subfieldName, basisOrder, quadOrder, dimension, cellBasis, isBasisContinuous, feSpace);
 
     PYLITH_METHOD_END;
 } // setAuxSubfieldDiscretization
@@ -122,17 +122,17 @@ pylith::problems::Physics::setAuxiliarySubfieldDiscretization(const char* subfie
 // Set discretization information for derived subfield.
 void
 pylith::problems::Physics::setDerivedSubfieldDiscretization(const char* subfieldName,
-                                                            const bool tensorBasis,
                                                             const int basisOrder,
                                                             const int quadOrder,
                                                             const int dimension,
+                                                            const pylith::topology::FieldBase::CellBasis cellBasis,
                                                             const bool isBasisContinuous,
                                                             const pylith::topology::FieldBase::SpaceEnum feSpace) {
     PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("setDerivedSubfieldDiscretization(subfieldName="<<subfieldName<<", tensorBasis="<<tensorBasis<<", basisOrder="<<basisOrder<<", quadOrder="<<quadOrder<<", dimension="<<dimension<<", isBasisContinuous="<<isBasisContinuous<<")");
+    PYLITH_COMPONENT_DEBUG("setDerivedSubfieldDiscretization(subfieldName="<<subfieldName<<", basisOrder="<<basisOrder<<", quadOrder="<<quadOrder<<", dimension="<<dimension<<", cellBasis="<<cellBasis<<", isBasisContinuous="<<isBasisContinuous<<")");
 
     pylith::topology::FieldFactory* factory = _getDerivedFactory();assert(factory);
-    factory->setSubfieldDiscretization(subfieldName, tensorBasis, basisOrder, quadOrder, dimension, isBasisContinuous, feSpace);
+    factory->setSubfieldDiscretization(subfieldName, basisOrder, quadOrder, dimension, cellBasis, isBasisContinuous, feSpace);
 
     PYLITH_METHOD_END;
 } // setDerivedSubfieldDiscretization

--- a/libsrc/pylith/problems/Physics.hh
+++ b/libsrc/pylith/problems/Physics.hh
@@ -75,14 +75,15 @@ public:
      * @param[in] basisOrder Polynomial order for basis.
      * @param[in] quadOrder Order of quadrature rule.
      * @param[in] dimension Dimension of points for discretization.
+     * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
      * @param[in] isBasisContinuous True if basis is continuous.
      * @param[in] feSpace Finite-element space.
      */
     void setAuxiliarySubfieldDiscretization(const char* subfieldName,
-                                            const bool tensorBasis,
                                             const int basisOrder,
                                             const int quadOrder,
                                             const int dimension,
+                                            const pylith::topology::FieldBase::CellBasis cellBasis,
                                             const bool isBasisContinuous,
                                             const pylith::topology::FieldBase::SpaceEnum feSpace);
 
@@ -92,14 +93,15 @@ public:
      * @param[in] basisOrder Polynomial order for basis.
      * @param[in] quadOrder Order of quadrature rule.
      * @param[in] dimension Dimension of points for discretization.
+     * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
      * @param[in] isBasisContinuous True if basis is continuous.
      * @param[in] feSpace Finite-element space.
      */
     void setDerivedSubfieldDiscretization(const char* subfieldName,
-                                          const bool tensorBasis,
                                           const int basisOrder,
                                           const int quadOrder,
                                           const int dimension,
+                                          const pylith::topology::FieldBase::CellBasis cellBasis,
                                           const bool isBasisContinuous,
                                           const pylith::topology::FieldBase::SpaceEnum feSpace);
 

--- a/libsrc/pylith/testing/FieldTester.cc
+++ b/libsrc/pylith/testing/FieldTester.cc
@@ -34,8 +34,8 @@
 // Check to make sure field matches spatial database.
 PylithReal
 pylith::testing::FieldTester::checkFieldWithDB(const pylith::topology::Field& field,
-                                                spatialdata::spatialdb::SpatialDB* fieldDB,
-                                                const PylithReal lengthScale) {
+                                               spatialdata::spatialdb::SpatialDB* fieldDB,
+                                               const PylithReal lengthScale) {
     PYLITH_METHOD_BEGIN;
     PylithReal norm = 0.0;
     PylithReal t = 0.0;
@@ -56,7 +56,7 @@ pylith::testing::FieldTester::checkFieldWithDB(const pylith::topology::Field& fi
 // Test subfield info created by factory.
 void
 pylith::testing::FieldTester::checkSubfieldInfo(const pylith::topology::Field& field,
-                                                 const pylith::topology::Field::SubfieldInfo& infoE) {
+                                                const pylith::topology::Field::SubfieldInfo& infoE) {
     PYLITH_METHOD_BEGIN;
 
     const pylith::topology::Field::SubfieldInfo& info = field.subfieldInfo(infoE.description.label.c_str());
@@ -83,10 +83,10 @@ pylith::testing::FieldTester::checkSubfieldInfo(const pylith::topology::Field& f
     // Discretization
     const pylith::topology::Field::Discretization& feE = infoE.fe;
     const pylith::topology::Field::Discretization& fe = info.fe;
-    CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.tensorBasis, fe.tensorBasis);
     CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.basisOrder, fe.basisOrder);
     CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.quadOrder, fe.quadOrder);
     CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.dimension, fe.dimension);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.cellBasis, fe.cellBasis);
     CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.isBasisContinuous, fe.isBasisContinuous);
     CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.feSpace, fe.feSpace);
 

--- a/libsrc/pylith/topology/Distributor.cc
+++ b/libsrc/pylith/topology/Distributor.cc
@@ -103,7 +103,11 @@ pylith::topology::Distributor::write(meshio::DataWriter* const writer,
     const int quadOrder = 0;
     const int dim = -1;
     const double scale = 1.0;
-    partition.subfieldAdd("partition", "partition", pylith::topology::Field::SCALAR, components, numComponents, scale, !mesh.isSimplex(), basisOrder, quadOrder, dim, true, pylith::topology::Field::POLYNOMIAL_SPACE);
+    pylith::topology::FieldBase::CellBasis cellBasis = mesh.isSimplex() ?
+                                                       pylith::topology::FieldBase::SIMPLEX_BASIS : pylith::topology::FieldBase::TENSOR_BASIS;
+    const bool isBasisContinuous = true;
+    partition.subfieldAdd("partition", "partition", pylith::topology::Field::SCALAR, components, numComponents, scale,
+                          basisOrder, quadOrder, dim, cellBasis, isBasisContinuous, pylith::topology::Field::POLYNOMIAL_SPACE);
     partition.subfieldsSetup();
     partition.createDiscretization();
     partition.allocate();

--- a/libsrc/pylith/topology/Field.cc
+++ b/libsrc/pylith/topology/Field.cc
@@ -928,7 +928,7 @@ pylith::topology::Field::subfieldAdd(const char *name,
                                      const bool isBasisContinuous,
                                      const SpaceEnum feSpace) {
     assert(numComponents > 0);
-    assert(dimension > 0);
+    assert(dimension != 0);
 
     Description description;
     description.label = name;

--- a/libsrc/pylith/topology/Field.cc
+++ b/libsrc/pylith/topology/Field.cc
@@ -100,10 +100,10 @@ pylith::topology::Field::Field(const Mesh& mesh,
     err = DMPlexGetConeSize(dm, cStart, &coneSize);PYLITH_CHECK_ERROR(err);
 
     Discretization fe;
-    fe.tensorBasis = (dim+1 == coneSize);
     fe.basisOrder = 1;
     fe.quadOrder = 1;
     fe.dimension = -1;
+    fe.cellBasis = (dim+1 == coneSize) ? TENSOR_BASIS : SIMPLEX_BASIS;
     subfieldAdd(description, fe);
     subfieldsSetup();
 
@@ -500,11 +500,26 @@ pylith::topology::Field::view(const char* label,
                     std::cout << " " << sinfo.description.componentNames[i];
                 } // for
             } // if
+            std::string cellBasisString = "default";
+            switch (sinfo.fe.cellBasis) {
+            case SIMPLEX_BASIS:
+                cellBasisString = "simplex";
+                break;
+            case TENSOR_BASIS:
+                cellBasisString = "tensor";
+                break;
+            case DEFAULT_BASIS:
+                cellBasisString = "default";
+                break;
+            default:
+                assert(0);
+                throw std::logic_error("Unknown cell basis");
+            } // switch
             std::cout << ", scale: " << sinfo.description.scale
-                      << ", tensorBasis: " << sinfo.fe.tensorBasis
                       << ", basisOrder: " << sinfo.fe.basisOrder
                       << ", quadOrder: " << sinfo.fe.quadOrder
                       << ", dimension: " << sinfo.fe.dimension
+                      << ", cellBasis: " << cellBasisString
                       << "\n";
         } // for
     } // if
@@ -652,9 +667,9 @@ pylith::topology::Field::createScatterWithBC(const Mesh& mesh,
     err = DMPlexGetDepthStratum(_dm, 0, NULL, &vEnd);PYLITH_CHECK_ERROR(err);
     cMax = cStart;
     for (PetscInt cell = cStart; cell < cEnd; ++cell, ++cMax) {
-      DMPolytopeType ct;
-      err = DMPlexGetCellType(_dm, cell, &ct);PYLITH_CHECK_ERROR(err);
-      if ((ct == DM_POLYTOPE_SEG_PRISM_TENSOR) || (ct == DM_POLYTOPE_TRI_PRISM_TENSOR) || (ct == DM_POLYTOPE_QUAD_PRISM_TENSOR)) break;
+        DMPolytopeType ct;
+        err = DMPlexGetCellType(_dm, cell, &ct);PYLITH_CHECK_ERROR(err);
+        if ((ct == DM_POLYTOPE_SEG_PRISM_TENSOR) || (ct == DM_POLYTOPE_TRI_PRISM_TENSOR) || (ct == DM_POLYTOPE_QUAD_PRISM_TENSOR)) { break;}
     }
     PetscInt excludeRanges[4] = {cMax, cEnd, vMax, vEnd};
     PetscInt numExcludes = (cMax < cEnd ? 1 : 0) + (vMax >= 0 ? 1 : 0);
@@ -906,10 +921,10 @@ pylith::topology::Field::subfieldAdd(const char *name,
                                      const char* components[],
                                      const int numComponents,
                                      const double scale,
-                                     const bool tensorBasis,
                                      const int basisOrder,
                                      const int quadOrder,
                                      const int dimension,
+                                     const CellBasis cellBasis,
                                      const bool isBasisContinuous,
                                      const SpaceEnum feSpace) {
     assert(numComponents > 0);
@@ -928,10 +943,10 @@ pylith::topology::Field::subfieldAdd(const char *name,
     description.validator = NULL;
 
     Discretization discretization;
-    discretization.tensorBasis = tensorBasis;
     discretization.basisOrder = basisOrder;
     discretization.quadOrder = quadOrder;
     discretization.dimension = dimension;
+    discretization.cellBasis = cellBasis;
     discretization.isBasisContinuous = isBasisContinuous;
     discretization.feSpace = feSpace;
 
@@ -971,7 +986,7 @@ pylith::topology::Field::subfieldUpdate(const char* subfieldName,
 
     subfields_type::iterator iter = _subfields.find(subfieldName);
     assert(iter != _subfields.end());
-    assert(discretization.tensorBasis == iter->second.fe.tensorBasis);
+    assert(discretization.cellBasis == iter->second.fe.cellBasis);
     assert(discretization.basisOrder == iter->second.fe.basisOrder);
     assert(discretization.quadOrder == iter->second.fe.quadOrder);
     assert(discretization.dimension == iter->second.fe.dimension);
@@ -1018,7 +1033,7 @@ pylith::topology::Field::subfieldsSetup(void) {
             quadOrderSet = true;
         } // if/else
 
-        sinfo.fe.tensorBasis = !_mesh.isSimplex();
+        sinfo.fe.cellBasis = _mesh.isSimplex() ? SIMPLEX_BASIS : TENSOR_BASIS;
         PetscFE fe = FieldOps::createFE(sinfo.fe, _dm, sinfo.description.numComponents);assert(fe);
         err = PetscFESetName(fe, sname);PYLITH_CHECK_ERROR(err);
         err = DMSetField(_dm, sinfo.index, NULL, (PetscObject)fe);PYLITH_CHECK_ERROR(err);

--- a/libsrc/pylith/topology/Field.hh
+++ b/libsrc/pylith/topology/Field.hh
@@ -210,6 +210,7 @@ public:
      * @param[in] basisOrder Order of basis functions for discretization.
      * @param[in] quadOrder Order of numerical quadrature for discretization.
      * @param[in] dimension Dimension of points for discretization.
+     * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
      * @param[in] isBasisContinuous True if basis is continuous.
      * @param[in] feSpace Finite-element space (POLYNOMIAL_SPACE or POINT_SPACE).
      */
@@ -219,10 +220,10 @@ public:
                      const char* components[],
                      const int numComponents,
                      const double scale,
-                     const bool tensorBasis,
                      const int basisOrder,
                      const int quadOrder,
                      const int dimension,
+                     const CellBasis cellBasis,
                      const bool isBasisContinuous,
                      const SpaceEnum feSpace);
 

--- a/libsrc/pylith/topology/FieldBase.hh
+++ b/libsrc/pylith/topology/FieldBase.hh
@@ -58,6 +58,12 @@ public:
         POINT_SPACE=1, ///< Point finite-element space.
     }; // SpaceEnum
 
+    enum CellBasis {
+        SIMPLEX_BASIS=1, ///< Simplex basis functions.
+        TENSOR_BASIS=2, ///< Tensor product basis functions.
+        DEFAULT_BASIS=10, ///< Use default for cell type.
+    }; // CellBasis
+
     // PUBLIC TYPEDEF ///////////////////////////////////////////////////////
 public:
 
@@ -112,65 +118,65 @@ public:
     }; // Description
 
     struct Discretization {
-        bool tensorBasis; ///< Is this a tensor polynomial basis
         int basisOrder; ///< Order of basis functions.
         int quadOrder; ///< Order of quadrature scheme.
         int dimension; ///< Dimension of point(s) for discretization.
-        int components; ///< Number of components for field
+        int components; ///< Number of components for field.
+        CellBasis cellBasis; ///< Cell basis (simplex, tensor, default).
         bool isBasisContinuous; ///< Is basis continuous?
         SpaceEnum feSpace; ///< Finite-element space.
 
-        Discretization(const bool tensorBasisValue=false,
-                       const int basisOrderValue=1,
+        Discretization(const int basisOrderValue=1,
                        const int quadOrderValue=1,
                        const int dimensionValue=-1,
                        const int componentsValue=-1,
+                       const CellBasis cellBasisValue=DEFAULT_BASIS,
                        const bool isBasisContinuousValue=true,
                        const SpaceEnum feSpaceValue=POLYNOMIAL_SPACE) :
-            tensorBasis(tensorBasisValue),
             basisOrder(basisOrderValue),
             quadOrder(quadOrderValue),
             dimension(dimensionValue),
             components(componentsValue),
+            cellBasis(cellBasisValue),
             isBasisContinuous(isBasisContinuousValue),
             feSpace(feSpaceValue)
         {}
 
-        bool operator==(const Discretization rhs) const
-        {
-          if (tensorBasis        != rhs.tensorBasis)       return false;
-          if (basisOrder         != rhs.basisOrder)        return false;
-          if (quadOrder          != rhs.quadOrder)         return false;
-          if (dimension          != rhs.dimension)         return false;
-          if (components         != rhs.components)        return false;
-          if (isBasisContinuous  != rhs.isBasisContinuous) return false;
-          if (feSpace            != rhs.feSpace)           return false;
-          return true;
+
+        bool operator==(const Discretization rhs) const {
+            if (basisOrder         != rhs.basisOrder) {return false;}
+            if (quadOrder          != rhs.quadOrder) {return false;}
+            if (dimension          != rhs.dimension) {return false;}
+            if (components         != rhs.components) {return false;}
+            if (cellBasis          != rhs.cellBasis) {return false;}
+            if (isBasisContinuous  != rhs.isBasisContinuous) {return false;}
+            if (feSpace            != rhs.feSpace) {return false;}
+            return true;
         }
 
-        bool operator<(const Discretization rhs) const
-        {
-          if (tensorBasis        < rhs.tensorBasis)       return true;
-          if (tensorBasis       == rhs.tensorBasis) {
-            if (basisOrder         < rhs.basisOrder)        return true;
+        bool operator<(const Discretization rhs) const {
+            if (basisOrder         < rhs.basisOrder) {return true;}
             if (basisOrder        == rhs.basisOrder) {
-              if (quadOrder        < rhs.quadOrder)         return true;
-              if (quadOrder       == rhs.quadOrder)  {
-                if (dimension      < rhs.dimension)         return true;
-                if (dimension     == rhs.dimension) {
-                  if (components   < rhs.components)         return true;
-                  if (components  == rhs.components) {
-                    if (isBasisContinuous  < rhs.isBasisContinuous) return true;
-                    if (isBasisContinuous == rhs.isBasisContinuous) {
-                      if (feSpace          < rhs.feSpace)           return true;
+                if (quadOrder        < rhs.quadOrder) {return true;}
+                if (quadOrder       == rhs.quadOrder) {
+                    if (dimension      < rhs.dimension) {return true;}
+                    if (dimension     == rhs.dimension) {
+                        if (components   < rhs.components) {return true;}
+                        if (components  == rhs.components) {
+                            if (cellBasis        < rhs.cellBasis) {return true;}
+                            if (cellBasis       == rhs.cellBasis) {
+                                if (isBasisContinuous  < rhs.isBasisContinuous) {return true;}
+                                if (isBasisContinuous == rhs.isBasisContinuous) {
+                                    if (feSpace          < rhs.feSpace) {return true;}
+                                }
+                            }
+                        }
                     }
-                  }
                 }
-              }
             }
-          }
-          return false;
+            return false;
         }
+
     }; // Discretization
 
     /// Mapping from field name to discretization (intended for subfields).

--- a/libsrc/pylith/topology/FieldFactory.cc
+++ b/libsrc/pylith/topology/FieldFactory.cc
@@ -62,21 +62,21 @@ pylith::topology::FieldFactory::getNumSubfields(void) const {
 // Set discretization information for auxiliary subfield.
 void
 pylith::topology::FieldFactory::setSubfieldDiscretization(const char* subfieldName,
-                                                          const bool tensorBasis,
                                                           const int basisOrder,
                                                           const int quadOrder,
                                                           const int dimension,
+                                                          const pylith::topology::FieldBase::CellBasis cellBasis,
                                                           const bool isBasisContinuous,
                                                           const pylith::topology::FieldBase::SpaceEnum feSpace) {
     PYLITH_METHOD_BEGIN;
-    PYLITH_JOURNAL_DEBUG("setSubfieldDiscretization(subfieldName="<<subfieldName<<", tensorBasis="<<tensorBasis<<", basisOrder="<<basisOrder<<", quadOrder="<<quadOrder<<", dimension="<<dimension<<", isBasisContinuous="<<isBasisContinuous<<")");
+    PYLITH_JOURNAL_DEBUG("setSubfieldDiscretization(subfieldName="<<subfieldName<<", basisOrder="<<basisOrder<<", quadOrder="<<quadOrder<<", dimension="<<dimension<<", cellBasis="<<cellBasis<<", isBasisContinuous="<<isBasisContinuous<<")");
     assert(dimension != 0);
 
     pylith::topology::FieldBase::Discretization feInfo;
-    feInfo.tensorBasis = tensorBasis;
     feInfo.basisOrder = basisOrder;
     feInfo.quadOrder = quadOrder;
     feInfo.dimension = dimension;
+    feInfo.cellBasis = cellBasis;
     feInfo.isBasisContinuous = isBasisContinuous;
     feInfo.feSpace = feSpace;
     _subfieldDiscretizations[subfieldName] = feInfo;

--- a/libsrc/pylith/topology/FieldFactory.hh
+++ b/libsrc/pylith/topology/FieldFactory.hh
@@ -55,14 +55,15 @@ public:
      * @param[in] basisOrder Polynomial order for basis.
      * @param[in] quadOrder Order of quadrature rule.
      * @param[in] dimension Dimension of points for discretization.
+     * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
      * @param[in] isBasisContinuous True if basis is continuous.
      * @param[in] feSpace Finite-element space.
      */
     void setSubfieldDiscretization(const char* subfieldName,
-                                   const bool tensorBasis,
                                    const int basisOrder,
                                    const int quadOrder,
                                    const int dimension,
+                                   const pylith::topology::FieldBase::CellBasis cellBasis,
                                    const bool isBasisContinuous,
                                    const pylith::topology::FieldBase::SpaceEnum feSpace);
 

--- a/modulesrc/problems/Physics.i
+++ b/modulesrc/problems/Physics.i
@@ -55,14 +55,15 @@ public:
              * @param[in] basisOrder Polynomial order for basis.
              * @param[in] quadOrder Order of quadrature rule.
              * @param[in] dimension Dimension of points for discretization.
+             * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
              * @param[in] isBasisContinuous True if basis is continuous.
              * @param[in] feSpace Finite-element space.
              */
             void setAuxiliarySubfieldDiscretization(const char* subfieldName,
-                                                    const bool tensorBasis,
                                                     const int basisOrder,
                                                     const int quadOrder,
                                                     const int dimension,
+                                                    const pylith::topology::FieldBase::CellBasis cellBasis,
                                                     const bool isBasisContinuous,
                                                     const pylith::topology::FieldBase::SpaceEnum feSpace);
 
@@ -72,14 +73,15 @@ public:
              * @param[in] basisOrder Polynomial order for basis.
              * @param[in] quadOrder Order of quadrature rule.
              * @param[in] dimension Dimension of points for discretization.
+             * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
              * @param[in] isBasisContinuous True if basis is continuous.
              * @param[in] feSpace Finite-element space.
              */
             void setDerivedSubfieldDiscretization(const char* subfieldName,
-                                                  const bool tensorBasis,
                                                   const int basisOrder,
                                                   const int quadOrder,
                                                   const int dimension,
+                                                  const pylith::topology::FieldBase::CellBasis cellBasis,
                                                   const bool isBasisContinuous,
                                                   const pylith::topology::FieldBase::SpaceEnum feSpace);
 

--- a/modulesrc/topology/Field.i
+++ b/modulesrc/topology/Field.i
@@ -119,6 +119,7 @@ public:
              * @param[in] basisOrder Polynomial order for basis.
              * @param[in] quadOrder Order of quadrature rule.
              * @param[in] dimension Dimension of points for discretization.
+             * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
              * @param[in] isBasisContinuous True if basis is continuous.
              * @param[in] feSpace Finite-element space (polynomial or point).
              * @param[in] scale Scale for dimensionalizing field.
@@ -132,10 +133,10 @@ public:
                              const char* components[],
                              const int numComponents,
                              const double scale,
-                             const bool tensorBasis,
                              const int basisOrder,
                              const int quadOrder,
                              const int dimension,
+                             const CellBasis cellBasis,
                              const bool isBasisContinuous,
                              const SpaceEnum feSpace);
 

--- a/modulesrc/topology/FieldBase.i
+++ b/modulesrc/topology/FieldBase.i
@@ -23,46 +23,48 @@
  */
 
 namespace pylith {
-  namespace topology {
+    namespace topology {
+        class FieldBase {
+            // PUBLIC ENUMS ///////////////////////////////////////////////////
+public:
 
-    class FieldBase
-    { // FieldBase
+            enum VectorFieldEnum {
+                SCALAR=0, ///< Scalar.
+                VECTOR=1, ///< Vector.
+                TENSOR=2, ///< Tensor.
+                OTHER=3, ///< Not a scalar, vector, or tensor.
+                MULTI_SCALAR=4, ///< Scalar at multiple points.
+                MULTI_VECTOR=5, ///< Vector at multiple points.
+                MULTI_TENSOR=6, ///< Tensor at multiple points.
+                MULTI_OTHER=7, ///< Not a scalar, vector, or tensor at multiple points.
+            }; // VectorFieldEnum
 
-      // PUBLIC ENUMS ///////////////////////////////////////////////////
-    public :
+            enum SpaceEnum {
+                POLYNOMIAL_SPACE=0, ///< Polynomial finite-element space.
+                POINT_SPACE=1, ///< Point finite-element space.
+            }; // SpaceEnum
 
-      enum VectorFieldEnum {
-	SCALAR=0, ///< Scalar.
-	VECTOR=1, ///< Vector.
-	TENSOR=2, ///< Tensor.
-	OTHER=3, ///< Not a scalar, vector, or tensor.
-	MULTI_SCALAR=4, ///< Scalar at multiple points.
-	MULTI_VECTOR=5, ///< Vector at multiple points.
-	MULTI_TENSOR=6, ///< Tensor at multiple points.
-	MULTI_OTHER=7, ///< Not a scalar, vector, or tensor at multiple points.
-      }; // VectorFieldEnum
+            enum CellBasis {
+                SIMPLEX_BASIS=1, ///< Simplex basis functions.
+                TENSOR_BASIS=2, ///< Tensor product basis functions.
+                DEFAULT_BASIS=10, ///< Use default for cell type.
+            }; // CellBasis
 
-      enum SpaceEnum {
-          POLYNOMIAL_SPACE=0, ///< Polynomial finite-element space.
-          POINT_SPACE=1, ///< Point finite-element space.
-      }; // SpaceEnum
+            // PUBLIC TYPEDEF /////////////////////////////////////////////////
+public:
 
-      // PUBLIC TYPEDEF /////////////////////////////////////////////////
-    public :
+            /// Function prototype for validator functions.
+            typedef const char* (*validatorfn_type)(const PylithReal);
 
-      /// Function prototype for validator functions.
-      typedef const char* (*validatorfn_type)(const PylithReal);
+            // PUBLIC MEMBERS /////////////////////////////////////////////////
+public:
 
-      // PUBLIC MEMBERS /////////////////////////////////////////////////
-    public :
+            FieldBase(void); ///< Default constructor.
+            ~FieldBase(void); ///< Default destructor.
 
-      FieldBase(void); ///< Default constructor.
-      ~FieldBase(void); ///< Default destructor.
+        }; // FieldBase
 
-    }; // FieldBase
-
-  } // topology
+    } // topology
 } // pylith
-
 
 // End of file

--- a/pylith/materials/RheologyElasticity.py
+++ b/pylith/materials/RheologyElasticity.py
@@ -61,8 +61,8 @@ class RheologyElasticity(PetscComponent, ModuleRheology):
         for subfield in self.auxiliarySubfields.components():
             fieldName = subfield.aliases[-1]
             quadOrder = problem.defaults.quadOrder if subfield.quadOrder < 0 else subfield.quadOrder
-            material.setAuxiliarySubfieldDiscretization(fieldName, subfield.basisOrder, quadOrder,
-                                                        subfield.dimension, subfield.isBasisContinuous, subfield.feSpace)
+            material.setAuxiliarySubfieldDiscretization(fieldName, subfield.basisOrder, quadOrder, subfield.dimension,
+                                                        subfield.cellBasis, subfield.isBasisContinuous, subfield.feSpace)
         return
 
     # PRIVATE METHODS ////////////////////////////////////////////////////

--- a/pylith/materials/RheologyIncompressibleElasticity.py
+++ b/pylith/materials/RheologyIncompressibleElasticity.py
@@ -62,8 +62,8 @@ class RheologyIncompressibleElasticity(PetscComponent, ModuleRheology):
         for subfield in self.auxiliarySubfields.components():
             fieldName = subfield.aliases[-1]
             quadOrder = problem.defaults.quadOrder if subfield.quadOrder < 0 else subfield.quadOrder
-            material.setAuxiliarySubfieldDiscretization(fieldName, subfield.basisOrder, quadOrder,
-                                                        subfield.dimension, subfield.isBasisContinuous, subfield.feSpace)
+            material.setAuxiliarySubfieldDiscretization(fieldName, subfield.basisOrder, quadOrder, subfield.dimension,
+                                                        subfield.cellBasis, subfield.isBasisContinuous, subfield.feSpace)
         return
 
     # PRIVATE METHODS ////////////////////////////////////////////////////

--- a/pylith/problems/Physics.py
+++ b/pylith/problems/Physics.py
@@ -88,13 +88,15 @@ class Physics(PetscComponent, ModulePhysics):
             fieldName = subfield.aliases[-1]
             quadOrder = problem.defaults.quadOrder if subfield.quadOrder < 0 else subfield.quadOrder
             ModulePhysics.setAuxiliarySubfieldDiscretization(self, fieldName, subfield.basisOrder, quadOrder,
-                                                             subfield.dimension, subfield.isBasisContinuous, subfield.feSpace)
+                                                             subfield.dimension, subfield.cellBasis,
+                                                             subfield.isBasisContinuous, subfield.feSpace)
 
         for subfield in self.derivedSubfields.components():
             fieldName = subfield.aliases[-1]
             quadOrder = problem.defaults.quadOrder if subfield.quadOrder < 0 else subfield.quadOrder
             ModulePhysics.setDerivedSubfieldDiscretization(self, fieldName, subfield.basisOrder, quadOrder,
-                                                           subfield.dimension, subfield.isBasisContinuous, subfield.feSpace)
+                                                           subfield.dimension, subfield.cellBasis,
+                                                           subfield.isBasisContinuous, subfield.feSpace)
 
         for observer in self.observers.components():
             observer.preinitialize(problem, identifier)

--- a/pylith/problems/Solution.py
+++ b/pylith/problems/Solution.py
@@ -78,7 +78,7 @@ class Solution(PetscComponent):
             quadOrder = problem.defaults.quadOrder if subfield.quadOrder < 0 else subfield.quadOrder
             self.field.subfieldAdd(subfield.fieldName, subfield.userAlias, subfield.vectorFieldType, subfield.componentNames,
                                    subfield.scale.value, subfield.basisOrder, quadOrder, subfield.dimension,
-                                   subfield.isBasisContinuous, subfield.feSpace)
+                                   subfield.cellBasis, subfield.isBasisContinuous, subfield.feSpace)
         return
 
     # PRIVATE METHODS ////////////////////////////////////////////////////

--- a/pylith/topology/Subfield.py
+++ b/pylith/topology/Subfield.py
@@ -33,6 +33,7 @@ class Subfield(Component):
       - *basis_order* Order of basis functions.
       - *quadrature_order* Order of numerical quadrature.
       - *dimension* Topological dimension associated with subfield.
+      - *cell_basis* Type of basis functions to use [simplex, tensor, default (for cell type)].
       - *basis_continuous* Is basis continuous?
       - *finite_element_space* Finite-element space [polynomial, point].
 
@@ -50,11 +51,15 @@ class Subfield(Component):
     quadOrder = pyre.inventory.int("quadrature_order", default=-1)
     quadOrder.meta['tip'] = "Order of numerical quadrature."
 
-    isBasisContinuous = pyre.inventory.bool("is_basis_continous", default=True)
-    isBasisContinuous.meta['tip'] = "Is basis continuous?"
-
     dimension = pyre.inventory.int("dimension", default=-1)
     dimension.meta["tip"] = "Topological dimension associated with subfield (=-1 will use dimension of domain)."
+
+    cellBasisStr = pyre.inventory.str("cell_basis", default="default",
+                                      validator=pyre.inventory.choice(["simplex", "tensor", "default"]))
+    cellBasisStr.meta['tip'] = "Type of cell basis functions (simplex, tensor, or default). Default is to use type matching cell type."
+
+    isBasisContinuous = pyre.inventory.bool("is_basis_continous", default=True)
+    isBasisContinuous.meta['tip'] = "Is basis continuous?"
 
     feSpaceStr = pyre.inventory.str("finite_element_space", default="polynomial",
                                     validator=pyre.inventory.choice(["polynomial", "point"]))
@@ -79,6 +84,14 @@ class Subfield(Component):
         from .topology import FieldBase
 
         Component._configure(self)
+
+        mapBasis = {
+            "simplex": FieldBase.SIMPLEX_BASIS,
+            "tensor": FieldBase.TENSOR_BASIS,
+            "default": FieldBase.DEFAULT_BASIS,
+        }
+        self.cellBasis = mapBasis[self.inventory.cellBasisStr]
+
         mapSpace = {
             "polynomial": FieldBase.POLYNOMIAL_SPACE,
             "point": FieldBase.POINT_SPACE,

--- a/tests/libtests/feassemble/TestAuxiliaryFactory.cc
+++ b/tests/libtests/feassemble/TestAuxiliaryFactory.cc
@@ -106,41 +106,43 @@ pylith::feassemble::TestAuxiliaryFactory::testQueryDB(void) {
 // Test setSubfieldDiscretization() and getSubfieldDiscretization().
 void
 pylith::feassemble::TestAuxiliaryFactory::testSubfieldDiscretization(void) {
-    pylith::topology::FieldBase::Discretization feDisp(false, 2, 2, -1, true, pylith::topology::FieldBase::POLYNOMIAL_SPACE);
-    pylith::topology::FieldBase::Discretization feVel(false, 3, 2, 1, false, pylith::topology::FieldBase::POINT_SPACE);
+    pylith::topology::FieldBase::Discretization feDisp(2, 2, -1, 2, pylith::topology::FieldBase::SIMPLEX_BASIS,
+                                                       true, pylith::topology::FieldBase::POLYNOMIAL_SPACE);
+    pylith::topology::FieldBase::Discretization feVel(3, 2, 1, 2, pylith::topology::FieldBase::SIMPLEX_BASIS,
+                                                      false, pylith::topology::FieldBase::POINT_SPACE);
 
     CPPUNIT_ASSERT(_factory);
-    _factory->setSubfieldDiscretization("displacement", feDisp.tensorBasis, feDisp.basisOrder, feDisp.quadOrder, feDisp.dimension,
-                                        feDisp.isBasisContinuous, feDisp.feSpace);
-    _factory->setSubfieldDiscretization("velocity", feVel.tensorBasis, feVel.basisOrder, feVel.quadOrder, feVel.dimension,
-                                        feVel.isBasisContinuous, feVel.feSpace);
+    _factory->setSubfieldDiscretization("displacement", feDisp.basisOrder, feDisp.quadOrder, feDisp.dimension,
+                                        feDisp.cellBasis, feDisp.isBasisContinuous, feDisp.feSpace);
+    _factory->setSubfieldDiscretization("velocity", feVel.basisOrder, feVel.quadOrder, feVel.dimension,
+                                        feVel.cellBasis, feVel.isBasisContinuous, feVel.feSpace);
 
     { // Check displacement discretization
         const pylith::topology::FieldBase::Discretization& feTest = _factory->getSubfieldDiscretization("displacement");
-        CPPUNIT_ASSERT_EQUAL(feDisp.tensorBasis, feTest.tensorBasis);
         CPPUNIT_ASSERT_EQUAL(feDisp.basisOrder, feTest.basisOrder);
         CPPUNIT_ASSERT_EQUAL(feDisp.quadOrder, feTest.quadOrder);
         CPPUNIT_ASSERT_EQUAL(feDisp.dimension, feTest.dimension);
+        CPPUNIT_ASSERT_EQUAL(feDisp.cellBasis, feTest.cellBasis);
         CPPUNIT_ASSERT_EQUAL(feDisp.isBasisContinuous, feTest.isBasisContinuous);
         CPPUNIT_ASSERT_EQUAL(feDisp.feSpace, feTest.feSpace);
     } // Check displacement discretization
 
     { // Check velocity discretization
         const pylith::topology::FieldBase::Discretization& feTest = _factory->getSubfieldDiscretization("velocity");
-        CPPUNIT_ASSERT_EQUAL(feVel.tensorBasis, feTest.tensorBasis);
         CPPUNIT_ASSERT_EQUAL(feVel.basisOrder, feTest.basisOrder);
         CPPUNIT_ASSERT_EQUAL(feVel.quadOrder, feTest.quadOrder);
         CPPUNIT_ASSERT_EQUAL(feVel.dimension, feTest.dimension);
+        CPPUNIT_ASSERT_EQUAL(feVel.cellBasis, feTest.cellBasis);
         CPPUNIT_ASSERT_EQUAL(feVel.isBasisContinuous, feTest.isBasisContinuous);
         CPPUNIT_ASSERT_EQUAL(feVel.feSpace, feTest.feSpace);
     } // Check velocity discretization
 
     { // default for unknown discretization
         const pylith::topology::FieldBase::Discretization& feTest = _factory->getSubfieldDiscretization("xyz");
-        CPPUNIT_ASSERT_EQUAL(false, feTest.tensorBasis);
         CPPUNIT_ASSERT_EQUAL(1, feTest.basisOrder);
         CPPUNIT_ASSERT_EQUAL(1, feTest.quadOrder);
         CPPUNIT_ASSERT_EQUAL(-1, feTest.dimension);
+        CPPUNIT_ASSERT_EQUAL(pylith::topology::FieldBase::DEFAULT_BASIS, feTest.cellBasis);
         CPPUNIT_ASSERT_EQUAL(true, feTest.isBasisContinuous);
         CPPUNIT_ASSERT_EQUAL(pylith::topology::FieldBase::POLYNOMIAL_SPACE, feTest.feSpace);
     }

--- a/tests/libtests/materials/TestAuxiliaryFactoryElastic.cc
+++ b/tests/libtests/materials/TestAuxiliaryFactoryElastic.cc
@@ -69,7 +69,7 @@ pylith::materials::TestAuxiliaryFactoryElastic::setUp(void) {
         pylith::topology::FieldQuery::validatorPositive
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 2, 2, _auxDim, 1, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, _auxDim, 1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 0;
     _data->subfields["density"] = info;
@@ -87,7 +87,7 @@ pylith::materials::TestAuxiliaryFactoryElastic::setUp(void) {
         pylith::topology::FieldQuery::validatorNonnegative
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 1, 2, _auxDim, 1, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        1, 2, _auxDim, 1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 1;
     _data->subfields["shear_modulus"] = info;
@@ -105,7 +105,7 @@ pylith::materials::TestAuxiliaryFactoryElastic::setUp(void) {
         pylith::topology::FieldQuery::validatorPositive
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 1, 2, _auxDim, 1, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        1, 2, _auxDim, 1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 2;
     _data->subfields["bulk_modulus"] = info;
@@ -127,7 +127,7 @@ pylith::materials::TestAuxiliaryFactoryElastic::setUp(void) {
         _data->normalizer->getPressureScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 2, 2, _auxDim, _auxDim, false, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, _auxDim, _auxDim, pylith::topology::Field::DEFAULT_BASIS, false, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 3;
     _data->subfields["reference_stress"] = info;
@@ -149,7 +149,7 @@ pylith::materials::TestAuxiliaryFactoryElastic::setUp(void) {
         1.0
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 2, 2, _auxDim, _auxDim, false, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, _auxDim, _auxDim, pylith::topology::Field::DEFAULT_BASIS, false, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 4;
     _data->subfields["reference_strain"] = info;
@@ -264,7 +264,7 @@ pylith::materials::TestAuxiliaryFactoryElastic::_initialize(void) {
     for (subfield_iter iter = _data->subfields.begin(); iter != _data->subfields.end(); ++iter) {
         const char* subfieldName = iter->first.c_str();
         const pylith::topology::Field::Discretization& fe = iter->second.fe;
-        _factory->setSubfieldDiscretization(subfieldName, fe.tensorBasis, fe.basisOrder, fe.quadOrder, fe.dimension, fe.isBasisContinuous, fe.feSpace);
+        _factory->setSubfieldDiscretization(subfieldName, fe.basisOrder, fe.quadOrder, fe.dimension, fe.cellBasis, fe.isBasisContinuous, fe.feSpace);
     } // for
     CPPUNIT_ASSERT(_data->normalizer);
     _factory->initialize(_auxiliaryField, *_data->normalizer, _data->dimension);

--- a/tests/libtests/materials/TestAuxiliaryFactoryElasticity.cc
+++ b/tests/libtests/materials/TestAuxiliaryFactoryElasticity.cc
@@ -63,7 +63,7 @@ pylith::materials::TestAuxiliaryFactoryElasticity::setUp(void) {
         pylith::topology::FieldQuery::validatorPositive
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 1, 2, _auxDim, 1, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        1, 2, _auxDim, 1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 0;
     _data->subfields["density"] = info;
@@ -82,7 +82,7 @@ pylith::materials::TestAuxiliaryFactoryElasticity::setUp(void) {
         _data->normalizer->getPressureScale() / _data->normalizer->getLengthScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 2, 2, _auxDim, _auxDim, false, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, _auxDim, _auxDim, pylith::topology::Field::DEFAULT_BASIS, false, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 1;
     _data->subfields["body_force"] = info;
@@ -101,7 +101,7 @@ pylith::materials::TestAuxiliaryFactoryElasticity::setUp(void) {
         _data->normalizer->getLengthScale() / pow(_data->normalizer->getTimeScale(), 2)
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 2, 2, _auxDim, _auxDim, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, _auxDim, _auxDim, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 2;
     _data->subfields["gravitational_acceleration"] = info;
@@ -210,7 +210,8 @@ pylith::materials::TestAuxiliaryFactoryElasticity::_initialize(void) {
     for (subfield_iter iter = _data->subfields.begin(); iter != _data->subfields.end(); ++iter) {
         const char* subfieldName = iter->first.c_str();
         const pylith::topology::Field::Discretization& fe = iter->second.fe;
-        _factory->setSubfieldDiscretization(subfieldName, fe.tensorBasis, fe.basisOrder, fe.quadOrder, fe.dimension, fe.isBasisContinuous, fe.feSpace);
+        _factory->setSubfieldDiscretization(subfieldName, fe.basisOrder, fe.quadOrder, fe.dimension, fe.cellBasis,
+                                            fe.isBasisContinuous, fe.feSpace);
     } // for
     CPPUNIT_ASSERT(_data->normalizer);
     _factory->initialize(_auxiliaryField, *_data->normalizer, _data->dimension);

--- a/tests/libtests/problems/TestSolutionFactory.cc
+++ b/tests/libtests/problems/TestSolutionFactory.cc
@@ -63,7 +63,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getLengthScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 1, 2, -1, -1, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        1, 2, -1, -1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 0;
     _data->subfields["displacement"] = info;
@@ -82,7 +82,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getLengthScale() / _data->normalizer->getTimeScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 2, 3, -1, -1, false, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 3, -1, -1, pylith::topology::Field::DEFAULT_BASIS, false, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 1;
     _data->subfields["velocity"] = info;
@@ -99,7 +99,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getPressureScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 2, 2, -1, -1, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, -1, -1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 0;
     _data->subfields["pressure"] = info;
@@ -116,7 +116,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getPressureScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 2, 3, -1, -1, true, pylith::topology::Field::POINT_SPACE
+        2, 3, -1, -1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POINT_SPACE
         );
     info.index = 1;
     _data->subfields["fluid_pressure"] = info;
@@ -135,7 +135,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getPressureScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 2, 2, -1, -1, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, -1, -1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
         );
     info.index = 1;
     _data->subfields["lagrange_multiplier_fault"] = info;
@@ -152,7 +152,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getTemperatureScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        false, 2, 3, -1, -1, true, pylith::topology::Field::POINT_SPACE
+        2, 3, -1, -1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POINT_SPACE
         );
     info.index = 1;
     _data->subfields["temperature"] = info;

--- a/tests/libtests/topology/TestFieldMesh_Cases.cc
+++ b/tests/libtests/topology/TestFieldMesh_Cases.cc
@@ -23,10 +23,8 @@
 // -----------------------------------------------------------------------------
 namespace pylith {
     namespace topology {
-
         // ---------------------------------------------------------------------
         class TestFieldMesh_Quad : public TestFieldMesh {
-
             CPPUNIT_TEST_SUB_SUITE(TestFieldMesh_Quad, TestFieldMesh);
             CPPUNIT_TEST_SUITE_END();
 
@@ -112,14 +110,12 @@ namespace pylith {
                 _data->bcBNumVertices = 2;
                 static const int _bcBVertices[2] = { 2, 3, };
                 _data->bcBVertices = const_cast<int*>(_bcBVertices);
-            }   // setUp
+            } // setUp
 
-
-        };  // TestFieldMesh_Quad
+        }; // TestFieldMesh_Quad
         CPPUNIT_TEST_SUITE_REGISTRATION(TestFieldMesh_Quad);
 
-    }   // topology
-}   // pylith
-
+    } // topology
+} // pylith
 
 // End of file

--- a/tests/libtests/topology/TestFieldsMesh.cc
+++ b/tests/libtests/topology/TestFieldsMesh.cc
@@ -211,7 +211,11 @@ pylith::topology::TestFieldsMesh::testCopyLayout(void) {
     const int basisOrder = 1;
     const int quadOrder = 1;
     const double scale = 1.2;
-    fieldA.subfieldAdd("displacement", "displacement", Field::SCALAR, components, numComponents, scale, !_mesh->isSimplex(), basisOrder, dim, quadOrder, true, Field::POLYNOMIAL_SPACE);
+    const pylith::topology::FieldBase::CellBasis cellBasis = _mesh->isSimplex() ?
+                                                             pylith::topology::FieldBase::SIMPLEX_BASIS :
+                                                             pylith::topology::FieldBase::TENSOR_BASIS;
+    fieldA.subfieldAdd("displacement", "displacement", Field::SCALAR, components, numComponents, scale, basisOrder, dim,
+                       quadOrder, cellBasis, true, Field::POLYNOMIAL_SPACE);
     fieldA.subfieldsSetup();
     fieldA.createDiscretization();
     fieldA.allocate();

--- a/tests/libtests/topology/TestFieldsSubmesh.cc
+++ b/tests/libtests/topology/TestFieldsSubmesh.cc
@@ -207,7 +207,11 @@ pylith::topology::TestFieldsSubmesh::testCopyLayout(void) {
     const int basisOrder = 1;
     const int quadOrder = 1;
     const double scale = 1.2;
-    fieldA.subfieldAdd("velocity", "velocity", Field::SCALAR, components, numComponents, scale, !_submesh->isSimplex(), basisOrder, quadOrder, dim, true, Field::POLYNOMIAL_SPACE);
+    const pylith::topology::FieldBase::CellBasis cellBasis = _submesh->isSimplex() ?
+                                                             pylith::topology::FieldBase::SIMPLEX_BASIS :
+                                                             pylith::topology::FieldBase::TENSOR_BASIS;
+    fieldA.subfieldAdd("velocity", "velocity", Field::SCALAR, components, numComponents, scale, basisOrder, quadOrder,
+                       dim, cellBasis, true, Field::POLYNOMIAL_SPACE);
     fieldA.subfieldsSetup();
     fieldA.createDiscretization();
     fieldA.allocate();

--- a/tests/mmstests/faults/TestFaultKin.cc
+++ b/tests/mmstests/faults/TestFaultKin.cc
@@ -98,8 +98,8 @@ pylith::mmstests::TestFaultKin::_initialize(void) {
 
     for (int i = 0; i < _data->matNumAuxSubfields; ++i) {
         const pylith::topology::FieldBase::Discretization& info = _data->matAuxDiscretizations[i];
-        _material->setAuxiliarySubfieldDiscretization(_data->matAuxSubfields[i], info.tensorBasis, info.basisOrder, info.quadOrder,
-                                                      _data->spaceDim, info.isBasisContinuous, info.feSpace);
+        _material->setAuxiliarySubfieldDiscretization(_data->matAuxSubfields[i], info.basisOrder, info.quadOrder,
+                                                      _data->spaceDim, info.cellBasis, info.isBasisContinuous, info.feSpace);
     } // for
 
     // Set up fault
@@ -113,8 +113,8 @@ pylith::mmstests::TestFaultKin::_initialize(void) {
     _data->kinsrc->auxFieldDB(_data->faultAuxDB);
     for (int i = 0; i < _data->faultNumAuxSubfields; ++i) {
         const pylith::topology::FieldBase::Discretization& info = _data->faultAuxDiscretizations[i];
-        _fault->setAuxiliarySubfieldDiscretization(_data->faultAuxSubfields[i], info.tensorBasis, info.basisOrder, info.quadOrder,
-                                                   _data->spaceDim-1, info.isBasisContinuous, info.feSpace);
+        _fault->setAuxiliarySubfieldDiscretization(_data->faultAuxSubfields[i], info.basisOrder, info.quadOrder,
+                                                   _data->spaceDim-1, info.cellBasis, info.isBasisContinuous, info.feSpace);
     } // for
 
     // Set up problem.


### PR DESCRIPTION
* Change bool `FieldBase::Discretization.tensorBasis` to enum `FieldBase::Discretization.cellBasis` to allow user to specify simplex, tensor, or default (use simplex for simplex mesh and tensor for quad/hex mesh).

* Change order of args in Discretization constructor. Move `cellBasis` to immediately before `isBasisContinuous`. This puts the fields that a user is likely to change as the first arguments and the ones a user is unlikely to change (non-default values) at the end.

* Fixed Python objects so that they use the new interface. Non-fault full scale tests now pass.