### PR TITLE
Add Brune, Liu, and time history slip time functions.

### DIFF
--- a/libsrc/pylith/Makefile.am
+++ b/libsrc/pylith/Makefile.am
@@ -48,6 +48,7 @@ libpylith_la_SOURCES = \
 	faults/KinSrcConstRate.cc \
 	faults/KinSrcBrune.cc \
 	faults/KinSrcLiuCos.cc \
+	faults/KinSrcTimeHistory.hh \
 	faults/KinSrcAuxiliaryFactory.cc \
 	faults/TopologyOps.cc \
 	feassemble/PhysicsImplementation.cc \

--- a/libsrc/pylith/Makefile.am
+++ b/libsrc/pylith/Makefile.am
@@ -46,6 +46,8 @@ libpylith_la_SOURCES = \
 	faults/KinSrc.cc \
 	faults/KinSrcStep.cc \
 	faults/KinSrcConstRate.cc \
+	faults/KinSrcBrune.cc \
+	faults/KinSrcLiuCos.cc \
 	faults/KinSrcAuxiliaryFactory.cc \
 	faults/TopologyOps.cc \
 	feassemble/PhysicsImplementation.cc \

--- a/libsrc/pylith/faults/FaultCohesiveKin.cc
+++ b/libsrc/pylith/faults/FaultCohesiveKin.cc
@@ -35,6 +35,7 @@
 #include "pylith/utils/journals.hh" // USES PYLITH_COMPONENT_*
 
 #include "spatialdata/geocoords/CoordSys.hh" // USES CoordSys
+#include "spatialdata/units/Nondimensional.hh" // USES Nondimensionalizer
 #include "spatialdata/spatialdb/SpatialDB.hh" // USES SpatialDB
 
 #include <cmath> // USES pow(), sqrt()
@@ -332,10 +333,11 @@ pylith::faults::FaultCohesiveKin::updateAuxiliaryField(pylith::topology::Field* 
                                  // field.
 
     // Compute slip field at current time step
+    assert(_normalizer);
     const srcs_type::const_iterator rupturesEnd = _ruptures.end();
     for (srcs_type::iterator r_iter = _ruptures.begin(); r_iter != rupturesEnd; ++r_iter) {
         KinSrc* src = r_iter->second;assert(src);
-        src->slip(auxiliaryField, t);
+        src->updateSlip(auxiliaryField, t, _normalizer->getTimeScale());
     } // for
 
     PYLITH_METHOD_END;

--- a/libsrc/pylith/faults/KinSrc.hh
+++ b/libsrc/pylith/faults/KinSrc.hh
@@ -102,9 +102,12 @@ public:
      *
      * @param[out] auxField Fault integrator's auxiliary field.
      * @param[in] t Time t.
+     * @param[in] timeScale Time scale for nondimensionalization..
      */
-    void slip(pylith::topology::Field* const auxField,
-              const PylithScalar t);
+    virtual
+    void updateSlip(pylith::topology::Field* const auxField,
+                    const PylithScalar t,
+                    const PylithScalar timeScale);
 
     // PROTECTED METHODS //////////////////////////////////////////////////
 protected:
@@ -123,7 +126,7 @@ protected:
      * @param[in] cs Coordinate system for problem.
      */
     virtual
-    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+    void _auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
                         const spatialdata::geocoords::CoordSys* cs) = 0;
 
     /** Set constants used in finite-element integrations.
@@ -135,9 +138,9 @@ protected:
     // PROTECTED MEMBERS //////////////////////////////////////////////////
 protected:
 
-    pylith::faults::KinSrcAuxiliaryFactory* _auxFactory; ///< Factory for auxiliary subfields.
+    pylith::faults::KinSrcAuxiliaryFactory* _auxiliaryFactory; ///< Factory for auxiliary subfields.
     PetscPointFunc _slipFnKernel; ///< Kernel for slip time function.
-    pylith::topology::Field* _auxField; ///< Auxiliary field for this integrator.
+    pylith::topology::Field* _auxiliaryField; ///< Auxiliary field for this integrator.
     PetscVec _slipLocalVec; ///< PETSc local Vec to hold slip for this rupture.
 
     // PRIVATE MEMBERS ////////////////////////////////////////////////////

--- a/libsrc/pylith/faults/KinSrcAuxiliaryFactory.hh
+++ b/libsrc/pylith/faults/KinSrcAuxiliaryFactory.hh
@@ -39,17 +39,33 @@ public:
     /// Destructor.
     virtual ~KinSrcAuxiliaryFactory(void);
 
-    /// Add slip initiation time (relative to origin time) subfield to auxiliary fields.
+    /// Add slip initiation time (relative to origin time) subfield to auxiliary field.
     void addInitiationTime(void);
 
-    /// Add rise time subfield to auxiliary fields.
+    /// Add rise time subfield to auxiliary field.
     void addRiseTime(void);
 
-    /// Add finalSlip to auxiliary fields.
+    /// Add final_slip subfield to auxiliary field.
     void addFinalSlip(void);
 
-    /// Add slipRate to auxiliary fields.
+    /// Add slip_rate subfield to auxiliary field.
     void addSlipRate(void);
+
+    /// Add time_history_value subfield to auxiliary field.
+    void addTimeHistoryValue(void);
+
+    /** Update time history value subfield for current time.
+     *
+     * @param[inout] auxiliaryField Auxiliary field to update.
+     * @param[in] t Current time.
+     * @param[in] timeScale Time scale for nondimensionalization.
+     * @param[in] dbTimeHistory Time history database.
+     */
+    static
+    void updateTimeHistoryValue(pylith::topology::Field* auxiliaryField,
+                                const PylithReal t,
+                                const PylithReal timeScale,
+                                spatialdata::spatialdb::TimeHistory* const dbTimeHistory);
 
     // NOT IMPLEMENTED /////////////////////////////////////////////////////////////////////////////////////////////////
 private:

--- a/libsrc/pylith/faults/KinSrcBrune.cc
+++ b/libsrc/pylith/faults/KinSrcBrune.cc
@@ -1,0 +1,118 @@
+// -*- C++ -*-
+//
+// ----------------------------------------------------------------------
+//
+// Brad T. Aagaard, U.S. Geological Survey
+// Charles A. Williams, GNS Science
+// Matthew G. Knepley, University of Chicago
+//
+// This code was developed as part of the Computational Infrastructure
+// for Geodynamics (http://geodynamics.org).
+//
+// Copyright (c) 2010-2017 University of California, Davis
+//
+// See COPYING for license information.
+//
+// ----------------------------------------------------------------------
+//
+
+#include <portinfo>
+
+#include "KinSrcBrune.hh" // implementation of object methods
+
+#include "pylith/faults/KinSrcAuxiliaryFactory.hh" // USES KinSrcAuxiliaryFactory
+
+#include "pylith/utils/journals.hh" // USES PYLITH_COMPONENT_*
+#include "pylith/utils/error.hh" // USES PYLITH_METHOD_BEGIN/END
+
+#include "spatialdata/geocoords/CoordSys.hh" // USES CoordSys
+
+#include <cassert> // USES assert()
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Default constructor.
+pylith::faults::KinSrcBrune::KinSrcBrune(void) {
+    pylith::utils::PyreComponent::setName("kinsrcbrune");
+} // constructor
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Destructor.
+pylith::faults::KinSrcBrune::~KinSrcBrune(void) {}
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Slip time function kernel.
+void
+pylith::faults::KinSrcBrune::slipFn(const PylithInt dim,
+                                    const PylithInt numS,
+                                    const PylithInt numA,
+                                    const PylithInt sOff[],
+                                    const PylithInt sOff_x[],
+                                    const PylithScalar s[],
+                                    const PylithScalar s_t[],
+                                    const PylithScalar s_x[],
+                                    const PylithInt aOff[],
+                                    const PylithInt aOff_x[],
+                                    const PylithScalar a[],
+                                    const PylithScalar a_t[],
+                                    const PylithScalar a_x[],
+                                    const PylithReal t,
+                                    const PylithScalar x[],
+                                    const PylithInt numConstants,
+                                    const PylithScalar constants[],
+                                    PylithScalar slip[]) {
+    const PylithInt _numA = 3;
+
+    assert(_numA == numA);
+    assert(aOff);
+    assert(a);
+    assert(slip);
+
+    const PylithInt i_initiationTime = 0;
+    const PylithInt i_finalSlip = 1;
+    const PylithInt i_riseTime = 2;
+    const PylithScalar initiationTime = a[aOff[i_initiationTime]];
+    const PylithScalar* finalSlip = &a[aOff[i_finalSlip]];
+    const PylithScalar riseTime = a[aOff[i_riseTime]];
+
+    const PylithInt i_originTime = 0;
+    const PylithScalar originTime = constants[i_originTime];
+    const PylithScalar t0 = originTime + initiationTime;
+
+    if (t >= t0) {
+        const PylithScalar tau = 0.21081916 * riseTime;
+        for (PylithInt i = 0; i < dim; ++i) {
+            slip[i] = finalSlip[i] * (1.0 - exp(-(t-t0)/tau) * (1.0 + (t-t0)/tau));
+        } // for
+    } // if
+
+} // slipFn
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Preinitialize earthquake source. Set names/sizes of auxiliary subfields.
+void
+pylith::faults::KinSrcBrune::_auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+                                            const spatialdata::geocoords::CoordSys* cs) {
+    PYLITH_METHOD_BEGIN;
+    PYLITH_COMPONENT_DEBUG("_auxFieldSetup()");
+
+    assert(_auxFactory);
+    assert(cs);
+    _auxFactory->initialize(_auxField, normalizer, cs->getSpaceDim());
+
+    // :ATTENTION: The order for adding subfields must match the order of the auxiliary fields in the slip time function
+    // kernel.
+
+    _auxFactory->addInitiationTime(); // 0
+    _auxFactory->addFinalSlip(); // 1
+    _auxFactory->addRiseTime(); // 2
+
+    _slipFnKernel = pylith::faults::KinSrcBrune::slipFn;
+
+    PYLITH_METHOD_END;
+} // _auxFieldSetup
+
+
+// End of file

--- a/libsrc/pylith/faults/KinSrcBrune.cc
+++ b/libsrc/pylith/faults/KinSrcBrune.cc
@@ -93,26 +93,26 @@ pylith::faults::KinSrcBrune::slipFn(const PylithInt dim,
 // ---------------------------------------------------------------------------------------------------------------------
 // Preinitialize earthquake source. Set names/sizes of auxiliary subfields.
 void
-pylith::faults::KinSrcBrune::_auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+pylith::faults::KinSrcBrune::_auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
                                             const spatialdata::geocoords::CoordSys* cs) {
     PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("_auxFieldSetup()");
+    PYLITH_COMPONENT_DEBUG("_auxiliaryFieldSetup()");
 
-    assert(_auxFactory);
+    assert(_auxiliaryFactory);
     assert(cs);
-    _auxFactory->initialize(_auxField, normalizer, cs->getSpaceDim());
+    _auxiliaryFactory->initialize(_auxiliaryField, normalizer, cs->getSpaceDim());
 
     // :ATTENTION: The order for adding subfields must match the order of the auxiliary fields in the slip time function
     // kernel.
 
-    _auxFactory->addInitiationTime(); // 0
-    _auxFactory->addFinalSlip(); // 1
-    _auxFactory->addRiseTime(); // 2
+    _auxiliaryFactory->addInitiationTime(); // 0
+    _auxiliaryFactory->addFinalSlip(); // 1
+    _auxiliaryFactory->addRiseTime(); // 2
 
     _slipFnKernel = pylith::faults::KinSrcBrune::slipFn;
 
     PYLITH_METHOD_END;
-} // _auxFieldSetup
+} // _auxiliaryFieldSetup
 
 
 // End of file

--- a/libsrc/pylith/faults/KinSrcBrune.hh
+++ b/libsrc/pylith/faults/KinSrcBrune.hh
@@ -98,7 +98,7 @@ protected:
      * @param[in] normalizer Normalizer for nondimensionalizing values.
      * @param[in] cs Coordinate system for problem.
      */
-    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+    void _auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
                         const spatialdata::geocoords::CoordSys* cs);
 
     /** Set kernel for slip time function.

--- a/libsrc/pylith/faults/KinSrcBrune.hh
+++ b/libsrc/pylith/faults/KinSrcBrune.hh
@@ -1,0 +1,120 @@
+// -*- C++ -*-
+//
+// ----------------------------------------------------------------------
+//
+// Brad T. Aagaard, U.S. Geological Survey
+// Charles A. Williams, GNS Science
+// Matthew G. Knepley, University of Chicago
+//
+// This code was developed as part of the Computational Infrastructure
+// for Geodynamics (http://geodynamics.org).
+//
+// Copyright (c) 2010-2017 University of California, Davis
+//
+// See COPYING for license information.
+//
+// ----------------------------------------------------------------------
+//
+
+/** @file libsrc/faults/KinSrcBrune.hh
+ *
+ * @brief C++ implementation of a constant slip rate slip time function.
+ */
+
+#if !defined(pylith_faults_kinsrcbrune_hh)
+#define pylith_faults_kinsrcbrune_hh
+
+// Include directives ---------------------------------------------------
+#include "KinSrc.hh"
+
+// KinSrcBrune ------------------------------------------------------
+/** @brief Slip function time history corresponding to the integral of Brune's (1970) far-field time function.
+ *
+ * slip = final_slip * (1.0 - exp(-(t-t0)/tau) * (1.0 + (t-t0)/tau))
+ * tau = 0.21081916 * rise_time
+ *
+ * slip = 0 for t < t0.
+ */
+class pylith::faults::KinSrcBrune : public KinSrc {
+    friend class TestKinSrcBrune; // unit testing
+
+    // PUBLIC METHODS ///////////////////////////////////////////////////////
+public:
+
+    /// Default constructor.
+    KinSrcBrune(void);
+
+    /// Destructor.
+    ~KinSrcBrune(void);
+
+    /** Slip time function kernel.
+     *
+     * The "solution" field s is ignored.
+     *
+     * @param[in] dim Spatial dimension.
+     * @param[in] numS Number of registered subfields in solution field.
+     * @param[in] numA Number of registered subfields in auxiliary field.
+     * @param[in] sOff Offset of registered subfields in solution field [numS].
+     * @param[in] sOff_x Offset of registered subfields in gradient of the solution field [numS].
+     * @param[in] s Solution field with all subfields.
+     * @param[in] s_t Time derivative of solution field.
+     * @param[in] s_x Gradient of solution field.
+     * @param[in] aOff Offset of registered subfields in auxiliary field [numA]
+     * @param[in] aOff_x Offset of registered subfields in gradient of auxiliary field [numA]
+     * @param[in] a Auxiliary field with all subfields.
+     * @param[in] a_t Time derivative of auxiliary field.
+     * @param[in] a_x Gradient of auxiliary field.
+     * @param[in] t Time for residual evaluation.
+     * @param[in] x Coordinates of point evaluation.
+     * @param[in] numConstants Number of registered constants.
+     * @param[in] constants Array of registered constants.
+     * @param[out] slip [dim].
+     */
+    static
+    void slipFn(const PylithInt dim,
+                const PylithInt numS,
+                const PylithInt numA,
+                const PylithInt sOff[],
+                const PylithInt sOff_x[],
+                const PylithScalar s[],
+                const PylithScalar s_t[],
+                const PylithScalar s_x[],
+                const PylithInt aOff[],
+                const PylithInt aOff_x[],
+                const PylithScalar a[],
+                const PylithScalar a_t[],
+                const PylithScalar a_x[],
+                const PylithReal t,
+                const PylithScalar x[],
+                const PylithInt numConstants,
+                const PylithScalar constants[],
+                PylithScalar slip[]);
+
+    // PROTECTED METHODS //////////////////////////////////////////////////
+protected:
+
+    /** Setup auxiliary subfields (discretization and query fns).
+     *
+     * @param[in] normalizer Normalizer for nondimensionalizing values.
+     * @param[in] cs Coordinate system for problem.
+     */
+    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+                        const spatialdata::geocoords::CoordSys* cs);
+
+    /** Set kernel for slip time function.
+     *
+     * @param[in] auxField Auxiliary field for fault with prescribed slip.
+     */
+    void _setSlipFnKernel(const pylith::topology::Field& auxField) const;
+
+    // NOT IMPLEMENTED //////////////////////////////////////////////////////
+private:
+
+    KinSrcBrune(const KinSrcBrune&); ///< Not implemented
+    const KinSrcBrune& operator=(const KinSrcBrune&); ///< Not implemented
+
+}; // class KinSrcBrune
+
+#endif // pylith_faults_kinsrcbrune_hh
+
+// End of file

