### PR TITLE
Disable reuse of discretizations via operator==  always retrning false.

### DIFF
--- a/libsrc/pylith/topology/FieldBase.hh
+++ b/libsrc/pylith/topology/FieldBase.hh
@@ -151,10 +151,12 @@ public:
             if (cellBasis          != rhs.cellBasis) {return false;}
             if (isBasisContinuous  != rhs.isBasisContinuous) {return false;}
             if (feSpace            != rhs.feSpace) {return false;}
-            return true;
+            // return true;
+            return false;
         }
 
         bool operator<(const Discretization rhs) const {
+            return true;
             if (basisOrder         < rhs.basisOrder) {return true;}
             if (basisOrder        == rhs.basisOrder) {
                 if (quadOrder        < rhs.quadOrder) {return true;}

--- a/libsrc/pylith/topology/FieldOps.cc
+++ b/libsrc/pylith/topology/FieldOps.cc
@@ -124,6 +124,7 @@ pylith::topology::FieldOps::createFE(const FieldBase::Discretization& feinfo,
 
         pylith::topology::FieldOps::feStore.insert(std::pair<FieldBase::Discretization, pylith::topology::FE>(feKey, fe));
     } else {
+        throw std::logic_error("FielfOps::createFE() :TODO: Can't reuse PetscFE due to naming of fields, so make a deep copy of fe.");
         fe = hasFE->second._fe;
         err = PetscObjectReference((PetscObject) fe);PYLITH_CHECK_ERROR(err);
     }


### PR DESCRIPTION
Disable reuse of discretizations via FieldBase:Discretization::operator== always returns false.

Can't reuse discretizations because they hold field (subfield) names and these get used in PETSc for solver settings.

If we want to avoid creating new discretizations, then we need to make a deep copy of the matching one and then set the field names in the copy.