### PR TITLE
Fix Neumann BC with time history

### DIFF
--- a/libsrc/pylith/bc/NeumannTimeDependent.cc
+++ b/libsrc/pylith/bc/NeumannTimeDependent.cc
@@ -29,6 +29,7 @@
 #include "pylith/topology/FieldOps.hh" // USES FieldOps
 #include "pylith/topology/Mesh.hh" // USES Mesh
 
+#include "spatialdata/spatialdb/TimeHistory.hh" // USES TimeHistory
 #include "spatialdata/units/Nondimensional.hh" // USES Nondimensional
 
 #include "pylith/utils/error.hh" // USES PYLITH_METHOD_BEGIN/END
@@ -266,6 +267,9 @@ pylith::bc::NeumannTimeDependent::createAuxiliaryField(const pylith::topology::F
         _auxiliaryFactory->addTimeHistoryAmplitude();
         _auxiliaryFactory->addTimeHistoryStartTime();
         _auxiliaryFactory->addTimeHistoryValue();
+        if (_dbTimeHistory) {
+            _dbTimeHistory->open();
+        } // if
     } // _useTimeHistory
 
     auxiliaryField->subfieldsSetup();
@@ -302,10 +306,10 @@ pylith::bc::NeumannTimeDependent::createDerivedField(const pylith::topology::Fie
 // ---------------------------------------------------------------------------------------------------------------------
 // Update auxiliary subfields at beginning of time step.
 void
-pylith::bc::NeumannTimeDependent::prestep(pylith::topology::Field* auxiliaryField,
-                                          const double t) {
+pylith::bc::NeumannTimeDependent::updateAuxiliaryField(pylith::topology::Field* auxiliaryField,
+                                                       const double t) {
     PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("prestep(auxiliaryField="<<auxiliaryField<<", t="<<t<<")");
+    PYLITH_COMPONENT_DEBUG("updateAuxiliaryField(auxiliaryField="<<auxiliaryField<<", t="<<t<<")");
 
     if (_useTimeHistory) {
         assert(_normalizer);
@@ -314,7 +318,7 @@ pylith::bc::NeumannTimeDependent::prestep(pylith::topology::Field* auxiliaryFiel
     } // if
 
     PYLITH_METHOD_END;
-} // prestep
+} // updateAuxiliaryField
 
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/libsrc/pylith/bc/NeumannTimeDependent.hh
+++ b/libsrc/pylith/bc/NeumannTimeDependent.hh
@@ -157,8 +157,8 @@ public:
      * @param[out] auxiliaryField Auxiliary field.
      * @param[in] t Current time.
      */
-    void prestep(pylith::topology::Field* auxiliaryField,
-                 const double t);
+    void updateAuxiliaryField(pylith::topology::Field* auxiliaryField,
+                              const double t);
 
     // PROTECTED METHODS ///////////////////////////////////////////////////////////////////////////////////////////////
 protected:

--- a/libsrc/pylith/feassemble/IntegratorBoundary.hh
+++ b/libsrc/pylith/feassemble/IntegratorBoundary.hh
@@ -108,6 +108,14 @@ public:
      */
     void initialize(const pylith::topology::Field& solution);
 
+    /** Update at beginning of time step.
+     *
+     * @param[in] t Current time.
+     * @param[in] dt Current time step.
+     */
+    void prestep(const PylithReal t,
+                 const PylithReal dt);
+
     /** Compute RHS residual for G(t,s).
      *
      * @param[out] residual Field for residual.

--- a/libsrc/pylith/fekernels/NeumannTimeDependent.cc
+++ b/libsrc/pylith/fekernels/NeumannTimeDependent.cc
@@ -315,7 +315,7 @@ pylith::fekernels::NeumannTimeDependent::g0_timeHistory_vector(const PylithInt d
         const PylithInt _dim = 2;
         const PylithScalar tanDir[2] = {-n[1], n[0] };
         for (PylithInt i = 0; i < _dim; ++i) {
-            g0[i] += a[i_amplitude] * (a[i_value+0]*tanDir[i] + a[i_value+1]*n[i]);
+            g0[i] += a[i_value] * (a[i_amplitude+0]*tanDir[i] + a[i_amplitude+1]*n[i]);
         } // for
         break;
     } // case 2
@@ -327,7 +327,7 @@ pylith::fekernels::NeumannTimeDependent::g0_timeHistory_vector(const PylithInt d
         _tangential_directions(_dim, refDir1, refDir2, n, tanDir1, tanDir2);
 
         for (PylithInt i = 0; i < _dim; ++i) {
-            g0[i] += a[i_amplitude] * (a[i_value+0]*tanDir1[i] + a[i_value+1]*tanDir2[i] + a[i_value+2]*n[i]);
+            g0[i] += a[i_value] * (a[i_amplitude+0]*tanDir1[i] + a[i_amplitude+1]*tanDir2[i] + a[i_amplitude+2]*n[i]);
         } // for
         break;
     } // case 3

--- a/modulesrc/bc/NeumannTimeDependent.i
+++ b/modulesrc/bc/NeumannTimeDependent.i
@@ -136,8 +136,8 @@ public:
              * @param[out] auxiliaryField Auxiliary field.
              * @param[in] t Current time.
              */
-            void prestep(pylith::topology::Field* auxiliaryField,
-                         const double t);
+            void updateAuxiliaryField(pylith::topology::Field* auxiliaryField,
+                                      const double t);
 
             // PROTECTED METHODS
             // ///////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix multiple bugs in using the Neumann BC with a time history.

1. Fix error in time history kernel. Amplitude is a vector; time history value is a scalar.
2. Fix updating auxiliary field with time history values. Need to open time history database and update add `IntegratorBoundary::prestep()`.