### PR TITLE
Update to PETSc 3.13.3.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,7 @@ CIT_HEADER_MPI
 
 # PETSC
 AC_LANG(C)
-CIT_PATH_PETSC([3.13.2])
+CIT_PATH_PETSC([3.13.3])
 CIT_HEADER_PETSC
 CIT_CHECK_LIB_PETSC
 
@@ -325,7 +325,7 @@ AC_CONFIG_FILES([Makefile
 		examples/3d/Makefile
 		examples/3d/box/Makefile
 		examples/3d/subduction/Makefile
-		examples/bar_shearwave/Makefile
+    examples/bar_shearwave/Makefile
 		examples/meshing/Makefile
 		examples/meshing/surface_nurbs/Makefile
 		examples/meshing/surface_nurbs/dem/Makefile

--- a/libsrc/pylith/testing/MMSTest.cc
+++ b/libsrc/pylith/testing/MMSTest.cc
@@ -80,7 +80,7 @@ pylith::testing::MMSTest::testDiscretization(void) {
     const size_t numSubfields = subfieldNames.size();
     pylith::real_array error(numSubfields);
     err = DMSNESCheckDiscretization(_problem->getPetscSNES(), _problem->getPetscDM(), _solution->scatterVector("mmstest"),
-                                    NULL, NULL, tolerance, &error[0]);CPPUNIT_ASSERT(!err);
+                                    tolerance, &error[0]);CPPUNIT_ASSERT(!err);
 
     bool fail = false;
     std::ostringstream msg;


### PR DESCRIPTION
Update PETSc requirement to 3.13.3.

Update MMSTest for changes to DMSNESCheckDiscretization().