### PR TITLE
Update EventLogger interface (rename getters/setters).

### DIFF
--- a/libsrc/pylith/topology/FieldQuery.cc
+++ b/libsrc/pylith/topology/FieldQuery.cc
@@ -55,7 +55,7 @@ pylith::topology::FieldQuery::FieldQuery(const Field& field) :
     _contextPtrs(NULL),
     _logger(new pylith::utils::EventLogger) {
     assert(_logger);
-    _logger->className("FieldQuery");
+    _logger->setClassName("FieldQuery");
     _logger->initialize();
     _logger->registerEvent("Py-FdQu-queryDB");
     _logger->registerEvent("Py-FdQu-queryPt");
@@ -202,7 +202,7 @@ pylith::topology::FieldQuery::queryDB(void) {
     PYLITH_METHOD_BEGIN;
 
     assert(_logger);
-    const PylithInt queryEvent = _logger->eventId("Py-FdQu-queryDB");
+    const PylithInt queryEvent = _logger->getEventId("Py-FdQu-queryDB");
     _logger->eventBegin(queryEvent);
 
     PetscErrorCode err = 0;
@@ -224,7 +224,7 @@ pylith::topology::FieldQuery::queryDBLabel(const char* labelName,
     PYLITH_METHOD_BEGIN;
 
     assert(_logger);
-    const PylithInt queryEvent = _logger->eventId("Py-FdQu-queryDB");
+    const PylithInt queryEvent = _logger->getEventId("Py-FdQu-queryDB");
     _logger->eventBegin(queryEvent);
 
     PetscErrorCode err = 0;
@@ -290,7 +290,7 @@ pylith::topology::FieldQuery::queryDBPointFn(PylithInt dim,
     } // if
 
     assert(queryctx->logger);
-    const PylithInt pointFnEvent = queryctx->logger->eventId("Py-FdQu-queryPt");
+    const PylithInt pointFnEvent = queryctx->logger->getEventId("Py-FdQu-queryPt");
     queryctx->logger->eventBegin(pointFnEvent);
 
     // Dimensionalize query location coordinates.

--- a/libsrc/pylith/utils/EventLogger.cc
+++ b/libsrc/pylith/utils/EventLogger.cc
@@ -29,114 +29,114 @@
 // ----------------------------------------------------------------------
 // Constructor
 pylith::utils::EventLogger::EventLogger(void) :
-  _className(""),
-  _classId(0)
-{ // constructor
-} // constructor
+    _className(""),
+    _classId(0)
+{}
+
 
 // ----------------------------------------------------------------------
 // Destructor
 pylith::utils::EventLogger::~EventLogger(void)
-{ // destructor
-} // destructor
+{}
+
 
 // ----------------------------------------------------------------------
 // Setup logging class.
 void
-pylith::utils::EventLogger::initialize(void)
-{ // initialize
-  PYLITH_METHOD_BEGIN;
+pylith::utils::EventLogger::initialize(void) {
+    PYLITH_METHOD_BEGIN;
 
-  if (_className == "")
-    throw std::logic_error("Must set logging class name before "
-			   "initializaing EventLogger.");
-  
-  _events.clear();
-  PetscErrorCode err = PetscClassIdRegister(_className.c_str(), &_classId);
-  if (err) {
-    std::ostringstream msg;
-    msg << "Could not register logging class '" << _className << "'.";
-    throw std::runtime_error(msg.str());
-  } // if
-  assert(_classId);
+    if (_className == "") {
+        throw std::logic_error("Must set logging class name before "
+                               "initializaing EventLogger.");
+    }
 
-  PYLITH_METHOD_END;
+    _events.clear();
+    PetscErrorCode err = PetscClassIdRegister(_className.c_str(), &_classId);
+    if (err) {
+        std::ostringstream msg;
+        msg << "Could not register logging class '" << _className << "'.";
+        throw std::runtime_error(msg.str());
+    } // if
+    assert(_classId);
+
+    PYLITH_METHOD_END;
 } // initialize
+
 
 // ----------------------------------------------------------------------
 // Register event.
 int
-pylith::utils::EventLogger::registerEvent(const char* name)
-{ // registerEvent
-  PYLITH_METHOD_BEGIN;
+pylith::utils::EventLogger::registerEvent(const char* name) {
+    PYLITH_METHOD_BEGIN;
 
-  assert(_classId);
-  int id = 0;
-  PetscErrorCode err = PetscLogEventRegister(name, _classId, &id);
-  if (err) {
-    std::ostringstream msg;
-    msg << "Could not register logging event '" << name
-	<< "' for logging class '" << _className << "'.";
-    throw std::runtime_error(msg.str());
-  } // if  
-  _events[name] = id;
-  PYLITH_METHOD_RETURN(id);
+    assert(_classId);
+    int id = 0;
+    PetscErrorCode err = PetscLogEventRegister(name, _classId, &id);
+    if (err) {
+        std::ostringstream msg;
+        msg << "Could not register logging event '" << name
+            << "' for logging class '" << _className << "'.";
+        throw std::runtime_error(msg.str());
+    } // if
+    _events[name] = id;
+    PYLITH_METHOD_RETURN(id);
 } // registerEvent
+
 
 // ----------------------------------------------------------------------
 // Get event identifier.
 int
-pylith::utils::EventLogger::eventId(const char* name)
-{ // eventId
-  PYLITH_METHOD_BEGIN;
+pylith::utils::EventLogger::getEventId(const char* name) {
+    PYLITH_METHOD_BEGIN;
 
-  map_event_type::iterator iter = _events.find(name);
-  if (iter == _events.end()) {
-    std::ostringstream msg;
-    msg << "Could not find logging event '" << name
-	<< "' in logging class '" << _className << "'.";
-    throw std::runtime_error(msg.str());
-  } // if
+    map_event_type::iterator iter = _events.find(name);
+    if (iter == _events.end()) {
+        std::ostringstream msg;
+        msg << "Could not find logging event '" << name
+            << "' in logging class '" << _className << "'.";
+        throw std::runtime_error(msg.str());
+    } // if
 
-  PYLITH_METHOD_RETURN(iter->second);
-} // eventId
+    PYLITH_METHOD_RETURN(iter->second);
+} // getEventId
+
 
 // ----------------------------------------------------------------------
 // Register stage.
 int
-pylith::utils::EventLogger::registerStage(const char* name)
-{ // registerStage
-  PYLITH_METHOD_BEGIN;
+pylith::utils::EventLogger::registerStage(const char* name) {
+    PYLITH_METHOD_BEGIN;
 
-  assert(_classId);
-  int id = 0;
-  PetscErrorCode err = PetscLogStageRegister(name, &id);
-  if (err) {
-    std::ostringstream msg;
-    msg << "Could not register logging stage '" << name << "'.";
-    throw std::runtime_error(msg.str());
-  } // if  
-  _stages[name] = id;
+    assert(_classId);
+    int id = 0;
+    PetscErrorCode err = PetscLogStageRegister(name, &id);
+    if (err) {
+        std::ostringstream msg;
+        msg << "Could not register logging stage '" << name << "'.";
+        throw std::runtime_error(msg.str());
+    } // if
+    _stages[name] = id;
 
-  PYLITH_METHOD_RETURN(id);
+    PYLITH_METHOD_RETURN(id);
 } // registerStage
+
 
 // ----------------------------------------------------------------------
 // Get stage identifier.
 int
-pylith::utils::EventLogger::stageId(const char* name)
-{ // stageId
-  PYLITH_METHOD_BEGIN;
+pylith::utils::EventLogger::getStageId(const char* name) {
+    PYLITH_METHOD_BEGIN;
 
-  map_event_type::iterator iter = _stages.find(name);
-  if (iter == _stages.end()) {
-    registerStage(name);
-    iter = _stages.find(name);
-    assert(iter != _stages.end());
-  } // if
+    map_event_type::iterator iter = _stages.find(name);
+    if (iter == _stages.end()) {
+        registerStage(name);
+        iter = _stages.find(name);
+        assert(iter != _stages.end());
+    } // if
 
-  PYLITH_METHOD_RETURN(iter->second);
-} // stagesId
+    PYLITH_METHOD_RETURN(iter->second);
+} // getStageId
 
 
-// End of file 
+// End of file

--- a/libsrc/pylith/utils/EventLogger.hh
+++ b/libsrc/pylith/utils/EventLogger.hh
@@ -41,105 +41,104 @@
  *
  * Each logger object manages the events for a single "logging class".
  */
-class pylith::utils::EventLogger
-{ // EventLogger
-  friend class TestEventLogger; // unit testing
+class pylith::utils::EventLogger { // EventLogger
+    friend class TestEventLogger; // unit testing
 
-// PUBLIC MEMBERS ///////////////////////////////////////////////////////
-public :
+    // PUBLIC MEMBERS ///////////////////////////////////////////////////////
+public:
 
-  /// Constructor
-  EventLogger(void);
+    /// Constructor
+    EventLogger(void);
 
-  /// Destructor
-  ~EventLogger(void);
+    /// Destructor
+    ~EventLogger(void);
 
-  /** Set name of logging class.
-   *
-   * @param name Name of logging class.
-   */
-  void className(const char* name);
+    /** Set name of logging class.
+     *
+     * @param name Name of logging class.
+     */
+    void setClassName(const char* name);
 
-  /** Get name of logging class.
-   *
-   * @returns Name of logging class.
-   */
-  const char* className(void) const;
+    /** Get name of logging class.
+     *
+     * @returns Name of logging class.
+     */
+    const char* getClassName(void) const;
 
-  /// Setup logging class.
-  void initialize(void);
+    /// Setup logging class.
+    void initialize(void);
 
-  /** Register event.
-   *
-   * @prerequisite Must call initialize() before registerEvent().
-   * 
-   * @param name Name of event.
-   * @returns Event identifier.
-   */
-  int registerEvent(const char* name);
+    /** Register event.
+     *
+     * @prerequisite Must call initialize() before registerEvent().
+     *
+     * @param name Name of event.
+     * @returns Event identifier.
+     */
+    int registerEvent(const char* name);
 
-  /** Get event identifier.
-   *
-   * @param name Name of event.
-   * @returns Event identifier.
-   */
-  int eventId(const char* name);
+    /** Get event identifier.
+     *
+     * @param name Name of event.
+     * @returns Event identifier.
+     */
+    int getEventId(const char* name);
 
-  /** Log event begin.
-   *
-   * @param id Event identifier.
-   */
-  void eventBegin(const int id);
+    /** Log event begin.
+     *
+     * @param id Event identifier.
+     */
+    void eventBegin(const int id);
 
-  /** Log event end.
-   *
-   * @param id Event identifier.
-   */
-  void eventEnd(const int id);
+    /** Log event end.
+     *
+     * @param id Event identifier.
+     */
+    void eventEnd(const int id);
 
-  /** Register stage.
-   *
-   * @prerequisite Must call initialize() before registerStage().
-   * 
-   * @param name Name of stage.
-   * @returns Stage identifier.
-   */
-  int registerStage(const char* name);
+    /** Register stage.
+     *
+     * @prerequisite Must call initialize() before registerStage().
+     *
+     * @param name Name of stage.
+     * @returns Stage identifier.
+     */
+    int registerStage(const char* name);
 
-  /** Get stage identifier.
-   *
-   * @param name Name of stage.
-   * @returns Stage identifier.
-   */
-  int stageId(const char* name);
+    /** Get stage identifier.
+     *
+     * @param name Name of stage.
+     * @returns Stage identifier.
+     */
+    int getStageId(const char* name);
 
-  /** Log stage begin.
-   *
-   * @param id Stage identifier.
-   */
-  void stagePush(const int id);
+    /** Log stage begin.
+     *
+     * @param id Stage identifier.
+     */
+    void stagePush(const int id);
 
-  /// Log stage end.
-  void stagePop(void);
+    /// Log stage end.
+    void stagePop(void);
 
-// PRIVATE METHODS //////////////////////////////////////////////////////
-private :
+    // PRIVATE METHODS //////////////////////////////////////////////////////
+private:
 
-  EventLogger(const EventLogger&); ///< Not implemented
-  const EventLogger& operator=(const EventLogger&); ///< Not implemented
+    EventLogger(const EventLogger&); ///< Not implemented
+    const EventLogger& operator=(const EventLogger&); ///< Not implemented
 
-// PRIVATE TYPEDEFS /////////////////////////////////////////////////////
-private :
+    // PRIVATE TYPEDEFS /////////////////////////////////////////////////////
+private:
 
-  typedef std::map<std::string,int> map_event_type;
+    typedef std::map<std::string,int> map_event_type;
 
-// PRIVATE MEMBERS //////////////////////////////////////////////////////
-private :
+    // PRIVATE MEMBERS //////////////////////////////////////////////////////
+private:
 
-  std::string _className; ///< Name of logging class
-  int _classId; ///< PETSc logging identifier for class
-  map_event_type _events; ///< PETSc logging identifiers for events
-  map_event_type _stages; ///< PETSc logging identifiers for stages
+    std::string _className; ///< Name of logging class
+    int _classId; ///< PETSc logging identifier for class
+    map_event_type _events; ///< PETSc logging identifiers for events
+    map_event_type _stages; ///< PETSc logging identifiers for stages
 
 }; // EventLogger
 
@@ -147,5 +146,4 @@ private :
 
 #endif // pylith_utils_eventlogger_hh
 
-
-// End of file 
+// End of file

--- a/libsrc/pylith/utils/EventLogger.icc
+++ b/libsrc/pylith/utils/EventLogger.icc
@@ -16,7 +16,6 @@
 // ======================================================================
 //
 
-
 #if !defined(pylith_utils_eventlogger_hh)
 #error "EventLogger.icc must only be included from EventLogger.hh"
 #endif
@@ -24,44 +23,49 @@
 // Set name of logging class.
 inline
 void
-pylith::utils::EventLogger::className(const char* name) {
-  _className = name;
+pylith::utils::EventLogger::setClassName(const char* name) {
+    _className = name;
 }
+
 
 // Get name of logging class.
 inline
 const char*
-pylith::utils::EventLogger::className(void) const {
-  return _className.c_str();
+pylith::utils::EventLogger::getClassName(void) const {
+    return _className.c_str();
 }
+
 
 // Log event begin.
 inline
 void
 pylith::utils::EventLogger::eventBegin(const int id) {
-  PetscLogEventBegin(id, 0, 0, 0, 0);
+    PetscLogEventBegin(id, 0, 0, 0, 0);
 } // eventBegin
-  
+
+
 // Log event end.
 inline
 void
 pylith::utils::EventLogger::eventEnd(const int id) {
-  PetscLogEventEnd(id, 0, 0, 0, 0);
+    PetscLogEventEnd(id, 0, 0, 0, 0);
 } // eventEnd
+
 
 // Log stage begin.
 inline
 void
 pylith::utils::EventLogger::stagePush(const int id) {
-  PetscLogStagePush(id);
+    PetscLogStagePush(id);
 } // stagePush
-  
+
+
 // Log stage end.
 inline
 void
 pylith::utils::EventLogger::stagePop(void) {
-  PetscLogStagePop();
+    PetscLogStagePop();
 } // stagePop
 
 
-// End of file 
+// End of file

--- a/tests/libtests/utils/TestEventLogger.cc
+++ b/tests/libtests/utils/TestEventLogger.cc
@@ -25,240 +25,248 @@
 #include "pylith/utils/error.h" // USES PYLITH_METHOD_BEGIN/END
 
 // ----------------------------------------------------------------------
-CPPUNIT_TEST_SUITE_REGISTRATION( pylith::utils::TestEventLogger );
+CPPUNIT_TEST_SUITE_REGISTRATION(pylith::utils::TestEventLogger);
 
 // ----------------------------------------------------------------------
 // Test constructor.
 void
-pylith::utils::TestEventLogger::testConstructor(void)
-{ // testConstructor
-  PYLITH_METHOD_BEGIN;
+pylith::utils::TestEventLogger::testConstructor(void) {
+    PYLITH_METHOD_BEGIN;
 
-  EventLogger logger;
+    EventLogger logger;
 
-  PYLITH_METHOD_END;
+    PYLITH_METHOD_END;
 } // testConstructor
 
+
 // ----------------------------------------------------------------------
-// Test className().
+// Test get/setClassName().
 void
-pylith::utils::TestEventLogger::testClassName(void)
-{ // testClassName
-  PYLITH_METHOD_BEGIN;
+pylith::utils::TestEventLogger::testClassName(void) {
+    PYLITH_METHOD_BEGIN;
 
-  EventLogger logger;
-  CPPUNIT_ASSERT_EQUAL(std::string(""), std::string(logger.className()));
+    EventLogger logger;
+    CPPUNIT_ASSERT_EQUAL(std::string(""), std::string(logger.getClassName()));
 
-  const std::string& name = "my name";
-  logger.className(name.c_str());
-  CPPUNIT_ASSERT_EQUAL(name, std::string(logger.className()));
+    const std::string& name = "my name";
+    logger.setClassName(name.c_str());
+    CPPUNIT_ASSERT_EQUAL(name, std::string(logger.getClassName()));
 
-  PYLITH_METHOD_END;
+    PYLITH_METHOD_END;
 } // testClassName
+
 
 // ----------------------------------------------------------------------
 // Test initialize().
 void
-pylith::utils::TestEventLogger::testInitialize(void)
-{ // testInitialize
-  PYLITH_METHOD_BEGIN;
+pylith::utils::TestEventLogger::testInitialize(void) {
+    PYLITH_METHOD_BEGIN;
 
-  EventLogger logger;
-  logger.className("my class");
-  CPPUNIT_ASSERT_EQUAL(0, logger._classId);
-  logger.initialize();
-  CPPUNIT_ASSERT(logger._classId);
+    EventLogger logger;
+    logger.setClassName("my class");
+    CPPUNIT_ASSERT_EQUAL(0, logger._classId);
+    logger.initialize();
+    CPPUNIT_ASSERT(logger._classId);
 
-  PYLITH_METHOD_END;
+    PYLITH_METHOD_END;
 } // testInitialize
+
 
 // ----------------------------------------------------------------------
 // Test registerEvent().
 void
-pylith::utils::TestEventLogger::testRegisterEvent(void)
-{ // testRegisterEvent
-  PYLITH_METHOD_BEGIN;
+pylith::utils::TestEventLogger::testRegisterEvent(void) {
+    PYLITH_METHOD_BEGIN;
 
-  EventLogger logger;
-  logger.className("my class");
-  logger.initialize();
+    EventLogger logger;
+    logger.setClassName("my class");
+    logger.initialize();
 
-  const int numEvents = 3;
-  const char* events[numEvents] = { "event A", "event B", "event C" };
-  int ids[numEvents];
+    const int numEvents = 3;
+    const char* events[numEvents] = { "event A", "event B", "event C" };
+    int ids[numEvents];
 
-  for (int i=0; i < numEvents; ++i)
-    ids[i] = logger.registerEvent(events[i]);
+    for (int i = 0; i < numEvents; ++i) {
+        ids[i] = logger.registerEvent(events[i]);
+    }
 
-  int i = 0;
-  for (EventLogger::map_event_type::iterator e_iter=logger._events.begin(); e_iter != logger._events.end(); ++e_iter, ++i) {
-    CPPUNIT_ASSERT_EQUAL(std::string(events[i]), e_iter->first);
-    CPPUNIT_ASSERT_EQUAL(ids[i], e_iter->second);
-  } // for
+    int i = 0;
+    for (EventLogger::map_event_type::iterator e_iter = logger._events.begin(); e_iter != logger._events.end(); ++e_iter, ++i) {
+        CPPUNIT_ASSERT_EQUAL(std::string(events[i]), e_iter->first);
+        CPPUNIT_ASSERT_EQUAL(ids[i], e_iter->second);
+    } // for
 
-  PYLITH_METHOD_END;
+    PYLITH_METHOD_END;
 } // testRegisterEvent
 
+
 // ----------------------------------------------------------------------
-// Test eventId().
+// Test getEventId().
 void
-pylith::utils::TestEventLogger::testEventId(void)
-{ // testEventId
-  PYLITH_METHOD_BEGIN;
+pylith::utils::TestEventLogger::testGetEventId(void) {
+    PYLITH_METHOD_BEGIN;
 
-  EventLogger logger;
-  logger.className("my class");
-  logger.initialize();
+    EventLogger logger;
+    logger.setClassName("my class");
+    logger.initialize();
 
-  const int numEvents = 3;
-  const char* events[numEvents] = { "event A", "event B", "event C" };
+    const int numEvents = 3;
+    const char* events[numEvents] = { "event A", "event B", "event C" };
 
-  for (int i=0; i < numEvents; ++i)
-    logger.registerEvent(events[i]);
+    for (int i = 0; i < numEvents; ++i) {
+        logger.registerEvent(events[i]);
+    }
 
-  const int order[numEvents] = { 1, 0, 2 };
-  int ids[numEvents];
-  for (int i=0; i < numEvents; ++i)
-    ids[order[i]] = logger.eventId(events[order[i]]);
+    const int order[numEvents] = { 1, 0, 2 };
+    int ids[numEvents];
+    for (int i = 0; i < numEvents; ++i) {
+        ids[order[i]] = logger.getEventId(events[order[i]]);
+    }
 
-  int i = 0;
-  for (EventLogger::map_event_type::iterator e_iter=logger._events.begin(); e_iter != logger._events.end(); ++e_iter, ++i)
-    CPPUNIT_ASSERT_EQUAL(e_iter->second, ids[i]);
+    int i = 0;
+    for (EventLogger::map_event_type::iterator e_iter = logger._events.begin(); e_iter != logger._events.end(); ++e_iter, ++i) {
+        CPPUNIT_ASSERT_EQUAL(e_iter->second, ids[i]);
+    }
 
-  PYLITH_METHOD_END;
-} // testEventId
+    PYLITH_METHOD_END;
+} // testGetEventId
+
 
 // ----------------------------------------------------------------------
 // Test eventBegin() and eventEnd().
 void
-pylith::utils::TestEventLogger::testEventLogging(void)
-{ // testEventLogging
-  PYLITH_METHOD_BEGIN;
+pylith::utils::TestEventLogger::testEventLogging(void) {
+    PYLITH_METHOD_BEGIN;
 
-  EventLogger logger;
-  logger.className("my class");
-  logger.initialize();
+    EventLogger logger;
+    logger.setClassName("my class");
+    logger.initialize();
 
-  const int numEvents = 3;
-  const char* events[numEvents] = { "event A", "event B", "event C" };
-  int ids[numEvents];
+    const int numEvents = 3;
+    const char* events[numEvents] = { "event A", "event B", "event C" };
+    int ids[numEvents];
 
-  for (int i=0; i < numEvents; ++i)
-    ids[i] = logger.registerEvent(events[i]);
+    for (int i = 0; i < numEvents; ++i) {
+        ids[i] = logger.registerEvent(events[i]);
+    }
 
-  int event = ids[1];
-  logger.eventBegin(event);
-  logger.eventEnd(event);
+    int event = ids[1];
+    logger.eventBegin(event);
+    logger.eventEnd(event);
 
-  event = ids[0];
-  logger.eventBegin(event);
-  logger.eventEnd(event);
+    event = ids[0];
+    logger.eventBegin(event);
+    logger.eventEnd(event);
 
-  event = ids[2];
-  logger.eventBegin(event);
-  int event2 = ids[0];
-  logger.eventBegin(event2);
-  logger.eventEnd(event2);
-  logger.eventEnd(event);
+    event = ids[2];
+    logger.eventBegin(event);
+    int event2 = ids[0];
+    logger.eventBegin(event2);
+    logger.eventEnd(event2);
+    logger.eventEnd(event);
 
-  PYLITH_METHOD_END;
+    PYLITH_METHOD_END;
 } // testEventLogging
+
 
 // ----------------------------------------------------------------------
 // Test registerStage().
 void
-pylith::utils::TestEventLogger::testRegisterStage(void)
-{ // testRegisterStage
-  PYLITH_METHOD_BEGIN;
+pylith::utils::TestEventLogger::testRegisterStage(void) {
+    PYLITH_METHOD_BEGIN;
 
-  EventLogger logger;
-  logger.className("my class");
-  logger.initialize();
+    EventLogger logger;
+    logger.setClassName("my class");
+    logger.initialize();
 
-  const int numStages = 3;
-  const char* stages[numStages] = { "stage A1", "stage B1", "stage C1" };
-  int ids[numStages];
+    const int numStages = 3;
+    const char* stages[numStages] = { "stage A1", "stage B1", "stage C1" };
+    int ids[numStages];
 
-  for (int i=0; i < numStages; ++i)
-    ids[i] = logger.registerStage(stages[i]);
+    for (int i = 0; i < numStages; ++i) {
+        ids[i] = logger.registerStage(stages[i]);
+    }
 
-  int i = 0;
-  for (EventLogger::map_event_type::iterator s_iter=logger._stages.begin(); s_iter != logger._stages.end(); ++s_iter, ++i) {
-    CPPUNIT_ASSERT_EQUAL(std::string(stages[i]), s_iter->first);
-    CPPUNIT_ASSERT_EQUAL(ids[i], s_iter->second);
-  } // for
+    int i = 0;
+    for (EventLogger::map_event_type::iterator s_iter = logger._stages.begin(); s_iter != logger._stages.end(); ++s_iter, ++i) {
+        CPPUNIT_ASSERT_EQUAL(std::string(stages[i]), s_iter->first);
+        CPPUNIT_ASSERT_EQUAL(ids[i], s_iter->second);
+    } // for
 
-  PYLITH_METHOD_END;
+    PYLITH_METHOD_END;
 } // testRegisterStage
+
 
 // ----------------------------------------------------------------------
 // Test stageId().
 void
-pylith::utils::TestEventLogger::testStageId(void)
-{ // testStageId
-  PYLITH_METHOD_BEGIN;
+pylith::utils::TestEventLogger::testGetStageId(void) {
+    PYLITH_METHOD_BEGIN;
 
-  EventLogger logger;
-  logger.className("my class");
-  logger.initialize();
+    EventLogger logger;
+    logger.setClassName("my class");
+    logger.initialize();
 
-  const int numStages = 3;
-  const char* stages[numStages] = { "stage A2", "stage B2", "stage C2" };
+    const int numStages = 3;
+    const char* stages[numStages] = { "stage A2", "stage B2", "stage C2" };
 
-  for (int i=0; i < numStages; ++i)
-    logger.registerStage(stages[i]);
+    for (int i = 0; i < numStages; ++i) {
+        logger.registerStage(stages[i]);
+    }
 
+    const int order[numStages] = { 1, 0, 2 };
+    int ids[numStages];
+    for (int i = 0; i < numStages; ++i) {
+        ids[order[i]] = logger.getStageId(stages[order[i]]);
+    }
 
-  const int order[numStages] = { 1, 0, 2 };
-  int ids[numStages];
-  for (int i=0; i < numStages; ++i)
-    ids[order[i]] = logger.stageId(stages[order[i]]);
+    int i = 0;
+    for (EventLogger::map_event_type::iterator s_iter = logger._stages.begin(); s_iter != logger._stages.end(); ++s_iter, ++i) {
+        CPPUNIT_ASSERT_EQUAL(s_iter->second, ids[i]);
+    }
 
-  int i = 0;
-  for (EventLogger::map_event_type::iterator s_iter=logger._stages.begin(); s_iter != logger._stages.end();  ++s_iter, ++i)
-    CPPUNIT_ASSERT_EQUAL(s_iter->second, ids[i]);
-  
-  const int idNew = logger.stageId("stage D2");
-  CPPUNIT_ASSERT_EQUAL(idNew, logger.stageId("stage D2"));
+    const int idNew = logger.getStageId("stage D2");
+    CPPUNIT_ASSERT_EQUAL(idNew, logger.getStageId("stage D2"));
 
-  PYLITH_METHOD_END;
+    PYLITH_METHOD_END;
 } // testStageId
+
 
 // ----------------------------------------------------------------------
 // Test statePush() and statePop().
 void
-pylith::utils::TestEventLogger::testStageLogging(void)
-{ // testStageLogging
-  PYLITH_METHOD_BEGIN;
+pylith::utils::TestEventLogger::testStageLogging(void) {
+    PYLITH_METHOD_BEGIN;
 
-  EventLogger logger;
-  logger.className("my class");
-  logger.initialize();
+    EventLogger logger;
+    logger.setClassName("my class");
+    logger.initialize();
 
-  const int numStages = 3;
-  const char* stages[numStages] = { "stage A3", "stage B3", "stage C3" };
-  int ids[numStages];
+    const int numStages = 3;
+    const char* stages[numStages] = { "stage A3", "stage B3", "stage C3" };
+    int ids[numStages];
 
-  for (int i=0; i < numStages; ++i)
-    ids[i] = logger.registerStage(stages[i]);
+    for (int i = 0; i < numStages; ++i) {
+        ids[i] = logger.registerStage(stages[i]);
+    }
 
-  int stage = ids[1];
-  logger.stagePush(stage);
-  logger.stagePop();
+    int stage = ids[1];
+    logger.stagePush(stage);
+    logger.stagePop();
 
-  stage = ids[0];
-  logger.stagePush(stage);
-  logger.stagePop();
+    stage = ids[0];
+    logger.stagePush(stage);
+    logger.stagePop();
 
-  stage = ids[2];
-  logger.stagePush(stage);
-  int stage2 = ids[0];
-  logger.stagePush(stage2);
-  logger.stagePop();
-  logger.stagePop();
+    stage = ids[2];
+    logger.stagePush(stage);
+    int stage2 = ids[0];
+    logger.stagePush(stage2);
+    logger.stagePop();
+    logger.stagePop();
 
-  PYLITH_METHOD_END;
+    PYLITH_METHOD_END;
 } // testStageLogging
 
 
-// End of file 
+// End of file

--- a/tests/libtests/utils/TestEventLogger.hh
+++ b/tests/libtests/utils/TestEventLogger.hh
@@ -31,63 +31,61 @@
 
 /// Namespace for pylith package
 namespace pylith {
-  namespace utils {
-    class TestEventLogger;
-  } // utils
+    namespace utils {
+        class TestEventLogger;
+    } // utils
 } // pylith
 
 /// C++ unit testing for TestEventLogger
-class pylith::utils::TestEventLogger : public CppUnit::TestFixture
-{ // class TestEventLogger
+class pylith::utils::TestEventLogger : public CppUnit::TestFixture { // class TestEventLogger
+                                                                     // CPPUNIT TEST SUITE
+                                                                     // /////////////////////////////////////////////////
+    CPPUNIT_TEST_SUITE(TestEventLogger);
 
-  // CPPUNIT TEST SUITE /////////////////////////////////////////////////
-  CPPUNIT_TEST_SUITE( TestEventLogger );
+    CPPUNIT_TEST(testConstructor);
+    CPPUNIT_TEST(testClassName);
+    CPPUNIT_TEST(testInitialize);
+    CPPUNIT_TEST(testRegisterEvent);
+    CPPUNIT_TEST(testGetEventId);
+    CPPUNIT_TEST(testEventLogging);
+    CPPUNIT_TEST(testRegisterStage);
+    CPPUNIT_TEST(testGetStageId);
+    CPPUNIT_TEST(testStageLogging);
 
-  CPPUNIT_TEST( testConstructor );
-  CPPUNIT_TEST( testClassName );
-  CPPUNIT_TEST( testInitialize );
-  CPPUNIT_TEST( testRegisterEvent );
-  CPPUNIT_TEST( testEventId );
-  CPPUNIT_TEST( testEventLogging );
-  CPPUNIT_TEST( testRegisterStage );
-  CPPUNIT_TEST( testStageId );
-  CPPUNIT_TEST( testStageLogging );
+    CPPUNIT_TEST_SUITE_END();
 
-  CPPUNIT_TEST_SUITE_END();
+    // PUBLIC METHODS ///////////////////////////////////////////////////////
+public:
 
-// PUBLIC METHODS ///////////////////////////////////////////////////////
-public :
+    /// Test constructor.
+    void testConstructor(void);
 
-  /// Test constructor.
-  void testConstructor(void);
+    /// Test get/setClassName().
+    void testClassName(void);
 
-  /// Test className().
-  void testClassName(void);
+    /// Test initialize().
+    void testInitialize(void);
 
-  /// Test initialize().
-  void testInitialize(void);
+    /// Test registerEvent().
+    void testRegisterEvent(void);
 
-  /// Test registerEvent().
-  void testRegisterEvent(void);
+    /// Test getEventId().
+    void testGetEventId(void);
 
-  /// Test eventId().
-  void testEventId(void);
+    /// Test eventBegin() and eventEnd().
+    void testEventLogging(void);
 
-  /// Test eventBegin() and eventEnd().
-  void testEventLogging(void);
+    /// Test registerStage().
+    void testRegisterStage(void);
 
-  /// Test registerStage().
-  void testRegisterStage(void);
+    /// Test getStageId().
+    void testGetStageId(void);
 
-  /// Test stageId().
-  void testStageId(void);
-
-  /// Test stagePush() and stagePop().
-  void testStageLogging(void);
+    /// Test stagePush() and stagePop().
+    void testStageLogging(void);
 
 }; // class TestEventLogging
 
 #endif // pylith_utils_testeventlogger_hh
 
-
-// End of file 
+// End of file


### PR DESCRIPTION
Update EventLogger interface to rename getters/setters, i.e., setX() and getX().