--- a/libsrc/pylith/faults/KinSrcConstRate.cc
+++ b/libsrc/pylith/faults/KinSrcConstRate.cc
@@ -90,25 +90,25 @@ pylith::faults::KinSrcConstRate::slipFn(const PylithInt dim,
 // ---------------------------------------------------------------------------------------------------------------------
 // Preinitialize earthquake source. Set names/sizes of auxiliary subfields.
 void
-pylith::faults::KinSrcConstRate::_auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+pylith::faults::KinSrcConstRate::_auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
                                                 const spatialdata::geocoords::CoordSys* cs) {
     PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("_auxFieldSetup()");
+    PYLITH_COMPONENT_DEBUG("_auxiliaryFieldSetup()");
 
-    assert(_auxFactory);
+    assert(_auxiliaryFactory);
     assert(cs);
-    _auxFactory->initialize(_auxField, normalizer, cs->getSpaceDim());
+    _auxiliaryFactory->initialize(_auxiliaryField, normalizer, cs->getSpaceDim());
 
     // :ATTENTION: The order for adding subfields must match the order of the auxiliary fields in the slip time function
     // kernel.
 
-    _auxFactory->addInitiationTime(); // 0
-    _auxFactory->addSlipRate(); // 1
+    _auxiliaryFactory->addInitiationTime(); // 0
+    _auxiliaryFactory->addSlipRate(); // 1
 
     _slipFnKernel = pylith::faults::KinSrcConstRate::slipFn;
 
     PYLITH_METHOD_END;
-} // _auxFieldSetup
+} // _auxiliaryFieldSetup
 
 
 // End of file

--- a/libsrc/pylith/faults/KinSrcLiuCos.cc
+++ b/libsrc/pylith/faults/KinSrcLiuCos.cc
@@ -1,0 +1,136 @@
+// -*- C++ -*-
+//
+// ----------------------------------------------------------------------
+//
+// Brad T. Aagaard, U.S. Geological Survey
+// Charles A. Williams, GNS Science
+// Matthew G. Knepley, University of Chicago
+//
+// This code was developed as part of the Computational Infrastructure
+// for Geodynamics (http://geodynamics.org).
+//
+// Copyright (c) 2010-2017 University of California, Davis
+//
+// See COPYING for license information.
+//
+// ----------------------------------------------------------------------
+//
+
+#include <portinfo>
+
+#include "KinSrcLiuCos.hh" // implementation of object methods
+
+#include "pylith/faults/KinSrcAuxiliaryFactory.hh" // USES KinSrcAuxiliaryFactory
+
+#include "pylith/utils/journals.hh" // USES PYLITH_COMPONENT_*
+#include "pylith/utils/error.hh" // USES PYLITH_METHOD_BEGIN/END
+
+#include "spatialdata/geocoords/CoordSys.hh" // USES CoordSys
+
+#include <cassert> // USES assert()
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Default constructor.
+pylith::faults::KinSrcLiuCos::KinSrcLiuCos(void) {
+    pylith::utils::PyreComponent::setName("kinsrcliucos");
+} // constructor
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Destructor.
+pylith::faults::KinSrcLiuCos::~KinSrcLiuCos(void) {}
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Slip time function kernel.
+void
+pylith::faults::KinSrcLiuCos::slipFn(const PylithInt dim,
+                                     const PylithInt numS,
+                                     const PylithInt numA,
+                                     const PylithInt sOff[],
+                                     const PylithInt sOff_x[],
+                                     const PylithScalar s[],
+                                     const PylithScalar s_t[],
+                                     const PylithScalar s_x[],
+                                     const PylithInt aOff[],
+                                     const PylithInt aOff_x[],
+                                     const PylithScalar a[],
+                                     const PylithScalar a_t[],
+                                     const PylithScalar a_x[],
+                                     const PylithReal t,
+                                     const PylithScalar x[],
+                                     const PylithInt numConstants,
+                                     const PylithScalar constants[],
+                                     PylithScalar slip[]) {
+    const PylithInt _numA = 3;
+
+    assert(_numA == numA);
+    assert(aOff);
+    assert(a);
+    assert(slip);
+
+    const PylithInt i_initiationTime = 0;
+    const PylithInt i_finalSlip = 1;
+    const PylithInt i_riseTime = 2;
+    const PylithScalar initiationTime = a[aOff[i_initiationTime]];
+    const PylithScalar* finalSlip = &a[aOff[i_finalSlip]];
+    const PylithScalar riseTime = a[aOff[i_riseTime]];
+
+    const PylithInt i_originTime = 0;
+    const PylithScalar originTime = constants[i_originTime];
+    const PylithScalar t0 = originTime + initiationTime;
+
+    if (t >= t0) {
+        const PylithScalar tR = t - t0;
+        const PylithScalar tau = riseTime * 1.525;
+        const PylithScalar tau1 = 0.13 * tau;
+        const PylithScalar tau2 = tau - tau1;
+        const PylithScalar Cn = M_PI /  (1.4 * M_PI * tau1 + 1.2 * tau1 + 0.3 * M_PI * tau2);
+
+        PylithScalar slipAmplitude = 0.0;
+        if (tR <= tau1) {
+            slipAmplitude = 0.7*tR - 0.7*tau1/M_PI*sin(M_PI*tR/tau1) - 0.6*tau1/(0.5*M_PI)*(cos(0.5*M_PI*tR/tau1) - 1.0);
+            slipAmplitude *= Cn;
+        } else if (tR <= 2.0*tau1) {
+            slipAmplitude = 1.0*tR - 0.7*tau1/M_PI*sin(M_PI*tR/tau1) + 0.3*tau2/M_PI*sin(M_PI*(tR-tau1)/tau2) + 1.2*tau1/M_PI
+                            - 0.3*tau1;
+            slipAmplitude *= Cn;
+        } else if (tR <= tau) {
+            slipAmplitude = 0.3*t + 0.3*tau2/M_PI*sin(M_PI*(tR-tau1)/tau2) + 1.1*tau1 + 1.2*tau1/M_PI;
+            slipAmplitude *= Cn;
+        } else {
+            slipAmplitude = 1.0;
+        } // if
+        for (PylithInt i = 0; i < dim; ++i) {
+            slip[i] = finalSlip[i] * slipAmplitude;
+        } // for
+    } // if
+} // slipFn
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Preinitialize earthquake source. Set names/sizes of auxiliary subfields.
+void
+pylith::faults::KinSrcLiuCos::_auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+                                             const spatialdata::geocoords::CoordSys* cs) {
+    PYLITH_METHOD_BEGIN;
+    PYLITH_COMPONENT_DEBUG("_auxFieldSetup()");
+
+    assert(_auxFactory);
+    assert(cs);
+    _auxFactory->initialize(_auxField, normalizer, cs->getSpaceDim());
+
+    // :ATTENTION: The order for adding subfields must match the order of the auxiliary fields in the slip time function
+    // kernel.
+
+    _auxFactory->addInitiationTime(); // 0
+    _auxFactory->addFinalSlip(); // 1
+    _auxFactory->addRiseTime(); // 2
+
+    _slipFnKernel = pylith::faults::KinSrcLiuCos::slipFn;
+
+    PYLITH_METHOD_END;
+} // _auxFieldSetup
+
+
+// End of file

