### PR TITLE
Add problem default for output field filter and by default only output solution fields defined over entire domain

### DIFF
--- a/examples/2d/reverse/pylithapp.cfg
+++ b/examples/2d/reverse/pylithapp.cfg
@@ -43,18 +43,15 @@ defaults.quadrature_order = 1
 basis_order = 1
 
 [pylithapp.problem]
+# Use FieldFilterProject if basis order of any solution field > 1
+#defaults.output_field_filter = pylith.meshio.FieldFilterProject
+
 solution_observers = [domain, boundary]
 solution_observers.boundary = pylith.meshio.OutputSolnBoundary
-
-[pylithapp.problem.solution_observers.domain]
-field_filter = pylith.meshio.FieldFilterProject
-data_fields = [displacement]
 
 [pylithapp.problem.solution_observers.boundary]
 # The label corresponds to the name of the nodeset in CUBIT/Trelis.
 label = edge_ypos
-field_filter = pylith.meshio.FieldFilterProject
-data_fields = [displacement]
 
 # ----------------------------------------------------------------------
 # materials
@@ -84,9 +81,6 @@ bulk_rheology.auxiliary_subfields.shear_modulus.basis_order = 0
 derived_subfields.cauchy_strain.basis_order = 1
 derived_subfields.cauchy_stress.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [cauchy_stress, cauchy_strain, displacement]
-
 
 [pylithapp.problem.materials.plate]
 label = Material below main fault
@@ -103,9 +97,6 @@ bulk_rheology.auxiliary_subfields.shear_modulus.basis_order = 0
 derived_subfields.cauchy_strain.basis_order = 1
 derived_subfields.cauchy_stress.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [cauchy_stress, cauchy_strain, displacement]
-
 
 [pylithapp.problem.materials.wedge]
 label = Material between main fault and splay
@@ -121,9 +112,6 @@ bulk_rheology.auxiliary_subfields.shear_modulus.basis_order = 0
 
 derived_subfields.cauchy_strain.basis_order = 1
 derived_subfields.cauchy_stress.basis_order = 1
-
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [cauchy_stress, cauchy_strain, displacement]
 
 
 # ----------------------------------------------------------------------
@@ -144,8 +132,6 @@ db_auxiliary_field.label = Dirichlet BC +x edge
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xneg]
 constrained_dof = [0]
@@ -155,8 +141,6 @@ db_auxiliary_field.label = Dirichlet BC -x edge
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_yneg]
 constrained_dof = [1]
@@ -166,8 +150,6 @@ db_auxiliary_field.label = Dirichlet BC -y edge
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 # ----------------------------------------------------------------------
 # PETSc

--- a/examples/2d/reverse/step01_gravity.cfg
+++ b/examples/2d/reverse/step01_gravity.cfg
@@ -61,6 +61,9 @@ gravity_field.gravity_dir = [0.0, -1.0, 0.0]
 
 defaults.quadrature_order = 2
 
+# Use FieldFilterProject because basis order of a solution subfield > 1
+defaults.output_field_filter = pylith.meshio.FieldFilterProject
+
 [pylithapp.problem.solution.subfields.displacement]
 basis_order = 2
 

--- a/examples/2d/reverse/step02_gravity_refstate.cfg
+++ b/examples/2d/reverse/step02_gravity_refstate.cfg
@@ -50,6 +50,9 @@ gravity_field.gravity_dir = [0.0, -1.0, 0.0]
 
 defaults.quadrature_order = 2
 
+# Use FieldFilterProject because basis order of a solution subfield > 1
+defaults.output_field_filter = pylith.meshio.FieldFilterProject
+
 [pylithapp.problem.solution.subfields.displacement]
 basis_order = 2
 

--- a/examples/2d/reverse/step03_gravity_incompressible.cfg
+++ b/examples/2d/reverse/step03_gravity_incompressible.cfg
@@ -63,12 +63,6 @@ basis_order = 1
 [pylithapp.problem.solution.subfields.pressure]
 basis_order = 1
 
-[pylithapp.problem.solution_observers.domain]
-data_fields = [displacement, pressure]
-
-[pylithapp.problem.solution_observers.boundary]
-data_fields = [displacement, pressure]
-
 # ----------------------------------------------------------------------
 # materials
 # ----------------------------------------------------------------------

--- a/examples/2d/reverse/step04_surfload.cfg
+++ b/examples/2d/reverse/step04_surfload.cfg
@@ -52,12 +52,6 @@ problem.defaults.name = step04_surfload
 [pylithapp.problem.solution.subfields.displacement]
 basis_order = 1
 
-[pylithapp.problem.solution_observers.domain]
-data_fields = [displacement]
-
-[pylithapp.problem.solution_observers.boundary]
-data_fields = [displacement]
-
 # ----------------------------------------------------------------------
 # boundary conditions
 # ----------------------------------------------------------------------
@@ -76,7 +70,5 @@ db_auxiliary_field.iohandler.filename = traction_surfload.spatialdb
 db_auxiliary_field.query_type = linear
 
 auxiliary_subfields.initial_amplitude.basis_order = 1
-
-observers.observer.data_fields = [displacement]
 
 # End of file

--- a/examples/2d/reverse/step06_twofaults_elastic.cfg
+++ b/examples/2d/reverse/step06_twofaults_elastic.cfg
@@ -46,12 +46,6 @@ solution = pylith.problems.SolnDispLagrange
 displacement.basis_order = 1
 lagrange_fault.basis_order = 1
 
-[pylithapp.problem.solution_observers.domain]
-field_filter = pylith.meshio.FieldFilterProject
-
-[pylithapp.problem.solution_observers.boundary]
-field_filter = pylith.meshio.FieldFilterProject
-
 # ----------------------------------------------------------------------
 # fault
 # ----------------------------------------------------------------------
@@ -62,7 +56,7 @@ interfaces = [fault, splay]
 id = 10
 label = fault
 edge = fault_edge
-# observers.observer.field_filter = pylith.meshio.FieldFilterProject
+
 observers.observer.data_fields = [slip]
 
 [pylithapp.problem.interfaces.fault.eq_ruptures.rupture]
@@ -75,7 +69,7 @@ db_auxiliary_field.data = [0.0*s, -2.0*m, 0.0*m]
 id = 11
 label = splay
 edge = splay_edge
-# observers.observer.field_filter = pylith.meshio.FieldFilterProject
+
 observers.observer.data_fields = [slip]
 
 [pylithapp.problem.interfaces.splay.eq_ruptures.rupture]

--- a/examples/2d/reverse/step07_twofaults_maxwell.cfg
+++ b/examples/2d/reverse/step07_twofaults_maxwell.cfg
@@ -72,9 +72,6 @@ db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.label = Maxwell viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_maxwell.spatialdb
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [cauchy_stress, cauchy_strain, displacement]
-
 bulk_rheology.auxiliary_subfields.maxwell_time.basis_order = 0
 
 # ----------------------------------------------------------------------
