### PR TITLE
Verify existence of mesh input files in Pyre validators.

### DIFF
--- a/pylith/meshio/MeshIOAscii.py
+++ b/pylith/meshio/MeshIOAscii.py
@@ -32,6 +32,10 @@ def validateFilename(value):
         msg = "Filename for ASCII input mesh not specified.  " + \
             "To test PyLith, run an example as discussed in the manual."
         raise ValueError(msg)
+    try:
+        open(value, "r")
+    except IOError:
+        raise IOError("ASCII input mesh '{}' not found.".format(value))
     return value
 
 

--- a/pylith/meshio/MeshIOCubit.py
+++ b/pylith/meshio/MeshIOCubit.py
@@ -29,7 +29,11 @@ def validateFilename(value):
     Validate filename.
     """
     if 0 == len(value):
-        raise ValueError("Filename for CUBIT input mesh not specified.")
+        raise ValueError("Filename for CUBIT/Trlis input mesh not specified.")
+    try:
+        open(value, "r")
+    except IOError:
+        raise IOError("CUBIT/Trelis input mesh '{}' not found.".format(value))
     return value
 
 
@@ -51,8 +55,7 @@ class MeshIOCubit(MeshIOObj, ModuleMeshIOCubit):
 
     import pyre.inventory
 
-    filename = pyre.inventory.str("filename", default="mesh.exo",
-                                  validator=validateFilename)
+    filename = pyre.inventory.str("filename", default="mesh.exo", validator=validateFilename)
     filename.meta['tip'] = "Name of Cubit Exodus file."
 
     useNames = pyre.inventory.bool("use_nodeset_names", default=True)

--- a/pylith/meshio/MeshIOLagrit.py
+++ b/pylith/meshio/MeshIOLagrit.py
@@ -30,6 +30,10 @@ def validateFilenameGmv(value):
     """
     if 0 == len(value):
         raise ValueError("Filename for LaGriT input mesh not specified.")
+    try:
+        open(value, "r")
+    except IOError:
+        raise IOError("LaGriT input mesh '{}' not found.".format(value))
     return value
 
 
@@ -39,6 +43,10 @@ def validateFilenamePset(value):
     """
     if 0 == len(value):
         raise ValueError("Filename for LaGriT pset file not specified.")
+    try:
+        open(value, "r")
+    except IOError:
+        raise IOError("LaGriT pset file '{}' not found.".format(value))
     return value
 
 


### PR DESCRIPTION
Trap missing mesh files earlier by checking that files exist during configure (Pyre validators).