--- a/libsrc/pylith/faults/KinSrcLiuCos.cc
+++ b/libsrc/pylith/faults/KinSrcLiuCos.cc
@@ -111,26 +111,26 @@ pylith::faults::KinSrcLiuCos::slipFn(const PylithInt dim,
 // ---------------------------------------------------------------------------------------------------------------------
 // Preinitialize earthquake source. Set names/sizes of auxiliary subfields.
 void
-pylith::faults::KinSrcLiuCos::_auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+pylith::faults::KinSrcLiuCos::_auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
                                              const spatialdata::geocoords::CoordSys* cs) {
     PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("_auxFieldSetup()");
+    PYLITH_COMPONENT_DEBUG("_auxiliaryFieldSetup()");
 
-    assert(_auxFactory);
+    assert(_auxiliaryFactory);
     assert(cs);
-    _auxFactory->initialize(_auxField, normalizer, cs->getSpaceDim());
+    _auxiliaryFactory->initialize(_auxiliaryField, normalizer, cs->getSpaceDim());
 
     // :ATTENTION: The order for adding subfields must match the order of the auxiliary fields in the slip time function
     // kernel.
 
-    _auxFactory->addInitiationTime(); // 0
-    _auxFactory->addFinalSlip(); // 1
-    _auxFactory->addRiseTime(); // 2
+    _auxiliaryFactory->addInitiationTime(); // 0
+    _auxiliaryFactory->addFinalSlip(); // 1
+    _auxiliaryFactory->addRiseTime(); // 2
 
     _slipFnKernel = pylith::faults::KinSrcLiuCos::slipFn;
 
     PYLITH_METHOD_END;
-} // _auxFieldSetup
+} // _auxiliaryFieldSetup
 
 
 // End of file

--- a/libsrc/pylith/faults/KinSrcLiuCos.hh
+++ b/libsrc/pylith/faults/KinSrcLiuCos.hh
@@ -1,0 +1,117 @@
+// -*- C++ -*-
+//
+// ----------------------------------------------------------------------
+//
+// Brad T. Aagaard, U.S. Geological Survey
+// Charles A. Williams, GNS Science
+// Matthew G. Knepley, University of Chicago
+//
+// This code was developed as part of the Computational Infrastructure
+// for Geodynamics (http://geodynamics.org).
+//
+// Copyright (c) 2010-2017 University of California, Davis
+//
+// See COPYING for license information.
+//
+// ----------------------------------------------------------------------
+//
+
+/** @file libsrc/faults/KinSrcLiuCos.hh
+ *
+ * @brief C++ implementation of a Liu cosine-sine slip time function.
+ */
+
+#if !defined(pylith_faults_kinsrcliucos_hh)
+#define pylith_faults_kinsrcliucos_hh
+
+// Include directives ---------------------------------------------------
+#include "KinSrc.hh"
+
+// KinSrcLiuCos ------------------------------------------------------
+/** @brief Slip function time history from Liu, Archuleta, and Hartzell,
+ * BSSA, 2006 (doi:10.1785/0120060036) which has a rapid rise and then
+ * a gradual falloff with a finite duration.
+ */
+class pylith::faults::KinSrcLiuCos : public KinSrc {
+    friend class TestKinSrcLiuCos; // unit testing
+
+    // PUBLIC METHODS ///////////////////////////////////////////////////////
+public:
+
+    /// Default constructor.
+    KinSrcLiuCos(void);
+
+    /// Destructor.
+    ~KinSrcLiuCos(void);
+
+    /** Slip time function kernel.
+     *
+     * The "solution" field s is ignored.
+     *
+     * @param[in] dim Spatial dimension.
+     * @param[in] numS Number of registered subfields in solution field.
+     * @param[in] numA Number of registered subfields in auxiliary field.
+     * @param[in] sOff Offset of registered subfields in solution field [numS].
+     * @param[in] sOff_x Offset of registered subfields in gradient of the solution field [numS].
+     * @param[in] s Solution field with all subfields.
+     * @param[in] s_t Time derivative of solution field.
+     * @param[in] s_x Gradient of solution field.
+     * @param[in] aOff Offset of registered subfields in auxiliary field [numA]
+     * @param[in] aOff_x Offset of registered subfields in gradient of auxiliary field [numA]
+     * @param[in] a Auxiliary field with all subfields.
+     * @param[in] a_t Time derivative of auxiliary field.
+     * @param[in] a_x Gradient of auxiliary field.
+     * @param[in] t Time for residual evaluation.
+     * @param[in] x Coordinates of point evaluation.
+     * @param[in] numConstants Number of registered constants.
+     * @param[in] constants Array of registered constants.
+     * @param[out] slip [dim].
+     */
+    static
+    void slipFn(const PylithInt dim,
+                const PylithInt numS,
+                const PylithInt numA,
+                const PylithInt sOff[],
+                const PylithInt sOff_x[],
+                const PylithScalar s[],
+                const PylithScalar s_t[],
+                const PylithScalar s_x[],
+                const PylithInt aOff[],
+                const PylithInt aOff_x[],
+                const PylithScalar a[],
+                const PylithScalar a_t[],
+                const PylithScalar a_x[],
+                const PylithReal t,
+                const PylithScalar x[],
+                const PylithInt numConstants,
+                const PylithScalar constants[],
+                PylithScalar slip[]);
+
+    // PROTECTED METHODS //////////////////////////////////////////////////
+protected:
+
+    /** Setup auxiliary subfields (discretization and query fns).
+     *
+     * @param[in] normalizer Normalizer for nondimensionalizing values.
+     * @param[in] cs Coordinate system for problem.
+     */
+    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+                        const spatialdata::geocoords::CoordSys* cs);
+
+    /** Set kernel for slip time function.
+     *
+     * @param[in] auxField Auxiliary field for fault with prescribed slip.
+     */
+    void _setSlipFnKernel(const pylith::topology::Field& auxField) const;
+
+    // NOT IMPLEMENTED //////////////////////////////////////////////////////
+private:
+
+    KinSrcLiuCos(const KinSrcLiuCos&); ///< Not implemented
+    const KinSrcLiuCos& operator=(const KinSrcLiuCos&); ///< Not implemented
+
+}; // class KinSrcLiuCos
+
+#endif // pylith_faults_kinsrcliucos_hh
+
+// End of file

--- a/libsrc/pylith/faults/KinSrcLiuCos.hh
+++ b/libsrc/pylith/faults/KinSrcLiuCos.hh
@@ -95,7 +95,7 @@ protected:
      * @param[in] normalizer Normalizer for nondimensionalizing values.
      * @param[in] cs Coordinate system for problem.
      */