@@ -87,7 +84,7 @@ interfaces = [fault, splay]
 id = 10
 label = fault
 edge = fault_edge
-# observers.observer.field_filter = pylith.meshio.FieldFilterProject
+
 observers.observer.data_fields = [slip]
 
 [pylithapp.problem.interfaces.fault.eq_ruptures.rupture]
@@ -100,7 +97,7 @@ db_auxiliary_field.data = [0.0*s, -2.0*m, 0.0*m]
 id = 11
 label = splay
 edge = splay_edge
-# observers.observer.field_filter = pylith.meshio.FieldFilterProject
+
 observers.observer.data_fields = [slip]
 
 [pylithapp.problem.interfaces.splay.eq_ruptures.rupture]

--- a/examples/2d/reverse/step08_twofaults_powerlaw.cfg
+++ b/examples/2d/reverse/step08_twofaults_powerlaw.cfg
@@ -72,8 +72,6 @@ db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.label = Maxwell viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_powerlaw.spatialdb
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-
 bulk_rheology.auxiliary_subfields.power_law_reference_strain_rate.basis_order = 0
 bulk_rheology.auxiliary_subfields.power_law_reference_stress.basis_order = 0
 bulk_rheology.auxiliary_subfields.power_law_exponent.basis_order = 0
@@ -88,6 +86,7 @@ interfaces = [fault, splay]
 id = 10
 label = fault
 edge = fault_edge
+
 observers.observer.data_fields = [slip]
 
 [pylithapp.problem.interfaces.fault.eq_ruptures.rupture]
@@ -100,6 +99,7 @@ db_auxiliary_field.data = [0.0*s, -2.0*m, 0.0*m]
 id = 11
 label = splay
 edge = splay_edge
+
 observers.observer.data_fields = [slip]
 
 [pylithapp.problem.interfaces.splay.eq_ruptures.rupture]

--- a/examples/2d/strikeslip/pylithapp.cfg
+++ b/examples/2d/strikeslip/pylithapp.cfg
@@ -45,6 +45,9 @@ defaults.quadrature_order = 1
 # to create a solution field with these two subfields.
 solution = pylith.problems.SolnDispLagrange
 
+# Use FieldFilterProject if basis order of any solution field > 1
+#defaults.output_field_filter = pylith.meshio.FieldFilterProject
+
 [pylithapp.problem.solution.subfields]
 displacement.basis_order = 1
 lagrange_fault.basis_order = 1
@@ -54,19 +57,11 @@ solution_observers = [domain, top_boundary, bot_boundary]
 solution_observers.top_boundary = pylith.meshio.OutputSolnBoundary
 solution_observers.bot_boundary = pylith.meshio.OutputSolnBoundary
 
-[pylithapp.problem.solution_observers.domain]
-data_fields = [displacement]
-# writer.filename = output/SIMULATION-domain.h5
-
 [pylithapp.problem.solution_observers.top_boundary]
 label = face_ypos
-data_fields = [displacement]
-#writer.filename = output/SIMULATION-boundary_ypos.h5
 
 [pylithapp.problem.solution_observers.bot_boundary]
 label = face_yneg
-data_fields = [displacement]
-#writer.filename = output/SIMULATION-boundary_yneg.h5
 
 # ----------------------------------------------------------------------
 # materials
@@ -91,8 +86,6 @@ db_auxiliary_field.label = Elastic properties xneg
 db_auxiliary_field.values = [density, vs, vp]
 db_auxiliary_field.data = [2500.0*kg/m**3, 3.00*km/s, 5.29*km/s]
 
-observers.observer.data_fields = [displacement, cauchy_stress, cauchy_strain]
-
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0
 bulk_rheology.auxiliary_subfields.shear_modulus.basis_order = 0
@@ -109,8 +102,6 @@ db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.label = Elastic properties xpos
 db_auxiliary_field.values = [density, vs, vp]
 db_auxiliary_field.data = [2500.0*kg/m**3, 4.24*km/s, 5.29*km/s]
-
-observers.observer.data_fields = [displacement, cauchy_stress, cauchy_strain]
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0
@@ -134,7 +125,6 @@ label = fault
 # different from any of the ids for the materials.
 id = 10
 observers.observer.data_fields = [slip]
-#observers.observer.writer.filename = output/SIMULATION_slip-fault.h5
 
 # ----------------------------------------------------------------------
 # boundary conditions
@@ -144,21 +134,19 @@ bc = [bc_xneg, bc_xpos]
 bc.bc_xneg = pylith.bc.DirichletTimeDependent
 bc.bc_xpos = pylith.bc.DirichletTimeDependent
 
+
 [pylithapp.problem.bc.bc_xpos]
 constrained_dof = [0, 1]
 label = face_xpos
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC +x boundary
 
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xneg]
 constrained_dof = [0, 1]
 label = face_xneg
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC -x boundary
-
-observers.observer.data_fields = [displacement]
 
 # ----------------------------------------------------------------------
 # PETSc

--- a/examples/2d/subduction/pylithapp.cfg
+++ b/examples/2d/subduction/pylithapp.cfg
@@ -43,6 +43,9 @@ defaults.quadrature_order = 1
 # to create a solution field with these two subfields.
 solution = pylith.problems.SolnDispLagrange
 
+# Use FieldFilterProject if basis order of any solution field > 1
+#defaults.output_field_filter = pylith.meshio.FieldFilterProject
+
 [pylithapp.problem.solution.subfields]
 displacement.basis_order = 1
 lagrange_fault.basis_order = 1
@@ -52,12 +55,10 @@ solution_observers = [domain, groundsurf]
 solution_observers.groundsurf = pylith.meshio.OutputSolnBoundary
 
 [pylithapp.problem.solution_observers.domain]
-data_fields = [displacement]
 trigger.num_skip = 1
 
 [pylithapp.problem.solution_observers.groundsurf]
 label = groundsurf
-data_fields = [displacement]
 
 # ----------------------------------------------------------------------
 # materials
@@ -91,7 +92,6 @@ id = 1
 db_auxiliary_field.label = Continental crust properties
 db_auxiliary_field.iohandler.filename = mat_concrust.spatialdb
 
-observers.observer.data_fields = [displacement, cauchy_stress, cauchy_strain]
 observers.observer.trigger.num_skip = 1
 
 auxiliary_subfields.density.basis_order = 0
@@ -110,7 +110,6 @@ id = 2
 db_auxiliary_field.label = Continental mantle properties
 db_auxiliary_field.iohandler.filename = mat_conmantle.spatialdb
 
-observers.observer.data_fields = [displacement, cauchy_stress, cauchy_strain]
 observers.observer.trigger.num_skip = 1
 
 auxiliary_subfields.density.basis_order = 0
@@ -129,7 +128,6 @@ id = 3
 db_auxiliary_field.label = Oceanic crust properties
 db_auxiliary_field.iohandler.filename = mat_oceancrust.spatialdb
 
