### PR TITLE
Robust implementation for updating slip in fault auxiliary field

### DIFF
--- a/libsrc/pylith/faults/FaultCohesiveKin.hh
+++ b/libsrc/pylith/faults/FaultCohesiveKin.hh
@@ -130,6 +130,8 @@ private:
 
     pylith::faults::AuxiliaryFactoryKinematic* _auxiliaryFactory; ///< Factory for auxiliary subfields.
     srcs_type _ruptures; ///< Array of kinematic earthquake ruptures.
+    PetscVec _slipVecRupture; ///< PETSc local Vec to hold slip for one kinematic rupture.
+    PetscVec _slipVecTotal; ///< PETSc local Vec to hold slip for all kinematic ruptures.
 
     // NOT IMPLEMENTED /////////////////////////////////////////////////////////////////////////////////////////////////
 private:
@@ -137,7 +139,17 @@ private:
     FaultCohesiveKin(const FaultCohesiveKin&); ///< Not implemented
     const FaultCohesiveKin& operator=(const FaultCohesiveKin&); ///< Not implemented.
 
-    static PetscErrorCode _zero(PetscInt dim, PetscReal t, const PetscReal x[], PetscInt Nc, PetscScalar *u, void *ctx) {for(int c = 0; c < Nc; ++c) u[c] = 0.0;return 0;}
+    static PetscErrorCode _zero(PetscInt dim,
+                                PetscReal t,
+                                const PetscReal x[],
+                                PetscInt Nc,
+                                PetscScalar *u,
+                                void *ctx) {
+        for (int c = 0; c < Nc; ++c) {
+            u[c] = 0.0;
+        }
+        return 0;
+    }
 
 }; // class FaultCohesiveKin
 

--- a/libsrc/pylith/faults/KinSrc.hh
+++ b/libsrc/pylith/faults/KinSrc.hh
@@ -98,14 +98,16 @@ public:
                     const spatialdata::units::Nondimensional& normalizer,
                     const spatialdata::geocoords::CoordSys* cs);
 
-    /** Set slip subfield in fault integrator's auxiliary field at time t.
+    /** Set slip values at time t.
      *
-     * @param[out] auxField Fault integrator's auxiliary field.
+     * @param[inout] slipLocalVec Local PETSc vector for slip values.
+     * @param[in] faultAuxiliaryField Auxiliary field for fault.
      * @param[in] t Time t.
-     * @param[in] timeScale Time scale for nondimensionalization..
+     * @param[in] timeScale Time scale for nondimensionalization.
      */
     virtual