-    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+    void _auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
                         const spatialdata::geocoords::CoordSys* cs);
 
     /** Set kernel for slip time function.

--- a/libsrc/pylith/faults/KinSrcStep.cc
+++ b/libsrc/pylith/faults/KinSrcStep.cc
@@ -90,25 +90,25 @@ pylith::faults::KinSrcStep::slipFn(const PylithInt dim,
 // ---------------------------------------------------------------------------------------------------------------------
 // Preinitialize earthquake source. Set names/sizes of auxiliary subfields.
 void
-pylith::faults::KinSrcStep::_auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+pylith::faults::KinSrcStep::_auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
                                            const spatialdata::geocoords::CoordSys* cs) {
     PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("_auxFieldSetup()");
+    PYLITH_COMPONENT_DEBUG("_auxiliaryFieldSetup()");
 
-    assert(_auxFactory);
+    assert(_auxiliaryFactory);
     assert(cs);
-    _auxFactory->initialize(_auxField, normalizer, cs->getSpaceDim());
+    _auxiliaryFactory->initialize(_auxiliaryField, normalizer, cs->getSpaceDim());
 
     // :ATTENTION: The order for adding subfields must match the order of the auxiliary fields in the slip time function
     // kernel.
 
-    _auxFactory->addInitiationTime(); // 0
-    _auxFactory->addFinalSlip(); // 1
+    _auxiliaryFactory->addInitiationTime(); // 0
+    _auxiliaryFactory->addFinalSlip(); // 1
 
     _slipFnKernel = pylith::faults::KinSrcStep::slipFn;
 
     PYLITH_METHOD_END;
-} // _auxFieldSetup
+} // _auxiliaryFieldSetup
 
 
 // End of file

--- a/libsrc/pylith/faults/KinSrcStep.hh
+++ b/libsrc/pylith/faults/KinSrcStep.hh
@@ -99,7 +99,7 @@ protected:
      * @param[in] normalizer Normalizer for nondimensionalizing values.
      * @param[in] cs Coordinate system for problem.
      */
-    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+    void _auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
                         const spatialdata::geocoords::CoordSys* cs);
 
     /** Set kernel for slip time function.

--- a/libsrc/pylith/faults/KinSrcTimeHistory.cc
+++ b/libsrc/pylith/faults/KinSrcTimeHistory.cc
@@ -1,0 +1,156 @@
+// -*- C++ -*-
+//
+// ----------------------------------------------------------------------
+//
+// Brad T. Aagaard, U.S. Geological Survey
+// Charles A. Williams, GNS Science
+// Matthew G. Knepley, University of Chicago
+//
+// This code was developed as part of the Computational Infrastructure
+// for Geodynamics (http://geodynamics.org).
+//
+// Copyright (c) 2010-2017 University of California, Davis
+//
+// See COPYING for license information.
+//
+// ----------------------------------------------------------------------
+//
+
+#include <portinfo>
+
+#include "KinSrcTimeHistory.hh" // implementation of object methods
+
+#include "pylith/faults/KinSrcAuxiliaryFactory.hh" // USES KinSrcAuxiliaryFactory
+
+#include "spatialdata/spatialdb/TimeHistory.hh" // USES TimeHistory#include <cassert> // USES assert()
+#include "spatialdata/geocoords/CoordSys.hh" // USES CoordSys
+
+#include "pylith/utils/journals.hh" // USES PYLITH_COMPONENT_*
+#include "pylith/utils/error.hh" // USES PYLITH_METHOD_BEGIN/END
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Default constructor.
+pylith::faults::KinSrcTimeHistory::KinSrcTimeHistory(void) :
+    _dbTimeHistory(NULL) {
+    pylith::utils::PyreComponent::setName("kinsrctimehistory");
+} // constructor
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Destructor.
+pylith::faults::KinSrcTimeHistory::~KinSrcTimeHistory(void) {
+    _dbTimeHistory = NULL; // :KLUDGE: Use shared pointer.
+} // destructor
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Set time history database.
+void
+pylith::faults::KinSrcTimeHistory::setTimeHistoryDB(spatialdata::spatialdb::TimeHistory* th) {
+    PYLITH_COMPONENT_DEBUG("setTimeHistoryDB(th"<<th<<")");
+
+    _dbTimeHistory = th;
+} // setTimeHistoryDB
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Get time history database.
+const spatialdata::spatialdb::TimeHistory*
+pylith::faults::KinSrcTimeHistory::getTimeHistoryDB(void) {
+    return _dbTimeHistory;
+} // getTimeHistoryDB
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Update slip subfield to current time.
+void
+pylith::faults::KinSrcTimeHistory::updateSlip(pylith::topology::Field* faultAuxField,
+                                              const double t,
+                                              const double timeScale) {
+    PYLITH_METHOD_BEGIN;
+    PYLITH_COMPONENT_DEBUG("updateSlip(auxiliaryField="<<faultAuxField<<", t="<<t<<", timeScale="<<timeScale<<")");
+
+    KinSrcAuxiliaryFactory::updateTimeHistoryValue(_auxiliaryField, t, timeScale, _dbTimeHistory);
+    KinSrc::updateSlip(faultAuxField, t, timeScale);
+
+    PYLITH_METHOD_END;
+} // updateSlip
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Slip time function kernel.
+void
+pylith::faults::KinSrcTimeHistory::slipFn(const PylithInt dim,
+                                          const PylithInt numS,
+                                          const PylithInt numA,
+                                          const PylithInt sOff[],
+                                          const PylithInt sOff_x[],
+                                          const PylithScalar s[],
+                                          const PylithScalar s_t[],
+                                          const PylithScalar s_x[],
+                                          const PylithInt aOff[],
+                                          const PylithInt aOff_x[],
+                                          const PylithScalar a[],
+                                          const PylithScalar a_t[],
+                                          const PylithScalar a_x[],
+                                          const PylithReal t,
+                                          const PylithScalar x[],
+                                          const PylithInt numConstants,
+                                          const PylithScalar constants[],
+                                          PylithScalar slip[]) {
+    const PylithInt _numA = 3;
+
+    assert(_numA == numA);
+    assert(aOff);
+    assert(a);
+    assert(slip);
+
+    const PylithInt i_initiationTime = 0;
+    const PylithInt i_finalSlip = 1;
+    const PylithInt i_timeHistoryValue = 2;
+    const PylithScalar initiationTime = a[aOff[i_initiationTime]];
+    const PylithScalar* finalSlip = &a[aOff[i_finalSlip]];
+    const PylithScalar timeHistoryValue = a[aOff[i_timeHistoryValue]];
+
+    const PylithInt i_originTime = 0;
+    const PylithScalar originTime = constants[i_originTime];
+    const PylithScalar t0 = originTime + initiationTime;
+
+    if (t >= t0) {
+        for (PylithInt i = 0; i < dim; ++i) {
+            slip[i] = finalSlip[i] * timeHistoryValue;
+        } // for
+    } // if
+
+} // slipFn
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Preinitialize earthquake source. Set names/sizes of auxiliary subfields.
+void
+pylith::faults::KinSrcTimeHistory::_auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+                                                        const spatialdata::geocoords::CoordSys* cs) {
+    PYLITH_METHOD_BEGIN;
+    PYLITH_COMPONENT_DEBUG("_auxiliaryFieldSetup()");
+
+    assert(_auxiliaryFactory);
+    assert(cs);
+    _auxiliaryFactory->initialize(_auxiliaryField, normalizer, cs->getSpaceDim());
+
+    // :ATTENTION: The order for adding subfields must match the order of the auxiliary fields in the slip time function
+    // kernel.
+
+    _auxiliaryFactory->addInitiationTime(); // 0
+    _auxiliaryFactory->addFinalSlip(); // 1
+    _auxiliaryFactory->addTimeHistoryValue(); // 2
+
+    assert(_dbTimeHistory);
+    _dbTimeHistory->open();
+
+    _slipFnKernel = pylith::faults::KinSrcTimeHistory::slipFn;
+
+    PYLITH_METHOD_END;
+} // _auxiliaryFieldSetup
+
+
+// End of file

--- a/libsrc/pylith/faults/KinSrcTimeHistory.hh
+++ b/libsrc/pylith/faults/KinSrcTimeHistory.hh
@@ -16,38 +16,52 @@
 // ----------------------------------------------------------------------
 //
 
-/** @file libsrc/faults/KinSrcConstRate.hh
+/** @file libsrc/faults/KinSrcTimeHistory.hh
  *
- * @brief C++ implementation of a constant slip rate slip time function.
+ * @brief C++ implementation of a time history data file slip time function.
  */
 