-observers.observer.data_fields = [displacement, cauchy_stress, cauchy_strain]
 observers.observer.trigger.num_skip = 1
 
 auxiliary_subfields.density.basis_order = 0
@@ -148,7 +146,6 @@ id = 4
 db_auxiliary_field.label = Oceanic mantle properties
 db_auxiliary_field.iohandler.filename = mat_oceanmantle.spatialdb
 
-observers.observer.data_fields = [displacement, cauchy_stress, cauchy_strain]
 observers.observer.trigger.num_skip = 1
 
 auxiliary_subfields.density.basis_order = 0

--- a/examples/2d/subduction/step01_coseismic.cfg
+++ b/examples/2d/subduction/step01_coseismic.cfg
@@ -90,8 +90,6 @@ label = bndry_east_crust
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC on east boundary (crust)
 
-observers.observer.data_fields = [displacement]
-
 
 # East boundary (mantle)
 [pylithapp.problem.bc.bc_east_mantle]
@@ -100,7 +98,6 @@ label = bndry_east_mantle
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC on east boundary (mantle)
 
-observers.observer.data_fields = [displacement]
 
 # West boundary
 [pylithapp.problem.bc.bc_west]
@@ -109,7 +106,6 @@ label = bndry_west
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC on west boundary
 
-observers.observer.data_fields = [displacement]
 
 # Bottom boundary (mantle)
 [pylithapp.problem.bc.bc_bottom_mantle]
@@ -117,8 +113,6 @@ constrained_dof = [1]
 label = bndry_bot_mantle
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC on bottom boundary (mantle)
-
-observers.observer.data_fields = [displacement]
 
 
 # End of file

--- a/examples/2d/subduction/step02_interseismic.cfg
+++ b/examples/2d/subduction/step02_interseismic.cfg
@@ -27,7 +27,7 @@
 # ----------------------------------------------------------------------
 [pylithapp]
 dump_parameters.filename = output/step02_interseismic-parameters.json
-#problem.progress_monitor.filename = output/step02_interseismic-progress.txt
+problem.progress_monitor.filename = output/step02_interseismic-progress.txt
 
 # Set the name of the problem that will be used to construct the
 # output filenames. The default directory for output is 'output'.
@@ -116,8 +116,6 @@ label = bndry_east_mantle
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC on east boundary (mantle)
 
-observers.observer.data_fields = [displacement]
-
 
 # West boundary
 [pylithapp.problem.bc.bc_west]
@@ -126,8 +124,6 @@ label = bndry_west
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC on west boundary
 
-observers.observer.data_fields = [displacement]
-
 
 # Bottom boundary (mantle)
 [pylithapp.problem.bc.bc_bottom_mantle]
@@ -135,8 +131,6 @@ constrained_dof = [1]
 label = bndry_bot_mantle
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC on bottom boundary (mantle)
-
-observers.observer.data_fields = [displacement]
 
 
 # End of file

--- a/examples/2d/subduction/step03_eqcycle.cfg
+++ b/examples/2d/subduction/step03_eqcycle.cfg
@@ -27,7 +27,7 @@
 # ----------------------------------------------------------------------
 [pylithapp]
 dump_parameters.filename = output/step03_eqcycle-parameters.json
-#problem.progress_monitor.filename = output/step03_eqcycle-progress.txt
+problem.progress_monitor.filename = output/step03_eqcycle-progress.txt
 
 # Set the name of the problem that will be used to construct the
 # output filenames. The default directory for output is 'output'.
@@ -132,8 +132,6 @@ label = bndry_east_mantle
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC on east boundary (mantle)
 
-observers.observer.data_fields = [displacement]
-
 
 # West boundary
 [pylithapp.problem.bc.bc_west]
@@ -142,8 +140,6 @@ label = bndry_west
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC on west boundary
 
-observers.observer.data_fields = [displacement]
-
 
 # Bottom boundary (mantle)
 [pylithapp.problem.bc.bc_bottom_mantle]
@@ -151,8 +147,6 @@ constrained_dof = [1]
 label = bndry_bot_mantle
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC on bottom boundary (mantle)
-
-observers.observer.data_fields = [displacement]
 
 
 # End of file

--- a/examples/3d/box/pylithapp.cfg
+++ b/examples/3d/box/pylithapp.cfg
@@ -36,6 +36,9 @@ solver = nonlinear
 # Set the default quadrature order for all discretizations.
 defaults.quadrature_order = 1
 
+# Use FieldFilterProject if basis order of any solution field > 1
+#defaults.output_field_filter = pylith.meshio.FieldFilterProject
+
 [pylithapp.problem.solution.subfields.displacement]
 # Set the discretization for each of the solution subfields.
 basis_order = 1

--- a/examples/3d/box/step01_axialdisp.cfg
+++ b/examples/3d/box/step01_axialdisp.cfg
@@ -38,14 +38,6 @@ problem.progress_monitor.filename = output/step01_axialdisp-progress.txt
 problem.defaults.name = step01_axialdisp
 
 # ----------------------------------------------------------------------
-# solution
-# ----------------------------------------------------------------------
-[pylithapp.problem.solution.subfields.displacement]
-# The solution has uniform strain, so displacement field is linear, so
-# basis order of 1 should give exact solution.
-basis_order = 1
-
-# ----------------------------------------------------------------------
 # boundary conditions
 # ----------------------------------------------------------------------
 [pylithapp.problem]

--- a/examples/3d/box/step02_sheardisp.cfg
+++ b/examples/3d/box/step02_sheardisp.cfg
@@ -30,13 +30,6 @@ problem.progress_monitor.filename = output/step02_sheardisp-progress.txt
 # output filenames. The default directory for output is 'output'.
 problem.defaults.name = step02_sheardisp
 
-# ----------------------------------------------------------------------
-# solution
-# ----------------------------------------------------------------------
-[pylithapp.problem.solution.subfields.displacement]
-# The solution has uniform strain, so displacement field is linear, so
-# basis order of 1 should give exact solution.
-basis_order = 1
 
 # ----------------------------------------------------------------------
 # boundary conditions

--- a/examples/3d/box/step03_sheardisptract.cfg
+++ b/examples/3d/box/step03_sheardisptract.cfg
@@ -41,13 +41,6 @@ problem.progress_monitor.filename = output/step03_sheardisptract-progress.txt
 # output filenames. The default directory for output is 'output'.
 problem.defaults.name = step03_sheardisptract
 
-# ----------------------------------------------------------------------
-# solution
-# ----------------------------------------------------------------------
-[pylithapp.problem.solution.subfields.displacement]
-# The solution has uniform strain, so displacement field is linear, so
-# basis order of 1 should give exact solution.
-basis_order = 1
 
 # ----------------------------------------------------------------------
 # boundary conditions

--- a/examples/3d/box/step04_sheardispic.cfg
+++ b/examples/3d/box/step04_sheardispic.cfg
@@ -38,13 +38,6 @@ problem.progress_monitor.filename = output/step04_sheardispic-progress.txt
 # output filenames. The default directory for output is 'output'.
 problem.defaults.name = step04_sheardispic
 