-    void updateSlip(pylith::topology::Field* const auxField,
+    void updateSlip(PetscVec slipLocalVec,
+                    pylith::topology::Field* faultAuxiliaryField,
                     const PylithScalar t,
                     const PylithScalar timeScale);
 
@@ -127,7 +129,7 @@ protected:
      */
     virtual
     void _auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
-                        const spatialdata::geocoords::CoordSys* cs) = 0;
+                              const spatialdata::geocoords::CoordSys* cs) = 0;
 
     /** Set constants used in finite-element integrations.
      *
@@ -141,7 +143,6 @@ protected:
     pylith::faults::KinSrcAuxiliaryFactory* _auxiliaryFactory; ///< Factory for auxiliary subfields.
     PetscPointFunc _slipFnKernel; ///< Kernel for slip time function.
     pylith::topology::Field* _auxiliaryField; ///< Auxiliary field for this integrator.
-    PetscVec _slipLocalVec; ///< PETSc local Vec to hold slip for this rupture.
 
     // PRIVATE MEMBERS ////////////////////////////////////////////////////
 private:

--- a/libsrc/pylith/faults/KinSrcBrune.cc
+++ b/libsrc/pylith/faults/KinSrcBrune.cc
@@ -94,7 +94,7 @@ pylith::faults::KinSrcBrune::slipFn(const PylithInt dim,
 // Preinitialize earthquake source. Set names/sizes of auxiliary subfields.
 void
 pylith::faults::KinSrcBrune::_auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
-                                            const spatialdata::geocoords::CoordSys* cs) {
+                                                  const spatialdata::geocoords::CoordSys* cs) {
     PYLITH_METHOD_BEGIN;
     PYLITH_COMPONENT_DEBUG("_auxiliaryFieldSetup()");
 

--- a/libsrc/pylith/faults/KinSrcConstRate.cc
+++ b/libsrc/pylith/faults/KinSrcConstRate.cc
@@ -80,7 +80,7 @@ pylith::faults::KinSrcConstRate::slipFn(const PylithInt dim,
 
     if (t >= t0) {
         for (PylithInt i = 0; i < dim; ++i) {
-            slip[i] += slipRate[i] * (t - t0);
+            slip[i] = slipRate[i] * (t - t0);
         } // for
     } // if
 
@@ -91,7 +91,7 @@ pylith::faults::KinSrcConstRate::slipFn(const PylithInt dim,
 // Preinitialize earthquake source. Set names/sizes of auxiliary subfields.
 void
 pylith::faults::KinSrcConstRate::_auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
-                                                const spatialdata::geocoords::CoordSys* cs) {
+                                                      const spatialdata::geocoords::CoordSys* cs) {
     PYLITH_METHOD_BEGIN;
     PYLITH_COMPONENT_DEBUG("_auxiliaryFieldSetup()");
 

--- a/libsrc/pylith/faults/KinSrcLiuCos.cc
+++ b/libsrc/pylith/faults/KinSrcLiuCos.cc
@@ -112,7 +112,7 @@ pylith::faults::KinSrcLiuCos::slipFn(const PylithInt dim,
 // Preinitialize earthquake source. Set names/sizes of auxiliary subfields.
 void
 pylith::faults::KinSrcLiuCos::_auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
-                                             const spatialdata::geocoords::CoordSys* cs) {
+                                                   const spatialdata::geocoords::CoordSys* cs) {
     PYLITH_METHOD_BEGIN;
     PYLITH_COMPONENT_DEBUG("_auxiliaryFieldSetup()");
 

--- a/libsrc/pylith/faults/KinSrcStep.cc
+++ b/libsrc/pylith/faults/KinSrcStep.cc
@@ -91,7 +91,7 @@ pylith::faults::KinSrcStep::slipFn(const PylithInt dim,
 // Preinitialize earthquake source. Set names/sizes of auxiliary subfields.
 void
 pylith::faults::KinSrcStep::_auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
-                                           const spatialdata::geocoords::CoordSys* cs) {
+                                                 const spatialdata::geocoords::CoordSys* cs) {
     PYLITH_METHOD_BEGIN;
     PYLITH_COMPONENT_DEBUG("_auxiliaryFieldSetup()");
 

--- a/libsrc/pylith/faults/KinSrcTimeHistory.cc
+++ b/libsrc/pylith/faults/KinSrcTimeHistory.cc
@@ -64,14 +64,16 @@ pylith::faults::KinSrcTimeHistory::getTimeHistoryDB(void) {
 // ---------------------------------------------------------------------------------------------------------------------
 // Update slip subfield to current time.
 void
-pylith::faults::KinSrcTimeHistory::updateSlip(pylith::topology::Field* faultAuxField,
+pylith::faults::KinSrcTimeHistory::updateSlip(PetscVec slipLocalVec,
+                                              pylith::topology::Field* faultAuxiliaryField,
                                               const double t,
                                               const double timeScale) {
     PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("updateSlip(auxiliaryField="<<faultAuxField<<", t="<<t<<", timeScale="<<timeScale<<")");
+    PYLITH_COMPONENT_DEBUG("updateSlip(slipLocalVec="<<slipLocalVec<<", faultAuxiliaryField="<<faultAuxiliaryField
+                                                     <<", t="<<t<<", timeScale="<<timeScale<<")");
 
     KinSrcAuxiliaryFactory::updateTimeHistoryValue(_auxiliaryField, t, timeScale, _dbTimeHistory);
-    KinSrc::updateSlip(faultAuxField, t, timeScale);
+    KinSrc::updateSlip(slipLocalVec, faultAuxiliaryField, t, timeScale);
 
     PYLITH_METHOD_END;
 } // updateSlip

--- a/libsrc/pylith/faults/KinSrcTimeHistory.hh
+++ b/libsrc/pylith/faults/KinSrcTimeHistory.hh
@@ -53,13 +53,15 @@ public:
      */
     const spatialdata::spatialdb::TimeHistory* getTimeHistoryDB(void);
 
-    /** Set slip subfield in fault integrator's auxiliary field at time t.
+    /** Set slip values at time t.
      *
-     * @param[out] auxField Fault integrator's auxiliary field.
+     * @param[inout] slipLocalVec Local PETSc vector for slip values.
+     * @param[in] faultAuxiliaryField Auxiliary field for fault.
      * @param[in] t Time t.
-     * @param[in] timeScale Time scale for nondimensionalization..
+     * @param[in] timeScale Time scale for nondimensionalization.
      */