-#if !defined(pylith_faults_kinsrcconstrate_hh)
-#define pylith_faults_kinsrcconstrate_hh
+#if !defined(pylith_faults_kinsrctimehistory_hh)
+#define pylith_faults_kinsrctimehistory_hh
 
 // Include directives ---------------------------------------------------
 #include "KinSrc.hh"
 
-// KinSrcConstRate ------------------------------------------------------
-/** @brief Constant slip rate slip-time function.
- *
- * Slip time function follows the integral of constant slip rate slip
- * time function.
- *
- * slip = slip_rate * (t - t0) for t >= t0.
- *
- * slip = 0 for t < t0.
- */
-class pylith::faults::KinSrcConstRate : public KinSrc {
-    friend class TestKinSrcConstRate; // unit testing
+// KinSrcTimeHistory ------------------------------------------------------
+/// @brief Slip function time history from a user-supplied text file.
+class pylith::faults::KinSrcTimeHistory : public KinSrc {
+    friend class TestKinSrcTimeHistory; // unit testing
 
     // PUBLIC METHODS ///////////////////////////////////////////////////////
 public:
 
     /// Default constructor.
-    KinSrcConstRate(void);
+    KinSrcTimeHistory(void);
 
     /// Destructor.
-    ~KinSrcConstRate(void);
+    ~KinSrcTimeHistory(void);
+
+    /** Set time history database.
+     *
+     * @param[in] db Time history database.
+     */
+    void setTimeHistoryDB(spatialdata::spatialdb::TimeHistory* th);
+
+    /** Get time history database.
+     *
+     * @preturns Time history database.
+     */
+    const spatialdata::spatialdb::TimeHistory* getTimeHistoryDB(void);
+
+    /** Set slip subfield in fault integrator's auxiliary field at time t.
+     *
+     * @param[out] auxField Fault integrator's auxiliary field.
+     * @param[in] t Time t.
+     * @param[in] timeScale Time scale for nondimensionalization..
+     */
+    void updateSlip(pylith::topology::Field* const auxField,
+                    const PylithScalar t,
+                    const PylithScalar timeScale);
 
     /** Slip time function kernel.
      *
@@ -109,14 +123,19 @@ protected:
      */
     void _setSlipFnKernel(const pylith::topology::Field& auxField) const;
 
+    // PRIVATE MEMBERS /////////////////////////////////////////////////////////////////////////////////////////////////
+private:
+
+    spatialdata::spatialdb::TimeHistory* _dbTimeHistory; ///< Time history database.
+
     // NOT IMPLEMENTED //////////////////////////////////////////////////////
 private:
 
-    KinSrcConstRate(const KinSrcConstRate&); ///< Not implemented
-    const KinSrcConstRate& operator=(const KinSrcConstRate&); ///< Not implemented
+    KinSrcTimeHistory(const KinSrcTimeHistory&); ///< Not implemented
+    const KinSrcTimeHistory& operator=(const KinSrcTimeHistory&); ///< Not implemented
 
-}; // class KinSrcConstRate
+}; // class KinSrcTimeHistory
 
-#endif // pylith_faults_kinsrcconstrate_hh
+#endif // pylith_faults_kinsrctimehistory_hh
 
 // End of file

--- a/libsrc/pylith/faults/Makefile.am
+++ b/libsrc/pylith/faults/Makefile.am
@@ -28,6 +28,7 @@ subpkginclude_HEADERS = \
 	KinSrcConstRate.hh \
 	KinSrcBrune.hh \
 	KinSrcLiuCos.hh \
+	KinSrcTimeHistory.hh \
 	KinSrcAuxiliaryFactory.hh \
 	faultsfwd.hh
 

--- a/libsrc/pylith/faults/Makefile.am
+++ b/libsrc/pylith/faults/Makefile.am
@@ -26,6 +26,8 @@ subpkginclude_HEADERS = \
 	KinSrc.hh \
 	KinSrcStep.hh \
 	KinSrcConstRate.hh \
+	KinSrcBrune.hh \
+	KinSrcLiuCos.hh \
 	KinSrcAuxiliaryFactory.hh \
 	faultsfwd.hh
 

--- a/libsrc/pylith/faults/faultsfwd.hh
+++ b/libsrc/pylith/faults/faultsfwd.hh
@@ -38,6 +38,7 @@ namespace pylith {
         class KinSrcStep;
         class KinSrcBrune;
         class KinSrcLiuCos;
+        class KinSrcTimeHistory;
         class KinSrcAuxiliaryFactory;
 
         class TopologyOps;

--- a/modulesrc/faults/KinSrc.i
+++ b/modulesrc/faults/KinSrc.i
@@ -77,9 +77,12 @@ namespace pylith {
 	     *
 	     * @param[out] auxField Fault integrator's auxiliary field.
 	     * @param[in] t Time t.
+	     * @param[in] timeScale Time scale for nondimensionalization..
 	     */
-	    void slip(pylith::topology::Field* const auxField,
-		      const PylithScalar t);
+	    virtual
+	    void updateSlip(pylith::topology::Field* const auxField,
+			    const PylithScalar t,
+			    const PylithScalar timeScale);
 	    
 	    // PROTECTED METHODS //////////////////////////////////////////////////
 	protected:
@@ -98,7 +101,7 @@ namespace pylith {
 	     * @param[in] cs Coordinate system for problem.
 	     */
 	    virtual
-	    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+	    void _auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
 				const spatialdata::geocoords::CoordSys* cs) = 0;
 	  
 	}; // class KinSrc

--- a/modulesrc/faults/KinSrcBrune.i
+++ b/modulesrc/faults/KinSrcBrune.i
@@ -1,0 +1,55 @@
+// -*- C++ -*-
+//
+// ----------------------------------------------------------------------
+//
+// Brad T. Aagaard, U.S. Geological Survey
+// Charles A. Williams, GNS Science
+// Matthew G. Knepley, University of Chicago
+//
+// This code was developed as part of the Computational Infrastructure
+// for Geodynamics (http://geodynamics.org).
+//
+// Copyright (c) 2010-2017 University of California, Davis
+//
+// See COPYING for license information.
+//
+// ----------------------------------------------------------------------
+//
+
+/** @file modulesrc/faults/KinSrcBrune.i
+ *
+ * @brief Python interface to C++ KinSrcBrune object.
+ */
+
+namespace pylith {
+    namespace faults {
+
+	class KinSrcBrune : public pylith::faults::KinSrc {
+
+	    // PUBLIC METHODS /////////////////////////////////////////////////
+	public :
+
+	    /// Default constructor.
+	    KinSrcBrune(void);
+      
+	    /// Destructor.
+	    ~KinSrcBrune(void);
+      
+	    // PROTECTED METHODS //////////////////////////////////////////////////
+	protected:
+
+	    /** Setup auxiliary subfields (discretization and query fns).
+	     *
+	     * @param[in] normalizer Normalizer for nondimensionalizing values.
+	     * @param[in] cs Coordinate system for problem.
+	     */
+	    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+				const spatialdata::geocoords::CoordSys* cs);
+	    
+	}; // class KinSrcBrune
+
+    } // faults
+} // pylith
+
+
+// End of file 