-# ----------------------------------------------------------------------
-# solution
-# ----------------------------------------------------------------------
-[pylithapp.problem.solution.subfields.displacement]
-# The solution has uniform strain, so displacement field is linear, so
-# basis order of 1 should give exact solution.
-basis_order = 1
 
 # ----------------------------------------------------------------------
 # boundary conditions

--- a/examples/3d/box/step05_sheardisptractrate.cfg
+++ b/examples/3d/box/step05_sheardisptractrate.cfg
@@ -64,13 +64,6 @@ end_time = 5.0*year
 [pylithapp.problem.normalizer]
 relaxation_time = 10.0*year
 
-# ----------------------------------------------------------------------
-# solution
-# ----------------------------------------------------------------------
-[pylithapp.problem.solution.subfields.displacement]
-# The solution has uniform strain, so displacement field is linear, so
-# basis order of 1 should give exact solution.
-basis_order = 1
 
 # ----------------------------------------------------------------------
 # boundary conditions

--- a/examples/3d/subduction/pylithapp.cfg
+++ b/examples/3d/subduction/pylithapp.cfg
@@ -69,12 +69,9 @@ solver = nonlinear
 # Set the default quadrature order for all discretizations.
 defaults.quadrature_order = 1
 
-# Set the discretization for each of the solution subfields.
-#
-# For a quastistatic simulation with a fault, we have two solution fields:
-# (1) displacement and (2) Lagrange multiplier. We use a predefined containter
-# to create a solution field with these two subfields.
-# solution = pylith.problems.SolnDispLagrange
+# Use FieldFilterProject if basis order of any solution field > 1
+#defaults.output_field_filter = pylith.meshio.FieldFilterProject
+
 
 [pylithapp.problem.solution.subfields]
 displacement.basis_order = 1
@@ -84,12 +81,10 @@ solution_observers = [domain, groundsurf]
 solution_observers.groundsurf = pylith.meshio.OutputSolnBoundary
 
 [pylithapp.problem.solution_observers.domain]
-data_fields = [displacement]
 trigger.num_skip = 1
 
 [pylithapp.problem.solution_observers.groundsurf]
 label = boundary_zpos
-data_fields = [displacement]
 trigger.num_skip = 1
 
 # ----------------------------------------------------------------------

--- a/examples/3d/subduction/step01_axialdisp.cfg
+++ b/examples/3d/subduction/step01_axialdisp.cfg
@@ -48,13 +48,6 @@ initial_dt = 5.0*year
 start_time = -5.0*year
 end_time = 0.0*year
 
-# ----------------------------------------------------------------------
-# solution
-# ----------------------------------------------------------------------
-[pylithapp.problem.solution.subfields.displacement]
-# The solution has uniform strain, so displacement field is linear, so
-# basis order of 1 should give exact solution.
-basis_order = 1
 
 # ----------------------------------------------------------------------
 # boundary conditions

--- a/examples/3d/subduction/step03_aseismic.cfg
+++ b/examples/3d/subduction/step03_aseismic.cfg
@@ -54,6 +54,11 @@
 dump_parameters.filename = output/step03_aseismic-parameters.json
 problem.progress_monitor.filename = output/step03_aseismic-progress.txt
 
+# Set the name of the problem that will be used to construct the
+# output filenames. The default directory for output is 'output'.
+problem.defaults.name = step03_aseismic
+
+
 # ----------------------------------------------------------------------
 # problem
 # ----------------------------------------------------------------------
@@ -81,16 +86,8 @@ solution = pylith.problems.SolnDispLagrange
 
 [pylithapp.problem.solution.subfields]
 displacement.basis_order = 1
-displacement.quadrature_order = 1
-
 lagrange_fault.basis_order = 1
-lagrange_fault.quadrature_order = 1
 
-[pylithapp.problem.solution_observers.domain]
-writer.filename = output_step03_aseismic-domain.h5
-
-[pylithapp.problem.solution_observers.groundsurf]
-writer.filename = output_step03_aseismic-groundsurf.h5
 # ----------------------------------------------------------------------
 # faults
 # ----------------------------------------------------------------------
@@ -116,7 +113,6 @@ edge = fault_slabbot_edge ; Nodeset for the buried edges
 ref_dir_1 = [-0.1,0,0.9]
 
 observers.observer.data_fields = [slip]
-observers.observer.writer.filename = output/step03_aseismic-slab_bottom.h5
 
 # Use the constant slip rate time function.
 eq_ruptures.rupture = pylith.faults.KinSrcConstRate
@@ -135,7 +131,6 @@ label = fault_slabtop ; Nodeset for the entire fault surface
 edge = fault_slabtop_edge ; Nodeset for the buried edges
 
 observers.observer.data_fields = [slip]
-observers.observer.writer.filename = output/step03_aseismic-slab_top.h5
 
 # Use the constant slip rate time function.
 eq_ruptures.rupture = pylith.faults.KinSrcConstRate
@@ -146,21 +141,6 @@ db_auxiliary_field = spatialdata.spatialdb.SimpleGridDB
 db_auxiliary_field.label = Slab top slip rate.
 db_auxiliary_field.filename = spatialdb/fault_slabtop_creep.spatialdb
 db_auxiliary_field.query_type = linear
-
-# ----------------------------------------------------------------------
-# materials
-# ----------------------------------------------------------------------
-[pylithapp.problem.materials.slab]
-observers.observer.writer.filename = output/step03_aseismic-slab.h5
-
-[pylithapp.problem.materials.wedge]
-observers.observer.writer.filename = output/step03_aseismic-wedge.h5
-
-[pylithapp.problem.materials.crust]
-observers.observer.writer.filename = output/step03_aseismic-crust.h5
-
-[pylithapp.problem.materials.mantle]
-observers.observer.writer.filename = output/step03_aseismic-mantle.h5
 
 # ----------------------------------------------------------------------
 # boundary conditions
@@ -176,25 +156,14 @@ observers.observer.writer.filename = output/step03_aseismic-mantle.h5
 # -x face
 [pylithapp.problem.bc.x_neg]
 label = boundary_xneg_noslab
-observers.observer.writer.filename = output/step03_aseismic_bc_xneg.h5
-
-# +x face
-[pylithapp.problem.bc.x_pos]
-observers.observer.writer.filename = output/step03_aseismic_bc_xpos.h5
 
 # -y face
 [pylithapp.problem.bc.y_neg]
 label = boundary_yneg_noslab
-observers.observer.writer.filename = output/step03_aseismic_bc_yneg.h5
 
 # +y face
 [pylithapp.problem.bc.y_pos]
 label = boundary_ypos_noslab
-observers.observer.writer.filename = output/step03_aseismic_bc_ypos.h5
-
-# -z face
-[pylithapp.problem.bc.z_neg]
-observers.observer.writer.filename = output/step03_aseismic_bc_zneg.h5
 
 
 # End of file

