### PR TITLE
DOC: Rename \warning and \tip to \userwarning and \usertip

### DIFF
--- a/doc/userguide/benchmarks/benchmarks.tex
+++ b/doc/userguide/benchmarks/benchmarks.tex
@@ -1,7 +1,7 @@
 \chapter{Benchmarks}
 \label{sec:benchmarks}
 
-\warning{None of the benchmark input files in the PyLith benchmarks
+\userwarning{None of the benchmark input files in the PyLith benchmarks
   repository on GitHub have been updated for v3.0.}
 
 \section{Overview}
@@ -9,9 +9,9 @@
 The Crustal Deformation Modeling and Earthquake Source Physics Focus
 Groups within the Southern California Earthquake Center and the Short-Term
 Tectonics Working Group within CIG have developed a suite of benchmarks
-to test the accuracy and performance of 3D numerical codes for quasi-static
+to test the accuracy and performance of 3D numerical codes for quasistatic
 crustal deformation and earthquake rupture dynamics. The benchmark
-definitions for the quasi-static crustal deformation benchmarks are
+definitions for the quasistatic crustal deformation benchmarks are
 posted on the CIG website at Short-Term Tectonics Benchmarks \url{geodynamics.org/cig/workinggroups/short/workarea/benchmarks/}
 and the definitions for the earthquake rupture benchmarks are posted
 on the SCEC website \url{scecdata.usc.edu/cvws/cgi-bin/cvws.cgi}.

--- a/doc/userguide/components.tex
+++ b/doc/userguide/components.tex
@@ -19,10 +19,10 @@ Time-dependent problem.
 \item [\object{GreensFns}] \filename{pylith.problems.GreensFns}\\
 Static Green's function problem with slip impulses.
 \item [\object{Implicit}] \filename{pylith.problems.Implicit}\\
-Implicit time stepping for static and quasi-static simulations with
+Implicit time stepping for static and quasistatic simulations with
 infinitesimal strains.
 \item [\object{ImplicitLgDeform}] \filename{pylith.problems.ImplicitLgDeform}\\
-Implicit time stepping for static and quasi-static simulations including
+Implicit time stepping for static and quasistatic simulations including
 the effects of rigid body motion and small strains.
 \item [\object{Explicit}] \filename{pylith.problems.Explicit}\\
 Explicit time stepping for dynamic simulations with a lumped system
@@ -287,6 +287,6 @@ Nondimensionalization of length, time, and pressure scales.
 \item [\object{NondimensionalElasticDynamic}] \filename{spatialdata.units.NondimensionalElasticDynamic}\\
 Nondimensionalization of scales for dynamic problems.
 \item [\object{NondimensionalElasticQuasistatic}] \filename{spatialdata.units.NondimensionalElasticQuasistatic}\\
-Nondimensionalization of scales for quasi-static problems.
+Nondimensionalization of scales for quasistatic problems.
 \end{description}
 

--- a/doc/userguide/developer/build.tex
+++ b/doc/userguide/developer/build.tex
@@ -118,7 +118,7 @@ you can use for development under the Forking Workflow:
 
 \end{enumerate}
 
-\tip{We recommend adding your SSH public key to your GitHub
+\usertip{We recommend adding your SSH public key to your GitHub
   account. See
   \href{https://help.github.com/articles/connecting-to-github-with-ssh/}{GitHub
     Help: Connecting To GitHub with SSH} for more information. This
@@ -177,7 +177,7 @@ include:
     spatialdata, PETSc, and PyLith.
 \end{description}
 
-\tip{For all development, we build with debugging turned on. By
+\usertip{For all development, we build with debugging turned on. By
   building in directories separate from the source code, we can build
   an optimized version for production runs in a different directory and
   use environment variables to select the desired build.}
@@ -317,7 +317,7 @@ commands. There are Git interfaces built into a number of editors and
 integrated development environments (IDEs), and there are standalong
 graphical user interfaces to Git.
 
-\tip{If you have multiple branches, make sure you are on the correct
+\usertip{If you have multiple branches, make sure you are on the correct
   branch before making commits.}
 
 \subsection{Making Pull Requests}
@@ -413,7 +413,7 @@ one of the following:
 \item[check] Run all unit tests and full-scale automated tests.
 \end{description}
 
-\tip{On a machine with multiple cores, faster builds of the C++ code
+\usertip{On a machine with multiple cores, faster builds of the C++ code
   (library and C++ unit tests) are available using the
   \commandline{-jNTHREADS} command line argument, where
   \commandline{NTHREADS} is the number of cores to use. For example,

--- a/doc/userguide/developer/codelayout.tex
+++ b/doc/userguide/developer/codelayout.tex
@@ -173,7 +173,7 @@ source code that follows shows the essential ingradients for Python
 and C++ objects, using the concrete example of the \object{Material}
 objects.
 
-\warning{The examples below show skeleton Python and C++ objects to illustrate the essential ingredients. We have
+\userwarning{The examples below show skeleton Python and C++ objects to illustrate the essential ingredients. We have
 ommitted documentation and comments that we would normally include and simplified the object hierarchy. See
 Section~\vref{cha:code:style} for  details about the coding style we use in PyLith.}
 

--- a/doc/userguide/developer/codestyle.tex
+++ b/doc/userguide/developer/codestyle.tex
@@ -85,7 +85,7 @@ call to a PETSc function.
     } // for  
 \end{cplusplus}
 
-\tip{For production runs only, we often build with -DNDEBUG to remove
+\usertip{For production runs only, we often build with -DNDEBUG to remove
   assert() calls.}
 
 \begin{cplusplus}[Example of using PYLITH\_CHECK\_ERROR macro]

--- a/doc/userguide/developer/developer.tex
+++ b/doc/userguide/developer/developer.tex
@@ -1,7 +1,7 @@
 \chapter{Extending PyLith}
 \label{cha:developer}
 
-\warning{This chapter has not been updated for the latest information
+\userwarning{This chapter has not been updated for the latest information
   for v3.0. In particular the materials, boundary conditions, fault
   interfaces, and output have been refactored to separate the physics
   from the finite-element operations.}

--- a/doc/userguide/examples/2d_subduction.tex
+++ b/doc/userguide/examples/2d_subduction.tex
@@ -35,7 +35,7 @@ directory \filename{examples/2d/subduction}.
 
 \subsection{Overview}
 
-This example examines quasi-static interseismic and coseismic
+This example examines quasistatic interseismic and coseismic
 deformation in 2D for a subduction zone (see Figure
 \vref{fig:example:subduction:2d:overview}).  It is based on the 2011
 M9.0 Tohoku earthquake off the east coast of Japan. Figure

--- a/doc/userguide/examples/3d_subduction.tex
+++ b/doc/userguide/examples/3d_subduction.tex
@@ -104,7 +104,7 @@ the trench and then constructs the top and bottom surfaces of the
 slab. The Python script also constructs a splay fault by copying a
 contour to a depth below the slab and above the ground surface.
 
-\tip{We define the coordinate systems we use in the simulations in the
+\usertip{We define the coordinate systems we use in the simulations in the
   the Python script \filename{coordsys.py} to make it easier to
   convert to/from various georeference coordinate systems in the pre-
   and post-processing. PyLith will automatically convert among
@@ -153,7 +153,7 @@ generate the mesh. In the end you will have an Exodus-II file
 \filename{mesh\_tet.exo}, which is a NetCDF file, in the
 \filename{mesh} directory. You can load this file into ParaView.
 
-\tip{We recommend carefully examining the \filename{geometry.jou}
+\usertip{We recommend carefully examining the \filename{geometry.jou}
   journal file to understand how we assemble the 3-D slab and cut the
   rectangular domain into pieces.}
 
@@ -595,7 +595,7 @@ approximately 200 years at a depth of 30 km, 100 years at a depth of
 100 km, and 50 years at a depth of 400 km. Using linear interpolation
 results in a piecewise linear variation in the viscosity with depth.
 
-\tip{The \object{SimpleGridDB} should be used whenever the points in a
+\usertip{The \object{SimpleGridDB} should be used whenever the points in a
   spatial database can be described with a logically rectangular
   grid. The grid points along each direction do not need to be
   uniformly spaced.}
@@ -1339,7 +1339,7 @@ spatial database files. This script reads parameters from
 distribution in geographic coordinates, along with a temporal database
 providing the slip amplitudes at different times.
 
-\tip{The \filename{generate\_slowslip.py} script is one of several
+\usertip{The \filename{generate\_slowslip.py} script is one of several
   examples where we make use of the Python interface to the
   spatialdata package. This provides useful methods for handling
   coordinate systems and spatial databases.}
@@ -1536,7 +1536,7 @@ Each simulation will produce four pairs of HDF5/Xdmf files. For Step
   impulse.
 \end{description}
 
-\tip{To save time, run the two sub-problems simultaneously in separate
+\usertip{To save time, run the two sub-problems simultaneously in separate
   shells (terminal windows or tabs). For a problem this size, this
   should work fine on a laptop. For larger problems, we would run the
   simulations via separate jobs on a cluster with each job running on
@@ -1854,7 +1854,7 @@ configuration is taken into account; Steps 8a and 8b use the default
 formulation should generally be used for viscoelastic problems with
 gravity where you need accurate estimates of the vertical deformation.
 
-\warning{The shear stress variations in the initial stresses will
+\userwarning{The shear stress variations in the initial stresses will
   cause the viscoelastic materials to drive viscous flow, resulting in
   time-dependent deformation. As long as the elastic materials impose
   deviatoric stresses in the viscoelastic materials through continuity

--- a/doc/userguide/examples/3d_subduction_features.tex
+++ b/doc/userguide/examples/3d_subduction_features.tex
@@ -89,7 +89,7 @@ Example
 \\ \hline
 \end{tabular}}
 \par
-{\bf Coordinate system} -- Cart: Cartesian, Proj: geographic projection. {\bf Mesh generator} -- ASCII: ASCII, CUBIT: CUBIT/Trelis, LaGriT: LaGriT. {\bf Problem type} -- TD: time dependent, GF: Green's functions. {\bf Time dependence} -- S: static, QS: quasi-static, D: dynamic. {\bf Solver} -- L: linear, NL: nonlinear. {\bf Preconditioner} -- ILU: ILU, ASM: Additive Schwarz, SCHUR: Schur complement, Cust: custom, ML: ML algebraic multigrid, GAMG: geometric algebraic multigrid. {\bf Time stepping} -- BE: Backward Euler, FE: Forward Euler. \\ 
+{\bf Coordinate system} -- Cart: Cartesian, Proj: geographic projection. {\bf Mesh generator} -- ASCII: ASCII, CUBIT: CUBIT/Trelis, LaGriT: LaGriT. {\bf Problem type} -- TD: time dependent, GF: Green's functions. {\bf Time dependence} -- S: static, QS: quasistatic, D: dynamic. {\bf Solver} -- L: linear, NL: nonlinear. {\bf Preconditioner} -- ILU: ILU, ASM: Additive Schwarz, SCHUR: Schur complement, Cust: custom, ML: ML algebraic multigrid, GAMG: geometric algebraic multigrid. {\bf Time stepping} -- BE: Backward Euler, FE: Forward Euler. \\ 
 \rowcolors{2}{yellow!30}{white}
 \resizebox{\textwidth}{!}{%
 \begin{tabular}{|l|%% Example

--- a/doc/userguide/examples/examples.tex
+++ b/doc/userguide/examples/examples.tex
@@ -23,7 +23,7 @@ the type of problems discussed.
 \filename{bar\_shearwave} & \ref{sec:example:shearwave:tri3}--\ref{sec:example:shearwave:hex8} & beginner & Illustration of wave propagation using simple shear beam. \\
 \filename{2d/subduction} & \ref{sec:example:subduction:2d} & intermediate & Illustration of coseismic, postseismic, and creep deformation using a 2-D subduction zone cross-section with a CUBIT mesh. \\
 \filename{2d/greensfns} & \ref{sec:example:greensfns2d} & intermediate & Illustration of computing static Green's functions for a strike-slip and reverse fault using a CUBIT mesh. \\
-\filename{3d/subduction} & \ref{sec:example:subduction:3d} & intermediate & Illustration of most PyLith features for quasi-static deformation using a 3-D subduction zone with a CUBIT mesh. \\
+\filename{3d/subduction} & \ref{sec:example:subduction:3d} & intermediate & Illustration of most PyLith features for quasistatic deformation using a 3-D subduction zone with a CUBIT mesh. \\
 \hline 
 \end{tabular}
 The \filename{3d/subduction} example suite is the newest and most
@@ -98,7 +98,7 @@ There are several different ways to run the ParaView Python scripts:
   \filename{PATH\_TO\_PVPYTHON/pvpython MY\_SCRIPT.py}
 \end{itemize}
 
-\tip{Running the ParaView Python script from within the ParaView GUI
+\usertip{Running the ParaView Python script from within the ParaView GUI
   allows further manipulation of the data, which is not possible when
   running the ParaView Python script outside the ParaView GUI. When
   run outside the ParaView GUI, the interaction is limited to
@@ -112,7 +112,7 @@ There are several different ways to run the ParaView Python scripts:
   general, import Python modules provided with the PyLith distribution
   into ParaView.}
 
-\tip{In creating the ParaView Python scripts, we performed the steps
+\usertip{In creating the ParaView Python scripts, we performed the steps
   within the GUI while capturing the commands using
   \menu{Tools}$\rightarrow$\menu{Start Trace} and then
   \menu{Tools}$\rightarrow$\menu{Start Trace}. This makes it very easy

--- a/doc/userguide/extending/extending.tex
+++ b/doc/userguide/extending/extending.tex
@@ -205,7 +205,7 @@ of a bulk material as well as several utility routines:
 \item [{\texttt{\_dimProperties()}}] Dimensionalizes the physical properties
   used in the constitutive model equations.
 \item [{\texttt{\_stableTimeStepImplicit()}}] Computes the stable time
-  step for implicit time stepping in quasi-static simulations given
+  step for implicit time stepping in quasistatic simulations given
   the current state (strain, stress, and state variables).
 \item [{\texttt{\_calcDensity()}}] Computes the density given the physical
   properties and state variables. In most cases density is a physical
@@ -229,7 +229,7 @@ S-wave speed, and density rather then Lame's constants $\mu$, $\lambda,$
 and density), each bulk constitutive model component has routines
 to convert the physical property parameters and state variables a
 user specifies via spatial databases to the physical property properties
-and state variables used in the constitutive model equations. In quasi-static
+and state variables used in the constitutive model equations. In quasistatic
 problems, PyLith computes an elastic solution for the first time step
 ($-\Delta t$ to $t$). This means that for inelastic materials, we
 supply two sets of functions for the constitutive behavior: one set

--- a/doc/userguide/implementation/implementation.tex
+++ b/doc/userguide/implementation/implementation.tex
@@ -142,7 +142,7 @@ exposed to the user. In this section we describe the data structures
 to give the user greater context for understanding what the parameters
 mean.
 
-\tip{See the dveloper guide in Chapter \vref{cha:developer} for a
+\usertip{See the dveloper guide in Chapter \vref{cha:developer} for a
   detailed discussion of the implementation and organization of the
   PyLith code.}
 
@@ -201,7 +201,7 @@ highest order in the basis functions. For example, a basis order of 0
 has just a constant and a basis order of 2 for a polynomial basis has
 constant, linear, and quadratic terms.
 
-\warning{Currently, the quadrature order {\bf MUST} be the same for
+\userwarning{Currently, the quadrature order {\bf MUST} be the same for
   all subfields in a simulation. This restriction may be relaxed in
   the future. PyLith will check this and indicate if a subfield has a
   quadrature order that does not match the first solution subfield.}

--- a/doc/userguide/install/install.tex
+++ b/doc/userguide/install/install.tex
@@ -45,10 +45,10 @@ running Windows 10 build 14316 and later can install a Linux bash
 environment and use the PyLith binary for Linux (see
 Section~\vref{sec:install:windows} for more information).
 
-\tip{On Linux systems you can check which version of glibc you have by
+\usertip{On Linux systems you can check which version of glibc you have by
   running \filename{ldd --version}}.
 
-\tip{On Darwin systems running OS X, you can check the operating
+\usertip{On Darwin systems running OS X, you can check the operating
   system version by clicking on the Apple icon and \menu{About this Mac}.}
 
 \subsection{Linux and Mac OS X (Darwin)}
@@ -81,7 +81,7 @@ $ source setup.sh
   \end{shell}
 \end{enumerate}
 
-\warning{The binary distribution contains PyLith and all of its
+\userwarning{The binary distribution contains PyLith and all of its
   dependencies. If you have any of this software already installed on
   your system, you need to be careful in setting up your environment
   so that preexisting software does not conflict with the PyLith
@@ -90,7 +90,7 @@ $ source setup.sh
   (for Linux) environment variables. This will prevent most
   conflicts.}
 
-\warning{The PyLith binary distribution for {\bf Darwin} systems is
+\userwarning{The PyLith binary distribution for {\bf Darwin} systems is
   built using the system clang compiler suite and the system
   Python. {\bf This means the system Python must be in your path to
     use the PyLith binary executable}; ensure \filename{/bin} and
@@ -145,7 +145,7 @@ binary distribution.
   well as header files for PyLith and all of its dependencies.
 \end{description}
 
-\tip{We encourage anyone extending PyLith to fork the PyLith
+\usertip{We encourage anyone extending PyLith to fork the PyLith
   repository and build from source using the PyLith Installer Utility
   to facilitate contributing these features back into the CIG
   repository via pull requests.}
@@ -307,7 +307,7 @@ arguments:
 $ pylith example.cfg
 \end{shell}
 
-\warning{This assumes your machine list has enough nodes for the
+\userwarning{This assumes your machine list has enough nodes for the
   simulation in question.}
 
 You will notice that a machine file \filename{mpirun.nodes} is generated.

--- a/doc/userguide/intro/intro.tex
+++ b/doc/userguide/intro/intro.tex
@@ -6,7 +6,7 @@
 PyLith is portable, scalable software for simulation of crustal
 deformation across spatial scales ranging from meters to hundreds of
 kilometers and temporal scales ranging from milliseconds to thousands
-of years. Its primary applications are quasi-static and dynamic
+of years. Its primary applications are quasistatic and dynamic
 modeling of earthquake faulting.
 
 \section{New in PyLith Version \pylithVersionNumber}
@@ -41,14 +41,14 @@ a summary of features and bugfixes for each release.
 \section{History}
 
 PyLith 1.0 was the first version to allow the solution of both
-implicit (quasi-static) and explicit (dynamic) problems and was a
+implicit (quasistatic) and explicit (dynamic) problems and was a
 complete rewrite of the original PyLith (version 0.8). PyLith 1.0
 combines the functionality of EqSim
 \cite{Aagaard:etal:2001a,Aagaard:etal:2001b} and PyLith 0.8. PyLith
 0.8 was a direct descendant of LithoMop and was the first version that
 ran in parallel, as well as providing several other improvements over
 LithoMop. LithoMop was the product of major re-engineering of Tecton, a
-finite-element code for simulating static and quasi-static crustal
+finite-element code for simulating static and quasistatic crustal
 deformation. The major new features present in LithoMop included
 dynamic memory allocation and the use of the Pyre simulation framework
 and PETSc solvers. EqSim was written by Brad Aagaard to solve problems
@@ -58,7 +58,7 @@ propagation.
 The release of PyLith 1.0 has been followed by additional releases
 that expand the number of features as well as improve performance.
 The PyLith 1.x series of releases allows the solution of both
-quasi-static and dynamic problems in one, two, or three
+quasistatic and dynamic problems in one, two, or three
 dimensions. The code runs in either serial or parallel, and the design
 allows for relatively easy scripting using the Python programming
 language. Material properties and values for boundary and fault
@@ -98,7 +98,7 @@ to perform the finite-element integrations.
 
 PyLith is under active development and we expect a number of additions
 and improvements in the near future. Likely enhancements will include
-additional bulk and fault constitutive models, coupled quasi-static
+additional bulk and fault constitutive models, coupled quasistatic
 and dynamic simulations for earthquake cycle modeling, and coupling
 between elasticity, heat flow, and/or fluid flow.
 

--- a/doc/userguide/physics/interfaces.tex
+++ b/doc/userguide/physics/interfaces.tex
@@ -9,7 +9,7 @@ fault opening, and in 3D left-lateral-slip, reverse-slip, and fault
 opening. PyLith supports kinematic (prescribed) slip and dynamic
 (spontaneous) rupture simulations.
 
-\warning{Spontaneous rupture is not available in PyLith v3.0; we plan
+\userwarning{Spontaneous rupture is not available in PyLith v3.0; we plan
   to have it reimplemented in v3.1.}
 
 \subsection{Conventions}
@@ -122,7 +122,7 @@ The fault coordinate system is shown in Figure
 system can be transformed to the global coordinate system using the
 direction vectors in the diagnostic output.
 
-\warning{Output of fault orientation information is not yet available
+\userwarning{Output of fault orientation information is not yet available
   in this beta release.}
 \todo{brad}{Implement output of fault orientation information.}
 
@@ -131,7 +131,7 @@ direction vectors in the diagnostic output.
 Kinematic earthquake ruptures use the \object{FaultCohesiveKin} object
 to prescribe the slip as a function of time on the fault surface. Slip
 may evolve simultaneously over the fault surface instantaneously in a
-single time step (as is usually done in quasi-static simulations) or
+single time step (as is usually done in quasistatic simulations) or
 propagate over the fault surface over hundreds and up to thousands of
 time steps (as is usually done in a dynamic simulation).
 
@@ -179,7 +179,7 @@ The current release of PyLith supports specification of the evolution
 of fault slip using analytical expressions for the slip time history
 at each point, where the parameters for the slip time function may
 vary over the fault surface. Currently, two slip time functions are
-available: (1) a step-function for quasi-static modeling of earthquake
+available: (1) a step-function for quasistatic modeling of earthquake
 rupture and (2) a constant slip rate time function for modeling steady
 aseismic slip.  Additional slip time functions will likely be
 available in future releases. The default slip time function is the
@@ -405,7 +405,7 @@ fault surface.
 % As long as the fault is locked, the initial state variables are zero,
 % so specifying the initial state variables for slip-weakening friction
 % is rare. The slip-weakening friction also includes a parameter, \property{force\_healing},
-% to control healing. In quasi-static simulations, one usually wants
+% to control healing. In quasistatic simulations, one usually wants
 % slip confined to a single time step (\property{force\_healing} = True),
 % whereas in a dynamic simulation slip occurs over many time steps (\property{force\_healing}
 % = False; default behavior) and fault healing is often neglected. The
@@ -612,8 +612,8 @@ fault surface.
 % where $V$ is slip rate, $V_{linear}$ is a cutoff for a linear slip
 % rate dependence, $a$ and $b$ are coefficients, $L$ is the characteristic
 % slip distance, $\theta$ is a state variable. With an interative solver
-% in quasi-static simulations with its small, but nonzero residual tolerance
-% we never encounter zero slip rates in quasi-static simulations. Instead
+% in quasistatic simulations with its small, but nonzero residual tolerance
+% we never encounter zero slip rates in quasistatic simulations. Instead
 % we want to avoid significant variations in the coefficient of friction
 % for slip rates on the same order as our residual tolerance. We regularize
 % the rate and state friction model by imposing a linearization of the
@@ -646,7 +646,7 @@ fault surface.
 % The properties include:
 % \begin{inventory}
 % \propertyitem{linear\_slip\_rate}{Nondimensional slip rate at which linearization
-% occurs, $V_{linear}$. In quasi-static simulations it should be about
+% occurs, $V_{linear}$. In quasistatic simulations it should be about
 % one order of magnitude larger than absolute tolerance in solve.}
 % \end{inventory}
 

--- a/doc/userguide/physics/materials.tex
+++ b/doc/userguide/physics/materials.tex
@@ -69,7 +69,7 @@ implemented for the elaticity equation.
   \end{tabular}
 \end{table}
 
-\warning{The \object{IsotropicDruckerPrager} rheology has not been
+\userwarning{The \object{IsotropicDruckerPrager} rheology has not been
   implemented in this beta release.}
 
 \begin{table}[htbp]

--- a/doc/userguide/preface.tex
+++ b/doc/userguide/preface.tex
@@ -22,9 +22,9 @@ and programming, but are not necessarily professional programmers.
 
 \section{Conventions}
 
-\warning{This is a warning.}
+\userwarning{This is a warning.}
 \important{This is something important.}
-\tip{This is a tip, helpful hint, or suggestion.}
+\usertip{This is a tip, helpful hint, or suggestion.}
 
 For features recently added to PyLith, we show the version number when
 they were added.\newfeature{\pylithVersion}
@@ -77,7 +77,7 @@ The following peer-reviewed paper discussed the development of PyLith:
 \begin{itemize}
 \item Aagaard, B. T., M. G. Knepley, and C. A. Williams (2013). A
   domain decomposition approach to implementing fault slip in
-  finite-element models of quasi-static and dynamic crustal
+  finite-element models of quasistatic and dynamic crustal
   deformation, \textit{Journal of Geophysical Research: Solid Earth},
   118, doi: 10.1002/jgrb.50217.
 \end{itemize}

--- a/doc/userguide/pylithdoc.cls
+++ b/doc/userguide/pylithdoc.cls
@@ -130,7 +130,7 @@
 % Boxes
 \usetikzlibrary{shadows.blur}
 % Warning
-\newcommand{\warning}[1]{%
+\newcommand{\userwarning}[1]{%
   \begin{center}\begin{tikzpicture}
       \node[draw=none,
         shade,
@@ -144,7 +144,7 @@
     \end{tikzpicture}\end{center}}
 %
 % Tip
-\newcommand{\tip}[1]{%
+\newcommand{\usertip}[1]{%
   \begin{center}\begin{tikzpicture}
       \node[draw=none,
         shade,

--- a/doc/userguide/references.tex
+++ b/doc/userguide/references.tex
@@ -13,12 +13,12 @@
 
 \bibitem[Aagaard et al., 2007]{Aagaard:etal:2007}Aagaard, B., C.
   Williams, and M. Knepley (2007), PyLith: A finite-element code for
-  modeling quasi-static and dynamic crustal deformation, \emph{Eos
+  modeling quasistatic and dynamic crustal deformation, \emph{Eos
     Trans.  AGU, 88}(52), Fall Meet. Suppl., Abstract T21B-0592.
 
 \bibitem[Aagaard et al., 2008]{Aagaard:etal:2008}Aagaard, B., C.
   Williams, and M. Knepley (2008), PyLith: A finite-element code for
-  modeling quasi-static and dynamic crustal deformation, \emph{Eos
+  modeling quasistatic and dynamic crustal deformation, \emph{Eos
     Trans.  AGU}, \emph{89(}53), Fall Meet. Suppl., Abstract
   T41A-1925.
 
@@ -133,7 +133,7 @@
 \bibitem[Williams et al., 2005]{Williams:etal:2005}Williams, C.A.,
   B. Aagaard, and M.G. Knepley (2005), Development of software for
   studying earthquakes across multiple spatial and temporal scales by
-  coupling quasi-static and dynamic simulations, \emph{Eos Trans. AGU,
+  coupling quasistatic and dynamic simulations, \emph{Eos Trans. AGU,
     86}(52), Fall Meet. Suppl., Abstract S53A-1072.
 
 \bibitem[Williams, 2006]{Williams:2006}Williams, C.A. (2006),

--- a/doc/userguide/runpylith/definesim.tex
+++ b/doc/userguide/runpylith/definesim.tex
@@ -106,7 +106,7 @@ which are formatted as follows:
 <p>PROPERTY2</p> = VALUE2 ; this is another comment
 \end{cfg}
 
-\tip{We strongly recommend that you use \filename{cfg} files for your
+\usertip{We strongly recommend that you use \filename{cfg} files for your
   work.  The files are syntax-highlighted in most editors, such as
   vim, Emacs, and Atom.}
 

--- a/doc/userguide/runpylith/output.tex
+++ b/doc/userguide/runpylith/output.tex
@@ -99,7 +99,7 @@ data from multiple VTK files.}
 (default is 1.0 s).}
 \end{inventory}
 
-\warning{We strongly discourage use of using VTK output. It is slow,
+\userwarning{We strongly discourage use of using VTK output. It is slow,
   inefficient, and not easily read from post-processing scripts. We
   strongly recommwnd using HDF5 output instead, which is the default
   starting in PyLith v3.0.0.}
@@ -193,7 +193,7 @@ datasets in external binary files with just metadata in the HDF5 files
 using the \object{DataWriterHDF5Ext} object. Both methods provide
 similar performance because they will use MPI I/O if it is available.
 
-\warning{Storing the datasets within the HDF5 file in a parallel
+\userwarning{Storing the datasets within the HDF5 file in a parallel
   simulation requires that the HDF5 library be configured with the
   \commandline{-{}-enable-parallel} option. The binary PyLith packages
   include this feature and it is a default setting in building HDF5
@@ -275,7 +275,7 @@ user-specified elasped time. The property is
   \propertyitem{elapsed\_time}{Elasped time between writes (default=0.0*s).}
 \end{inventory}
  
-\tip{Due to roundoff error in determining the simulation time over
+\usertip{Due to roundoff error in determining the simulation time over
   many time steps, a simulation may occasionally skip writing output
   unexpectedly when using \object{OutputTriggerTime}. The best
   workaround is to use an \property{elapsed\_time} that is a fraction

--- a/doc/userguide/runpylith/postprocessing.tex
+++ b/doc/userguide/runpylith/postprocessing.tex
@@ -44,7 +44,7 @@ $ pylith_genxdmf --files=FILE_OR_FILE_PATTERN
 \end{shell}
 The default value for \filename{FILE\_OR\_FILE\_PATTERN} is \filename{*.h5}.
 
-\warning{If the HDF5 files contain external datasets, then this
+\userwarning{If the HDF5 files contain external datasets, then this
   utility should be run from the same relative path to the HDF5 files
   as when they were created. For example, if a PyLith simulation was
   run from directory \filename{work} and HDF5 files were generated in

--- a/doc/userguide/runpylith/problems.tex
+++ b/doc/userguide/runpylith/problems.tex
@@ -2,7 +2,7 @@
 
 \subsection{Time-Dependent Problem (\protect\object{TimeDependent})}
 
-This type of problem applies to transient static, quasi-static, and
+This type of problem applies to transient static, quasistatic, and
 dynamic simulations. We use the PETSc \object{TS} object to manage the
 time-stepping. The selection of the time-stepping algorithm is done
 via the PETSc options. By default PyLith use the backward Euler time
@@ -133,7 +133,7 @@ Not yet reimplemented in v3.x.
 %% <f>progres_monitor</f> = pylith.problems.ProgressMonitorTime ; default
 %% \end{cfg}
 
-%% \warning{The \object{GreensFns} problem generates slip impulses on a
+%% \userwarning{The \object{GreensFns} problem generates slip impulses on a
 %%   fault. The current version of PyLith requires that impulses can only
 %%   be applied to a single fault and the fault facility must be set to
 %%   \object{FaultCohesiveImpulses}.}

--- a/doc/userguide/runpylith/pylithapp.tex
+++ b/doc/userguide/runpylith/pylithapp.tex
@@ -75,7 +75,7 @@ Reordering the mesh so that vertices and cells connected topologically
 also reside close together in memory improves overall performance
 and can improve solver performance as well.
 
-\warning{The coordinate system associated with the mesh must be a
+\userwarning{The coordinate system associated with the mesh must be a
   Cartesian coordinate system, such as a generic Cartesian coordinate
   system or a geographic projection.}
 
@@ -127,7 +127,7 @@ and facilities are:
 \facilityitem{coordsys}{Coordinate system associated with mesh.}
 \end{inventory}
 
-\warning{The PyLith developers have not used LaGriT since around 2008
+\userwarning{The PyLith developers have not used LaGriT since around 2008
   and the most recent release appears to have been in 2010.}
 
 \subsubsection{\object{Distributor}}
@@ -195,7 +195,7 @@ so $n$ should be limited to 1-2.
 The problem component specifies the basic parameters of the simulation,
 including the physical properties, the boundary conditions, and interface
 conditions (faults). The current release of PyLith contains two types
-of problems, \object{TimeDependent} for use in static, quasi-static,
+of problems, \object{TimeDependent} for use in static, quasistatic,
 and dynamic simulations and \object{GreensFns} for computing static
 Green's functions. The general properties facilities include:
 \begin{inventory}
@@ -337,7 +337,7 @@ properties:
   problems; however, it may be necessary to change the default values
   in some cases. When doing this, keep in mind that the
   nondimensionalization generally applies to the minimum values
-  encountered for a problem.  For example, in a quasi-static problem,
+  encountered for a problem.  For example, in a quasistatic problem,
   the \property{length\_scale} should be on the order of the minimum
   cell size. Similarly, the \property{relaxation\_time} should be on
   the order of the minimum relaxation time or time scale associated
@@ -500,7 +500,7 @@ See
   linear solver table} for a list of PETSc options for linear solvers
 and preconditioners.
 
-\tip{It is important to keep in mind the resolution of the model and
+\usertip{It is important to keep in mind the resolution of the model and
   observations when setting solver tolerances. For example, matching
   observations with an accuracy of 1.0\si{\milli\meter} does not
   require solving the equations to an accuracy of
@@ -587,7 +587,7 @@ settings are available in
 \end{cfg}
 
 
-\warning{The split fields and algebraic multigrid preconditioning
+\userwarning{The split fields and algebraic multigrid preconditioning
   currently fails in problems with a nonzero null space. This most
   often occurs when a problem contains multiple faults that extend
   through the entire domain and create subdomains without any

--- a/doc/userguide/runpylith/troubleshooting.tex
+++ b/doc/userguide/runpylith/troubleshooting.tex
@@ -12,7 +12,7 @@ than that for resolving displacements).
 \item Merge materials using the same material model. This will result in
 only one VTK or HDF5 file for each material model rather than several
 files.
-\item The rate of convergence in quasi-static (implicit) problems can sometimes
+\item The rate of convergence in quasistatic (implicit) problems can sometimes
 be improved by renumbering the vertices in the finite-element mesh
 to reduce the bandwidth of the sparse matrix. PyLith can use the reverse
 Cuthill-McKee algorithm to reorder the vertices and cells.

--- a/doc/userguide/styleguide.tex
+++ b/doc/userguide/styleguide.tex
@@ -21,8 +21,8 @@
 
 \begin{document}
 
-\warning{This is a warning.}
-\tip{This is a tip, helpful hint, or suggestion.}
+\userwarning{This is a warning.}
+\usertip{This is a tip, helpful hint, or suggestion.}
 \important{This is something important.}
 
 \todo{brad}{This is something for Brad to do. 


### PR DESCRIPTION
Documentation cleanup.

Rename `\warning` to `\userwarning` to avoid conflict with previously defined command `\warning`.
Also rename `\tip` to `\usertip` for consistency. Keep `\important`  

Also change "quasi-static" to "quasistatic".