--- a/modulesrc/faults/KinSrcBrune.i
+++ b/modulesrc/faults/KinSrcBrune.i
@@ -43,7 +43,7 @@ namespace pylith {
 	     * @param[in] normalizer Normalizer for nondimensionalizing values.
 	     * @param[in] cs Coordinate system for problem.
 	     */
-	    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+	    void _auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
 				const spatialdata::geocoords::CoordSys* cs);
 	    
 	}; // class KinSrcBrune

--- a/modulesrc/faults/KinSrcConstRate.i
+++ b/modulesrc/faults/KinSrcConstRate.i
@@ -43,7 +43,7 @@ namespace pylith {
 	     * @param[in] normalizer Normalizer for nondimensionalizing values.
 	     * @param[in] cs Coordinate system for problem.
 	     */
-	    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+	    void _auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
 				const spatialdata::geocoords::CoordSys* cs);
 	    
 	}; // class KinSrcConstRate

--- a/modulesrc/faults/KinSrcLiuCos.i
+++ b/modulesrc/faults/KinSrcLiuCos.i
@@ -1,0 +1,55 @@
+// -*- C++ -*-
+//
+// ----------------------------------------------------------------------
+//
+// Brad T. Aagaard, U.S. Geological Survey
+// Charles A. Williams, GNS Science
+// Matthew G. Knepley, University of Chicago
+//
+// This code was developed as part of the Computational Infrastructure
+// for Geodynamics (http://geodynamics.org).
+//
+// Copyright (c) 2010-2017 University of California, Davis
+//
+// See COPYING for license information.
+//
+// ----------------------------------------------------------------------
+//
+
+/** @file modulesrc/faults/KinSrcLiuCos.i
+ *
+ * @brief Python interface to C++ KinSrcLiuCos object.
+ */
+
+namespace pylith {
+    namespace faults {
+
+	class KinSrcLiuCos : public pylith::faults::KinSrc {
+
+	    // PUBLIC METHODS /////////////////////////////////////////////////
+	public :
+
+	    /// Default constructor.
+	    KinSrcLiuCos(void);
+      
+	    /// Destructor.
+	    ~KinSrcLiuCos(void);
+      
+	    // PROTECTED METHODS //////////////////////////////////////////////////
+	protected:
+
+	    /** Setup auxiliary subfields (discretization and query fns).
+	     *
+	     * @param[in] normalizer Normalizer for nondimensionalizing values.
+	     * @param[in] cs Coordinate system for problem.
+	     */
+	    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+				const spatialdata::geocoords::CoordSys* cs);
+	    
+	}; // class KinSrcLiuCos
+
+    } // faults
+} // pylith
+
+
+// End of file 

--- a/modulesrc/faults/KinSrcStep.i
+++ b/modulesrc/faults/KinSrcStep.i
@@ -43,7 +43,7 @@ namespace pylith {
 	     * @param[in] normalizer Normalizer for nondimensionalizing values.
 	     * @param[in] cs Coordinate system for problem.
 	     */
-	    void _auxFieldSetup(const spatialdata::units::Nondimensional& normalizer,
+	    void _auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
 				const spatialdata::geocoords::CoordSys* cs);
 	    
 	}; // class KinSrcStep

--- a/modulesrc/faults/KinSrcTimeHistory.i
+++ b/modulesrc/faults/KinSrcTimeHistory.i
@@ -16,25 +16,47 @@
 // ----------------------------------------------------------------------
 //
 
-/** @file modulesrc/faults/KinSrcLiuCos.i
+/** @file modulesrc/faults/KinSrcBrune.i
  *
- * @brief Python interface to C++ KinSrcLiuCos object.
+ * @brief Python interface to C++ KinSrcBrune object.
  */
 
 namespace pylith {
     namespace faults {
 
-	class KinSrcLiuCos : public pylith::faults::KinSrc {
+	class KinSrcBrune : public pylith::faults::KinSrc {
 
 	    // PUBLIC METHODS /////////////////////////////////////////////////
 	public :
 
 	    /// Default constructor.
-	    KinSrcLiuCos(void);
+	    KinSrcBrune(void);
       
 	    /// Destructor.
-	    ~KinSrcLiuCos(void);
+	    ~KinSrcBrune(void);
       
+	  /** Set time history database.
+	   *
+	   * @param[in] db Time history database.
+	   */
+	  void setTimeHistoryDB(spatialdata::spatialdb::TimeHistory* th);
+
+	  /** Get time history database.
+	   *
+	   * @preturns Time history database.
+	   */
+	  const spatialdata::spatialdb::TimeHistory* getTimeHistoryDB(void);
+
+	  /** Set slip subfield in fault integrator's auxiliary field at time t.
+	   *
+	   * @param[out] auxField Fault integrator's auxiliary field.
+	   * @param[in] t Time t.
+	   * @param[in] timeScale Time scale for nondimensionalization..
+	   */
+	  void updateSlip(pylith::topology::Field* const auxField,
+			  const PylithScalar t,
+			  const PylithScalar timeScale);
+
 	    // PROTECTED METHODS //////////////////////////////////////////////////
 	protected:
 
@@ -46,7 +68,7 @@ namespace pylith {
 	    void _auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
 				const spatialdata::geocoords::CoordSys* cs);
 	    
-	}; // class KinSrcLiuCos
+	}; // class KinSrcBrune
 
     } // faults
 } // pylith

--- a/modulesrc/faults/Makefile.am
+++ b/modulesrc/faults/Makefile.am
@@ -34,7 +34,8 @@ swig_sources = \
 	KinSrcStep.i \
 	KinSrcConstRate.i \
 	KinSrcBrune.i \
-	KinSrcLiuCos.i
+	KinSrcLiuCos.i \
+	KinSrcTimeHistory.i
 
 swig_generated = \
 	faults_wrap.cxx \

--- a/modulesrc/faults/Makefile.am
+++ b/modulesrc/faults/Makefile.am
@@ -32,7 +32,9 @@ swig_sources = \
 	FaultCohesiveKin.i \
 	KinSrc.i \
 	KinSrcStep.i \
-	KinSrcConstRate.i
+	KinSrcConstRate.i \
+	KinSrcBrune.i \
+	KinSrcLiuCos.i
 
 swig_generated = \
 	faults_wrap.cxx \

--- a/modulesrc/faults/faults.i
+++ b/modulesrc/faults/faults.i
@@ -24,6 +24,8 @@
 #include "pylith/faults/KinSrc.hh"
 #include "pylith/faults/KinSrcStep.hh"
 #include "pylith/faults/KinSrcConstRate.hh"
+#include "pylith/faults/KinSrcBrune.hh"
+#include "pylith/faults/KinSrcLiuCos.hh"
 %}
 
 %include "exception.i"
@@ -58,5 +60,7 @@ import_array();
 %include "KinSrc.i"
 %include "KinSrcStep.i"
 %include "KinSrcConstRate.i"
+%include "KinSrcBrune.i"
+%include "KinSrcLiuCos.i"
 
 // End of file

--- a/modulesrc/faults/faults.i
+++ b/modulesrc/faults/faults.i
@@ -26,6 +26,7 @@
 #include "pylith/faults/KinSrcConstRate.hh"
 #include "pylith/faults/KinSrcBrune.hh"
 #include "pylith/faults/KinSrcLiuCos.hh"