--- a/examples/3d/subduction/step06_slowslip.cfg
+++ b/examples/3d/subduction/step06_slowslip.cfg
@@ -66,19 +66,15 @@ problem.defaults.name = step06_slowslip
 total_time = 30.0*day
 dt = 2.0*day
 
-[pylithapp.problem.solution.subfields]
-displacement.basis_order = 1
-lagrange_fault.basis_order = 1
-
 # Set the discretization for each of the solution subfields.
 #
 # For a quastistatic simulation with a fault, we have two solution fields:
 # (1) displacement and (2) Lagrange multiplier. We use a predefined containter
 # to create a solution field with these two subfields.
 # solution = pylith.problems.SolnDispLagrange
-
 [pylithapp.problem.solution.subfields]
 displacement.basis_order = 1
+lagrange_fault.basis_order = 1
 
 [pylithapp.problem]
 solution_observers = [domain, groundsurf, cgps_sites]
@@ -86,12 +82,10 @@ solution_observers.groundsurf = pylith.meshio.OutputSolnBoundary
 solution_observers.cgps_sites = pylith.meshio.OutputSolnPoints
 
 [pylithapp.problem.solution_observers.domain]
-data_fields = [displacement]
 trigger.num_skip = 1
 
 [pylithapp.problem.solution_observers.groundsurf]
 label = boundary_zpos
-data_fields = [displacement]
 trigger.num_skip = 1
 
 [pylithapp.problem.solution_observers.cgps_sites]

--- a/examples/3d/subduction/step08b_gravity_incompressible.cfg
+++ b/examples/3d/subduction/step08b_gravity_incompressible.cfg
@@ -77,12 +77,6 @@ defaults.quadrature_order = 2
 displacement.basis_order = 1
 pressure.basis_order = 1
 
-[pylithapp.problem.solution_observers.domain]
-data_fields = [displacement, pressure]
-
-[pylithapp.problem.solution_observers.groundsurf]
-data_fields = [displacement, pressure]
-
 
 # ----------------------------------------------------------------------
 # boundary conditions

--- a/libsrc/pylith/meshio/OutputPhysics.cc
+++ b/libsrc/pylith/meshio/OutputPhysics.cc
@@ -27,6 +27,7 @@
 
 #include "pylith/topology/Mesh.hh" // USES Mesh
 #include "pylith/topology/Field.hh" // USES Field
+#include "pylith/topology/FieldOps.hh" // USES FieldOps
 #include "pylith/topology/Fields.hh" // USES Fields
 
 #include "pylith/utils/journals.hh" // USES PYLITH_COMPONENT_*
@@ -161,7 +162,7 @@ pylith::meshio::OutputPhysics::verifyConfiguration(const pylith::topology::Field
         } // for
     } // if/else
 