-    void updateSlip(pylith::topology::Field* const auxField,
+    void updateSlip(PetscVec slipLocalVec,
+                    pylith::topology::Field* faultAuxiliaryField,
                     const PylithScalar t,
                     const PylithScalar timeScale);
 
@@ -115,7 +117,7 @@ protected:
      * @param[in] cs Coordinate system for problem.
      */
     void _auxiliaryFieldSetup(const spatialdata::units::Nondimensional& normalizer,
-                        const spatialdata::geocoords::CoordSys* cs);
+                              const spatialdata::geocoords::CoordSys* cs);
 
     /** Set kernel for slip time function.
      *

--- a/libsrc/pylith/topology/VisitorMesh.icc
+++ b/libsrc/pylith/topology/VisitorMesh.icc
@@ -33,7 +33,7 @@ pylith::topology::VecVisitorMesh::VecVisitorMesh(const Field& field,
     _dm(NULL),
     _localVec(NULL),
     _section(NULL),
-    _localArray(NULL) { // constructor
+    _localArray(NULL) {
     _dm = field.mesh().dmMesh();assert(_dm);
     initialize(field, subfield);
 } // constructor

--- a/libsrc/pylith/topology/VisitorMesh.icc
+++ b/libsrc/pylith/topology/VisitorMesh.icc
@@ -63,12 +63,12 @@ pylith::topology::VecVisitorMesh::initialize(const Field& field,
 
     if (!subfield) {
         _section = fieldSection;
-        err = PetscObjectReference((PetscObject)_section);PYLITH_CHECK_ERROR(err);
     } else {
         const int fieldIndex = field.subfieldInfo(subfield).index;
         assert(fieldIndex >= 0 && fieldIndex < numFields);
         err = PetscSectionGetField(fieldSection, fieldIndex, &_section);PYLITH_CHECK_ERROR(err);
     } // if/else
+    err = PetscObjectReference((PetscObject)_section);PYLITH_CHECK_ERROR(err);
     _localVec = field.localVector();assert(_localVec);
 
     err = VecGetArray(_localVec, &_localArray);PYLITH_CHECK_ERROR(err);

--- a/modulesrc/faults/KinSrc.i
+++ b/modulesrc/faults/KinSrc.i
@@ -72,17 +72,19 @@ namespace pylith {
 	    void initialize(const pylith::topology::Field& auxField,
 			    const spatialdata::units::Nondimensional& normalizer,
 			    const spatialdata::geocoords::CoordSys* cs);
-	    
-	    /** Set slip subfield in fault integrator's auxiliary field at time t.
-	     *
-	     * @param[out] auxField Fault integrator's auxiliary field.
-	     * @param[in] t Time t.
-	     * @param[in] timeScale Time scale for nondimensionalization..
-	     */
-	    virtual
-	    void updateSlip(pylith::topology::Field* const auxField,
-			    const PylithScalar t,
-			    const PylithScalar timeScale);
+
+	      /** Set slip values at time t.
+	       *
+	       * @param[inout] slipLocalVec Local PETSc vector for slip values.
+	       * @param[in] faultAuxiliaryField Auxiliary field for fault.
+	       * @param[in] t Time t.
+	       * @param[in] timeScale Time scale for nondimensionalization.
+	       */
+	      virtual
+	      void updateSlip(PetscVec slipLocalVec,
+			      pylith::topology::Field* faultAuxiliaryField,
+			      const PylithScalar t,
+			      const PylithScalar timeScale);
 	    
 	    // PROTECTED METHODS //////////////////////////////////////////////////
 	protected:

--- a/modulesrc/faults/KinSrcTimeHistory.i
+++ b/modulesrc/faults/KinSrcTimeHistory.i
@@ -34,26 +34,28 @@ namespace pylith {
       
 	    /// Destructor.
 	    ~KinSrcBrune(void);
-      
+	  
 	  /** Set time history database.
 	   *
 	   * @param[in] db Time history database.
 	   */
 	  void setTimeHistoryDB(spatialdata::spatialdb::TimeHistory* th);
-
+	  
 	  /** Get time history database.
 	   *
 	   * @preturns Time history database.
 	   */
 	  const spatialdata::spatialdb::TimeHistory* getTimeHistoryDB(void);
-
-	  /** Set slip subfield in fault integrator's auxiliary field at time t.
+	  
+	  /** Set slip values at time t.
 	   *
-	   * @param[out] auxField Fault integrator's auxiliary field.
+	   * @param[inout] slipLocalVec Local PETSc vector for slip values.
+	   * @param[in] faultAuxiliaryField Auxiliary field for fault.
 	   * @param[in] t Time t.
-	   * @param[in] timeScale Time scale for nondimensionalization..
+	   * @param[in] timeScale Time scale for nondimensionalization.
 	   */
-	  void updateSlip(pylith::topology::Field* const auxField,
+	  void updateSlip(PetscVec slipLocalVec,
+			  pylith::topology::Field* faultAuxiliaryField,
 			  const PylithScalar t,
 			  const PylithScalar timeScale);
 


### PR DESCRIPTION
Fix kludge in `FaultCohesiveKin`.

Set slip subfield in fault auxiliary field for earthquake ruptures. Store cumulative slip in local PETSc vector and then insert slip into fault auxiliary field. Use two PETSc vectors: one for storing the slip for a given rupture and one for accumulating the total slip across all ruptures at the current time.