+#include "pylith/faults/KinSrcTimeHistory.hh"
 %}
 
 %include "exception.i"
@@ -62,5 +63,6 @@ import_array();
 %include "KinSrcConstRate.i"
 %include "KinSrcBrune.i"
 %include "KinSrcLiuCos.i"
+%include "KinSrcTimeHistory.i"
 
 // End of file

--- a/pylith/Makefile.am
+++ b/pylith/Makefile.am
@@ -37,6 +37,7 @@ nobase_pkgpyexec_PYTHON = \
 	faults/KinSrcConstRate.py \
 	faults/KinSrcBrune.py \
 	faults/KinSrcLiuCos.py \
+	faults/KinSrcTimeHistory.py \
 	faults/SingleRupture.py \
 	feassemble/__init__.py \
 	friction/__init__.py \

--- a/pylith/Makefile.am
+++ b/pylith/Makefile.am
@@ -35,6 +35,8 @@ nobase_pkgpyexec_PYTHON = \
 	faults/KinSrc.py \
 	faults/KinSrcStep.py \
 	faults/KinSrcConstRate.py \
+	faults/KinSrcBrune.py \
+	faults/KinSrcLiuCos.py \
 	faults/SingleRupture.py \
 	feassemble/__init__.py \
 	friction/__init__.py \

--- a/pylith/faults/KinSrcBrune.py
+++ b/pylith/faults/KinSrcBrune.py
@@ -1,0 +1,60 @@
+# ----------------------------------------------------------------------
+#
+# Brad T. Aagaard, U.S. Geological Survey
+# Charles A. Williams, GNS Science
+# Matthew G. Knepley, University of Chicago
+#
+# This code was developed as part of the Computational Infrastructure
+# for Geodynamics (http://geodynamics.org).
+#
+# Copyright (c) 2010-2017 University of California, Davis
+#
+# See COPYING for license information.
+#
+# ----------------------------------------------------------------------
+#
+# @file pylith/faults/KinSrcBrune.py
+#
+# @brief Python object for a Brune's (1970) slip time function.
+#
+# Factory: eq_kinematic_src
+
+from .KinSrc import KinSrc
+from .faults import KinSrcBrune as ModuleKinSrc
+
+
+class KinSrcBrune(KinSrc, ModuleKinSrc):
+    """
+    Python object for Brune's (1970) far-field slip time function.
+
+    Factory: eq_kinematic_src
+    """
+
+    # PUBLIC METHODS /////////////////////////////////////////////////////
+
+    def __init__(self, name="kinsrcbrune"):
+        """
+        Constructor.
+        """
+        KinSrc.__init__(self, name)
+        return
+
+    # PRIVATE METHODS ////////////////////////////////////////////////////
+
+    def _createModuleObj(self):
+        """
+        Call constructor for module object for access to C++ object.
+        """
+        ModuleKinSrc.__init__(self)
+
+
+# FACTORIES ////////////////////////////////////////////////////////////
+
+def eq_kinematic_src():
+    """
+    Factory associated with KinSrcBrune.
+    """
+    return KinSrcBrune()
+
+
+# End of file

--- a/pylith/faults/KinSrcLiuCos.py
+++ b/pylith/faults/KinSrcLiuCos.py
@@ -1,0 +1,60 @@
+# ----------------------------------------------------------------------
+#
+# Brad T. Aagaard, U.S. Geological Survey
+# Charles A. Williams, GNS Science
+# Matthew G. Knepley, University of Chicago
+#
+# This code was developed as part of the Computational Infrastructure
+# for Geodynamics (http://geodynamics.org).
+#
+# Copyright (c) 2010-2017 University of California, Davis
+#
+# See COPYING for license information.
+#
+# ----------------------------------------------------------------------
+#
+# @file pylith/faults/KinSrcLiuCos.py
+#
+# @brief Python object for a Liu () cosine-sine slip time function.
+#
+# Factory: eq_kinematic_src
+
+from .KinSrc import KinSrc
+from .faults import KinSrcLiuCos as ModuleKinSrc
+
+
+class KinSrcLiuCos(KinSrc, ModuleKinSrc):
+    """
+    Python object for Liu (1970) cosine-sine slip time function.
+
+    Factory: eq_kinematic_src
+    """
+
+    # PUBLIC METHODS /////////////////////////////////////////////////////
+
+    def __init__(self, name="kinsrcliucos"):
+        """
+        Constructor.
+        """
+        KinSrc.__init__(self, name)
+        return
+
+    # PRIVATE METHODS ////////////////////////////////////////////////////
+
+    def _createModuleObj(self):
+        """
+        Call constructor for module object for access to C++ object.
+        """
+        ModuleKinSrc.__init__(self)
+
+
+# FACTORIES ////////////////////////////////////////////////////////////
+
+def eq_kinematic_src():
+    """
+    Factory associated with KinSrcLiuCos.
+    """
+    return KinSrcLiuCos()
+
+
+# End of file

--- a/pylith/faults/KinSrcTimeHistory.py
+++ b/pylith/faults/KinSrcTimeHistory.py
@@ -1,0 +1,82 @@
+# ----------------------------------------------------------------------
+#
+# Brad T. Aagaard, U.S. Geological Survey
+# Charles A. Williams, GNS Science
+# Matthew G. Knepley, University of Chicago
+#
+# This code was developed as part of the Computational Infrastructure
+# for Geodynamics (http://geodynamics.org).
+#
+# Copyright (c) 2010-2017 University of California, Davis
+#
+# See COPYING for license information.
+#
+# ----------------------------------------------------------------------
+#
+# @file pylith/faults/KinSrcTimeHistory.py
+#
+# @brief Python object for time history data file slip time function.
+#
+# Factory: eq_kinematic_src
+
+from .KinSrc import KinSrc
+from .faults import KinSrcTimeHistory as ModuleKinSrc
+
+
+class KinSrcTimeHistory(KinSrc, ModuleKinSrc):
+    """
+    Python object for time history data file slip time function.
+
+    INVENTORY
+
+    Properties
+      - None
+
+    Facilities
+      - *time_history* Time history with normalized amplitude as a function of time.
+
+    Factory: eq_kinematic_src
+    """
+    import pyre.inventory
+
+    from spatialdata.spatialdb.TimeHistory import TimeHistory
+    dbTimeHistory = pyre.inventory.facility("time_history", factory=TimeHistory, family="temporal_database")
+    dbTimeHistory.meta['tip'] = "Time history with normalized amplitude as a function of time."
+
+    # PUBLIC METHODS /////////////////////////////////////////////////////
+
+    def __init__(self, name="kinsrctimehistory"):
+        """
+        Constructor.
+        """
+        KinSrc.__init__(self, name)
+        return
+
+    def preinitialize(self):
+        """
+        Do pre-initialization setup.
+        """
+        KinSrc.preinitialize(self)
+
+        ModuleKinSrc.setTimeHistory(self, self.dbTimeHistory)
+        return
+
+    # PRIVATE METHODS ////////////////////////////////////////////////////
+
+    def _createModuleObj(self):
+        """
+        Call constructor for module object for access to C++ object.
+        """
+        ModuleKinSrc.__init__(self)
+
+
+# FACTORIES ////////////////////////////////////////////////////////////
+
+def eq_kinematic_src():
+    """
+    Factory associated with KinSrcTimeHistory.
+    """
+    return KinSrcTimeHistory()
+
+
+# End of file


### PR DESCRIPTION
Add slip time functions used primarily in dynamic simulations:
* Integral of Brune's far-field time function
* Liu cosine-sine slip time function
* Time history from data file slip time function

Closes https://github.com/geodynamics/pylith/issues/170