-    // Data fields should be in solution, constraint's auxiliary field, or constraint's derived field.
+    // Data fields should be in solution, auxiliary field, or derived field.
     const size_t numDataFields = _dataFieldNames.size();
     if ((numDataFields > 0) && (std::string("all") != _dataFieldNames[0])) {
         for (size_t i = 0; i < numDataFields; i++) {
@@ -409,8 +410,7 @@ pylith::meshio::OutputPhysics::_expandDataFieldNames(const pylith::topology::Fie
     PYLITH_METHOD_BEGIN;
 
     if ((1 == _dataFieldNames.size()) && (std::string("all") == _dataFieldNames[0])) {
-        pylith::string_vector dataNames;
-        dataNames = solution.subfieldNames();
+        pylith::string_vector dataNames = pylith::topology::FieldOps::getSubfieldNamesDomain(solution);
 
         if (derivedField) {
             const pylith::string_vector& derivedSubfields = derivedField->subfieldNames();

--- a/libsrc/pylith/meshio/OutputSolnDomain.cc
+++ b/libsrc/pylith/meshio/OutputSolnDomain.cc
@@ -22,6 +22,7 @@
 
 #include "pylith/topology/Mesh.hh" // USES Mesh
 #include "pylith/topology/Field.hh" // USES Field
+#include "pylith/topology/FieldOps.hh" // USES FieldOps
 
 #include "pylith/utils/journals.hh" // USES PYLITH_COMPONENT_*
 
@@ -46,7 +47,7 @@ pylith::meshio::OutputSolnDomain::_writeSolnStep(const PylithReal t,
     PYLITH_METHOD_BEGIN;
     PYLITH_COMPONENT_DEBUG("_writeSolnStep(t="<<t<<", tindex="<<tindex<<", solution="<<solution.getLabel()<<")");
 
-    const pylith::string_vector& subfieldNames = _expandSubfieldNames(solution);
+    const pylith::string_vector& subfieldNames = pylith::topology::FieldOps::getSubfieldNamesDomain(solution);
 
     _openSolnStep(t, solution.mesh());
     const size_t numSubfieldNames = subfieldNames.size();

--- a/libsrc/pylith/topology/FieldOps.hh
+++ b/libsrc/pylith/topology/FieldOps.hh
@@ -37,16 +37,23 @@
 // Wrapper for PetscFE
 class pylith::topology::FE {
 public:
-  FE(PetscFE fe) : _fe(fe) {PetscObjectReference((PetscObject) _fe);};
-  FE(const FE& fe) : _fe(fe._fe) {PetscObjectReference((PetscObject) _fe);};
-  ~FE() {
-    PetscInt refct = -1;
 
-    if (_fe) {PetscObjectGetReference((PetscObject) _fe, &refct);}
-    PetscObjectDereference((PetscObject) _fe);
-  }
+    FE(PetscFE fe) : _fe(fe) {
+        PetscObjectReference((PetscObject) _fe);
+    }
 
-  PetscFE _fe;
+    FE(const FE& fe) : _fe(fe._fe) {
+        PetscObjectReference((PetscObject) _fe);
+    }
+
+    ~FE() {
+        PetscInt refct = -1;
+
+        if (_fe) {PetscObjectGetReference((PetscObject) _fe, &refct);}
+        PetscObjectDereference((PetscObject) _fe);
+    }
+
+    PetscFE _fe;
 };
 
 // FieldOps -------------------------------------------------------------
@@ -91,6 +98,16 @@ public:
     void checkDiscretization(const pylith::topology::Field& target,
                              const pylith::topology::Field& auxiliary);
 
+    /** Get names of subfields extending over the entire domain.
+     *
+     * Excludes subfields extending over only a subset of the domain, like the fault Lagrange multiplier subfield.
+     *
+     * @param[in] field Field with subfields.
+     * @returns Array with names of subfields.
+     */
+    static
+    pylith::string_vector getSubfieldNamesDomain(const pylith::topology::Field& field);
+
     /** Check to see if fields have the same subfields and match in size.
      *
      * @param[in] fieldA Field to check.
@@ -102,7 +119,7 @@ public:
                       const pylith::topology::Field& fieldB);
 
     /** Free saved PetscFE objects.
-    */
+     */
     static
     void deallocate(void);
 

--- a/pylith/meshio/FieldFilter.py
+++ b/pylith/meshio/FieldFilter.py
@@ -43,6 +43,7 @@ class FieldFilter(PetscComponent):
     def preinitialize(self):
         """Do minimal initialization."""
         self._createModuleObj()
+        self.setIdentifier(self.aliases[-1])
         return
 
 

--- a/pylith/problems/ProblemDefaults.py
+++ b/pylith/problems/ProblemDefaults.py
@@ -35,12 +35,12 @@ class ProblemDefaults(Component):
     INVENTORY
 
     Properties
-      - *output_directory* Directory for output.
       - *name* Name of problem.
+      - *output_directory* Directory for output.
       - *quadrature_order* Finite-element quadrature order.
 
     Facilities
-      None
+      - *output_field_filter* Filter applied to output fields (e.g., FieldFilterProject).
     """
 
     import pyre.inventory
@@ -53,6 +53,12 @@ class ProblemDefaults(Component):
 
     quadOrder = pyre.inventory.int("quadrature_order", default=1, validator=pyre.inventory.greater(0))
     quadOrder.meta['tip'] = "Finite-element quadrature order."
+
+    from pylith.meshio.FieldFilterNone import FieldFilterNone
+    outputFieldFilter = pyre.inventory.facility(
+        "output_field_filter", family="output_field_filter", factory=FieldFilterNone)
+    outputFieldFilter.meta['tip'] = "Filter applied to output fields (e.g., FieldFilterProject)."
+
 
     # PUBLIC METHODS /////////////////////////////////////////////////////
 

--- a/tests/fullscale/linearelasticity/faults-2d/pylithapp.cfg
+++ b/tests/fullscale/linearelasticity/faults-2d/pylithapp.cfg
@@ -56,12 +56,8 @@ lagrange_fault.basis_order = 1
 solution_observers = [domain, boundary_ypos]
 solution_observers.boundary_ypos = pylith.meshio.OutputSolnBoundary
 
-[pylithapp.problem.solution_observers.domain]
-data_fields = [displacement]
-
 [pylithapp.problem.solution_observers.boundary_ypos]
 label = edge_ypos
-data_fields = [displacement]
 
 # ----------------------------------------------------------------------
 # materials
@@ -78,8 +74,6 @@ db_auxiliary_field.label = Elastic properties
 db_auxiliary_field.values = [density, vs, vp]
 db_auxiliary_field.data = [2500*kg/m**3, 3.0*km/s, 5.2915026*km/s]
 
-observers.observer.field_filter = pylith.meshio.FieldFilterNone
-observers.observer.data_fields = [displacement]
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0
@@ -94,9 +88,6 @@ db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.label = Elastic properties
 db_auxiliary_field.values = [density, vs, vp]
 db_auxiliary_field.data = [2500*kg/m**3, 3.0*km/s, 5.2915026*km/s]
-
-observers.observer.field_filter = pylith.meshio.FieldFilterNone
-observers.observer.data_fields = [displacement]
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0

--- a/tests/fullscale/linearelasticity/faults-2d/twoblocks.cfg
+++ b/tests/fullscale/linearelasticity/faults-2d/twoblocks.cfg
@@ -14,7 +14,7 @@ interfaces = [fault]
 id = 10
 label = fault_x
 
-observers.observer.data_fields = []
+observers.observer.data_fields = [slip]
 
 [pylithapp.problem.interfaces.fault.eq_ruptures.rupture]
 db_auxiliary_field = spatialdata.spatialdb.UniformDB
@@ -39,9 +39,6 @@ db_auxiliary_field.label = Dirichlet BC +x edge
 db_auxiliary_field.values = [initial_amplitude_x, initial_amplitude_y]
 db_auxiliary_field.data = [0.0*m, -1.0*m]
 
-observers.observer.data_fields = [displacement]
-observers.observer.field_filter = pylith.meshio.FieldFilterNone
-
 [pylithapp.problem.bc.bc_xneg]
 constrained_dof = [0, 1]
 label = edge_xneg
@@ -49,9 +46,6 @@ db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.label = Dirichlet BC +x edge
 db_auxiliary_field.values = [initial_amplitude_x, initial_amplitude_y]
 db_auxiliary_field.data = [0.0*m, +1.0*m]
-
-observers.observer.data_fields = [displacement]
-observers.observer.field_filter = pylith.meshio.FieldFilterNone
 
 
 # End of file

--- a/tests/fullscale/linearelasticity/faults-2d/twoblocks_ic.cfg
+++ b/tests/fullscale/linearelasticity/faults-2d/twoblocks_ic.cfg
@@ -15,7 +15,7 @@ interfaces = [fault]
 id = 10
 label = fault_x
 
-observers.observer.data_fields = []
+observers.observer.data_fields = [slip]
 
 [pylithapp.problem.interfaces.fault.eq_ruptures.rupture]
 db_auxiliary_field = spatialdata.spatialdb.UniformDB
@@ -74,8 +74,6 @@ db_auxiliary_field.label = Dirichlet BC +x edge
 db_auxiliary_field.values = [initial_amplitude_x, initial_amplitude_y]
 db_auxiliary_field.data = [0.0*m, -1.0*m]
 
-observers.observer.data_fields = [displacement]
-observers.observer.field_filter = pylith.meshio.FieldFilterNone
 
 [pylithapp.problem.bc.bc_xneg]
 constrained_dof = [0, 1]
@@ -84,9 +82,6 @@ db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.label = Dirichlet BC +x edge
 db_auxiliary_field.values = [initial_amplitude_x, initial_amplitude_y]
 db_auxiliary_field.data = [0.0*m, +1.0*m]
-
-observers.observer.data_fields = [displacement]
-observers.observer.field_filter = pylith.meshio.FieldFilterNone
 
 
 # End of file

--- a/tests/fullscale/linearelasticity/faults-2d/twoblocks_ic_quad.cfg
+++ b/tests/fullscale/linearelasticity/faults-2d/twoblocks_ic_quad.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/twoblocks_ic_quad-parameters.json
-#problem.progress_monitor.filename = output/twoblocks_ic_quad-progress.txt
+problem.progress_monitor.filename = output/twoblocks_ic_quad-progress.txt
 
 problem.defaults.name = twoblocks_ic_quad
 

--- a/tests/fullscale/linearelasticity/faults-2d/twoblocks_ic_tri.cfg
+++ b/tests/fullscale/linearelasticity/faults-2d/twoblocks_ic_tri.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/twoblocks_ic_tri-parameters.json
-#problem.progress_monitor.filename = output/twoblocks_ic_tri-progress.txt
+problem.progress_monitor.filename = output/twoblocks_ic_tri-progress.txt
 
 problem.defaults.name = twoblocks_ic_tri
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/gravity.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/gravity.cfg
@@ -6,15 +6,10 @@ gravity_field = spatialdata.spatialdb.GravityField
 gravity_field.gravity_dir = [0.0, -1.0, 0.0]
 
 defaults.quadrature_order = 2
+defaults.output_field_filter = pylith.meshio.FieldFilterProject
 
 [pylithapp.problem.solution.subfields.displacement]
 basis_order = 2
-
-[pylithapp.problem.solution_observers.domain]
-field_filter = pylith.meshio.FieldFilterProject
-
-[pylithapp.problem.solution_observers.boundary_ypos]
-field_filter = pylith.meshio.FieldFilterProject
 
 # ----------------------------------------------------------------------
 # materials
@@ -24,8 +19,6 @@ db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.label = Elastic properties
 db_auxiliary_field.values = [density, vs, vp]
 db_auxiliary_field.data = [2500*kg/m**3, 3.0*km/s, 5.2915026*km/s]
-
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 
 auxiliary_subfields.density.basis_order = 0
 auxiliary_subfields.gravitational_acceleration.basis_order = 0
@@ -40,8 +33,6 @@ db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.label = Elastic properties
 db_auxiliary_field.values = [density, vs, vp]
 db_auxiliary_field.data = [2500*kg/m**3, 3.0*km/s, 5.2915026*km/s]
-
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 
 auxiliary_subfields.density.basis_order = 0
 auxiliary_subfields.gravitational_acceleration.basis_order = 0
@@ -68,7 +59,6 @@ db_auxiliary_field.label = Dirichlet BC +x edge
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 
 [pylithapp.problem.bc.bc_xneg]
 constrained_dof = [0]
@@ -78,7 +68,6 @@ db_auxiliary_field.label = Dirichlet BC -x edge
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 
 [pylithapp.problem.bc.bc_yneg]
 constrained_dof = [1]
@@ -87,8 +76,6 @@ db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC -y edge
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
-
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 
 
 # End of file

--- a/tests/fullscale/linearelasticity/nofaults-3d/gravity.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/gravity.cfg
@@ -6,15 +6,10 @@ gravity_field = spatialdata.spatialdb.GravityField
 gravity_field.gravity_dir = [0.0, 0.0, -1.0]
 
 defaults.quadrature_order = 2
+defaults.output_field_filter = pylith.meshio.FieldFilterProject
 
 [pylithapp.problem.solution.subfields.displacement]
 basis_order = 2
-
-[pylithapp.problem.solution_observers.domain]
-field_filter = pylith.meshio.FieldFilterProject
-
-[pylithapp.problem.solution_observers.groundsurf]
-field_filter = pylith.meshio.FieldFilterProject
 
 # ----------------------------------------------------------------------
 # materials
@@ -24,8 +19,6 @@ db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.label = Elastic properties for upper crust
 db_auxiliary_field.values = [density, vs, vp]
 db_auxiliary_field.data = [2500*kg/m**3, 3.0*km/s, 5.2915026*km/s]
-
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 
 auxiliary_subfields.density.basis_order = 0
 auxiliary_subfields.gravitational_acceleration.basis_order = 0
@@ -41,8 +34,6 @@ db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.label = Elastic properties lower crust
 db_auxiliary_field.values = [density, vs, vp]
 db_auxiliary_field.data = [2500*kg/m**3, 3.0*km/s, 5.2915026*km/s]
-
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 
 auxiliary_subfields.density.basis_order = 0
 auxiliary_subfields.gravitational_acceleration.basis_order = 0
@@ -72,7 +63,6 @@ db_auxiliary_field.label = Dirichlet BC +x boundary
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 
 [pylithapp.problem.bc.bc_xneg]
 constrained_dof = [0]
@@ -82,7 +72,6 @@ db_auxiliary_field.label = Dirichlet BC -x boundary
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 
 [pylithapp.problem.bc.bc_ypos]
 constrained_dof = [1]
@@ -91,8 +80,6 @@ db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC +y boundary
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
-
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 
 
 [pylithapp.problem.bc.bc_yneg]
@@ -103,8 +90,6 @@ db_auxiliary_field.label = Dirichlet BC -y boundary
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-
 
 [pylithapp.problem.bc.bc_zneg]
 constrained_dof = [2]
@@ -113,8 +98,6 @@ db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.label = Dirichlet BC -z boundary
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
-
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 
 
 # End of file

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialstrain_genmaxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialstrain_genmaxwell.cfg
@@ -36,7 +36,6 @@ auxiliary_subfields.density.basis_order = 0
 derived_subfields.cauchy_strain.basis_order = 1
 derived_subfields.cauchy_stress.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 observers.observer.data_fields = [cauchy_stress, cauchy_strain, displacement, viscous_strain]
 
 [pylithapp.problem.materials.viscomat.bulk_rheology]
@@ -70,7 +69,6 @@ db_auxiliary_field.iohandler.filename = axialstrain_genmaxwell_bc.spatialdb
 db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_ypos]
@@ -82,8 +80,6 @@ db_auxiliary_field.iohandler.filename = axialstrain_genmaxwell_bc.spatialdb
 db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xneg]
 constrained_dof = [0]
@@ -94,8 +90,6 @@ db_auxiliary_field.iohandler.filename = axialstrain_genmaxwell_bc.spatialdb
 db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xpos]
 constrained_dof = [0]
@@ -106,7 +100,5 @@ db_auxiliary_field.iohandler.filename = axialstrain_genmaxwell_bc.spatialdb
 db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 # End of file

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialstrainrate_genmaxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialstrainrate_genmaxwell.cfg
@@ -36,7 +36,6 @@ auxiliary_subfields.density.basis_order = 0
 derived_subfields.cauchy_strain.basis_order = 1
 derived_subfields.cauchy_stress.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 observers.observer.data_fields = [cauchy_stress, cauchy_strain, displacement, viscous_strain]
 
 [pylithapp.problem.materials.viscomat.bulk_rheology]
@@ -72,8 +71,6 @@ db_auxiliary_field.iohandler.filename = axialstrainrate_genmaxwell_bc.spatialdb
 db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_ypos]
 constrained_dof = [1]
@@ -86,8 +83,6 @@ db_auxiliary_field.iohandler.filename = axialstrainrate_genmaxwell_bc.spatialdb
 db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xneg]
 constrained_dof = [0]
@@ -100,8 +95,6 @@ db_auxiliary_field.iohandler.filename = axialstrainrate_genmaxwell_bc.spatialdb
 db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xpos]
 constrained_dof = [0]
@@ -114,7 +107,5 @@ db_auxiliary_field.iohandler.filename = axialstrainrate_genmaxwell_bc.spatialdb
 db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 # End of file

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialtraction_maxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialtraction_maxwell.cfg
@@ -36,7 +36,6 @@ auxiliary_subfields.density.basis_order = 0
 derived_subfields.cauchy_strain.basis_order = 1
 derived_subfields.cauchy_stress.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 observers.observer.data_fields = [cauchy_stress, cauchy_strain, displacement, viscous_strain]
 
 [pylithapp.problem.materials.viscomat.bulk_rheology]
@@ -68,8 +67,6 @@ db_auxiliary_field.label = Dirichlet BC on -y
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_ypos]
 constrained_dof = [1]
@@ -79,8 +76,6 @@ db_auxiliary_field.label = Dirichlet BC on +y
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xneg]
 constrained_dof = [0]
@@ -90,8 +85,6 @@ db_auxiliary_field.label = Dirichlet BC on -x
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xpos]
 label = edge_xpos
@@ -102,7 +95,5 @@ db_auxiliary_field.data = [0*Pa,-10*MPa]
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 # End of file

--- a/tests/fullscale/viscoelasticity/nofaults-2d/pylithapp.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/pylithapp.cfg
@@ -23,8 +23,10 @@ reader.coordsys.space_dim = 2
 # solution
 # ----------------------------------------------------------------------
 [pylithapp.problem]
-defaults.quadrature_order = 2
 solver = nonlinear ; Use nonlinear solver to ensure residual and Jacobian are consistent.
+
+defaults.quadrature_order = 2
+defaults.output_field_filter = pylith.meshio.FieldFilterProject
 
 [pylithapp.problem.solution.subfields.displacement]
 basis_order = 2
@@ -33,11 +35,7 @@ basis_order = 2
 solution_observers = [domain, boundary]
 solution_observers.boundary = pylith.meshio.OutputSolnBoundary
 
-[pylithapp.problem.solution_observers.domain]
-field_filter = pylith.meshio.FieldFilterProject
-
 [pylithapp.problem.solution_observers.boundary]
-field_filter = pylith.meshio.FieldFilterProject
 label = edge_xpos
 
 # ----------------------------------------------------------------------

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialstrain_genmaxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialstrain_genmaxwell.cfg
@@ -36,7 +36,6 @@ auxiliary_subfields.density.basis_order = 0
 derived_subfields.cauchy_strain.basis_order = 1
 derived_subfields.cauchy_stress.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 observers.observer.data_fields = [cauchy_stress, cauchy_strain, displacement, viscous_strain]
 
 [pylithapp.problem.materials.viscomat.bulk_rheology]
@@ -73,8 +72,6 @@ db_auxiliary_field.query_type = linear
 
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_ypos]
 constrained_dof = [1]
@@ -86,8 +83,6 @@ db_auxiliary_field.query_type = linear
 
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xneg]
 constrained_dof = [0]
@@ -99,8 +94,6 @@ db_auxiliary_field.query_type = linear
 
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xpos]
 constrained_dof = [0]
@@ -112,8 +105,6 @@ db_auxiliary_field.query_type = linear
 
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_zneg]
 constrained_dof = [2]
@@ -125,8 +116,6 @@ db_auxiliary_field.query_type = linear
 
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_zpos]
 constrained_dof = [2]
@@ -138,7 +127,5 @@ db_auxiliary_field.query_type = linear
 
 auxiliary_subfields.initial_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 # End of file

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialstrainrate_genmaxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialstrainrate_genmaxwell.cfg
@@ -36,7 +36,6 @@ auxiliary_subfields.density.basis_order = 0
 derived_subfields.cauchy_strain.basis_order = 1
 derived_subfields.cauchy_stress.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 observers.observer.data_fields = [cauchy_stress, cauchy_strain, displacement, viscous_strain]
 
 [pylithapp.problem.materials.viscomat.bulk_rheology]
@@ -76,8 +75,6 @@ db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 auxiliary_subfields.rate_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_ypos]
 constrained_dof = [1]
@@ -92,8 +89,6 @@ db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 auxiliary_subfields.rate_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xneg]
 constrained_dof = [0]
@@ -108,8 +103,6 @@ db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 auxiliary_subfields.rate_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xpos]
 constrained_dof = [0]
@@ -124,8 +117,6 @@ db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 auxiliary_subfields.rate_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_zneg]
 constrained_dof = [2]
@@ -140,8 +131,6 @@ db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 auxiliary_subfields.rate_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_zpos]
 constrained_dof = [2]
@@ -156,7 +145,5 @@ db_auxiliary_field.query_type = linear
 auxiliary_subfields.initial_amplitude.basis_order = 1
 auxiliary_subfields.rate_amplitude.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 # End of file

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialtraction_maxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialtraction_maxwell.cfg
@@ -36,7 +36,6 @@ auxiliary_subfields.density.basis_order = 0
 derived_subfields.cauchy_strain.basis_order = 1
 derived_subfields.cauchy_stress.basis_order = 1
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
 observers.observer.data_fields = [cauchy_stress, cauchy_strain, displacement, viscous_strain]
 
 [pylithapp.problem.materials.viscomat.bulk_rheology]
@@ -69,8 +68,6 @@ db_auxiliary_field.label = Dirichlet BC on -x
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_xpos]
 constrained_dof = [0]
@@ -80,8 +77,6 @@ db_auxiliary_field.label = Dirichlet BC on +x
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_yneg]
 constrained_dof = [1]
@@ -91,8 +86,6 @@ db_auxiliary_field.label = Dirichlet BC on -y
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_ypos]
 constrained_dof = [1]
@@ -102,8 +95,6 @@ db_auxiliary_field.label = Dirichlet BC on +y
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_zneg]
 constrained_dof = [2]
@@ -113,8 +104,6 @@ db_auxiliary_field.label = Dirichlet BC on -z
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 [pylithapp.problem.bc.bc_zpos]
 label = boundary_zpos
@@ -125,7 +114,5 @@ db_auxiliary_field.data = [0.0*Pa, 0.0*Pa, -10.0*MPa]
 
 auxiliary_subfields.initial_amplitude.basis_order = 0
 
-observers.observer.field_filter = pylith.meshio.FieldFilterProject
-observers.observer.data_fields = [displacement]
 
 # End of file

--- a/tests/fullscale/viscoelasticity/nofaults-3d/pylithapp.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/pylithapp.cfg
@@ -23,8 +23,10 @@ reader.coordsys.space_dim = 3
 # solution
 # ----------------------------------------------------------------------
 [pylithapp.problem]
-defaults.quadrature_order = 2
 solver = nonlinear ; Use nonlinear solver to ensure residual and Jacobian are consistent.
+
+defaults.quadrature_order = 2
+defaults.output_field_filter = pylith.meshio.FieldFilterProject
 
 [pylithapp.problem.solution.subfields.displacement]
 basis_order = 2
@@ -33,11 +35,7 @@ basis_order = 2
 solution_observers = [domain, boundary]
 solution_observers.boundary = pylith.meshio.OutputSolnBoundary
 
-[pylithapp.problem.solution_observers.domain]
-field_filter = pylith.meshio.FieldFilterProject
-
 [pylithapp.problem.solution_observers.boundary]
-field_filter = pylith.meshio.FieldFilterProject
 label = boundary_zpos
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
* Add `output_field_filter` to problem defaults. This allows use of one switch to project all output fields to basis order =1 when the solution basis order > 1.
* By default, only output solution fields that are defined over the entire domain. This means that we do not include the Lagrange multiplier field defined over the fault when outputting the solution fields for the domain, materials, etc (which would fail during the projection).