### PR TITLE
Add missing code so elastic rheologies can specify when Jacobian should be recomputed

### DIFF
--- a/libsrc/pylith/feassemble/Integrator.cc
+++ b/libsrc/pylith/feassemble/Integrator.cc
@@ -99,36 +99,24 @@ pylith::feassemble::Integrator::needNewLHSJacobianLumped(const bool dtChanged) {
 // ---------------------------------------------------------------------------------------------------------------------
 // Set LHS Jacobian trigger.
 void
-pylith::feassemble::Integrator::setLHSJacobianTriggers(const NewJacobianTriggers value) {
-    if (value == NEW_JACOBIAN_NEVER) {
-        _lhsJacobianTriggers = value;
-    } else {
-        _lhsJacobianTriggers |= value;
-    } // if/else
+pylith::feassemble::Integrator::setLHSJacobianTriggers(const int value) {
+    _lhsJacobianTriggers |= value;
 } // setLHSJacobianTriggers
 
 
 // ---------------------------------------------------------------------------------------------------------------------
 // Set LHS lumped Jacobian trigger.
 void
-pylith::feassemble::Integrator::setLHSJacobianLumpedTriggers(const NewJacobianTriggers value) {
-    if (value == NEW_JACOBIAN_NEVER) {
-        _lhsJacobianLumpedTriggers = value;
-    } else {
-        _lhsJacobianLumpedTriggers |= value;
-    } // if/else
+pylith::feassemble::Integrator::setLHSJacobianLumpedTriggers(const int value) {
+    _lhsJacobianLumpedTriggers |= value;
 } // setLHSJacobianLumpedTriggers
 
 
 // ---------------------------------------------------------------------------------------------------------------------
 // Set RHS Jacobian trigger.
 void
-pylith::feassemble::Integrator::setRHSJacobianTriggers(const NewJacobianTriggers value) {
-    if (value == NEW_JACOBIAN_NEVER) {
-        _rhsJacobianTriggers = value;
-    } else {
-        _rhsJacobianTriggers |= value;
-    } // if/else
+pylith::feassemble::Integrator::setRHSJacobianTriggers(const int value) {
+    _rhsJacobianTriggers |= value;
 } // setRHSJacobianTriggers
 
 

--- a/libsrc/pylith/feassemble/Integrator.cc
+++ b/libsrc/pylith/feassemble/Integrator.cc
@@ -41,9 +41,9 @@ pylith::feassemble::Integrator::Integrator(pylith::problems::Physics* const phys
     _needNewRHSJacobian(true),
     _needNewLHSJacobian(true),
     _needNewLHSJacobianLumped(true),
-    _LHSJacobianTriggers(NEW_JACOBIAN_NEVER),
-    _LHSJacobianLumpedTriggers(NEW_JACOBIAN_NEVER),
-    _RHSJacobianTriggers(NEW_JACOBIAN_NEVER)
+    _lhsJacobianTriggers(NEW_JACOBIAN_NEVER),
+    _lhsJacobianLumpedTriggers(NEW_JACOBIAN_NEVER),
+    _rhsJacobianTriggers(NEW_JACOBIAN_NEVER)
 {}
 
 
@@ -58,9 +58,9 @@ pylith::feassemble::Integrator::~Integrator(void) {
 // Check whether RHS Jacobian needs to be recomputed.
 bool
 pylith::feassemble::Integrator::needNewRHSJacobian(const bool dtChanged) {
-    if (_RHSJacobianTriggers & NEW_JACOBIAN_ALWAYS) {
+    if (_rhsJacobianTriggers & NEW_JACOBIAN_ALWAYS) {
         _needNewRHSJacobian = true;
-    } else if (dtChanged && (_RHSJacobianTriggers & NEW_JACOBIAN_TIME_STEP_CHANGE)) {
+    } else if (dtChanged && (_rhsJacobianTriggers & NEW_JACOBIAN_TIME_STEP_CHANGE)) {
         _needNewRHSJacobian = true;
     } // if
 
@@ -72,9 +72,9 @@ pylith::feassemble::Integrator::needNewRHSJacobian(const bool dtChanged) {
 // Check whether LHS Jacobian needs to be recomputed.
 bool
 pylith::feassemble::Integrator::needNewLHSJacobian(const bool dtChanged) {
-    if (_LHSJacobianTriggers & NEW_JACOBIAN_ALWAYS) {
+    if (_lhsJacobianTriggers & NEW_JACOBIAN_ALWAYS) {
         _needNewLHSJacobian = true;
-    } else if (dtChanged && (_LHSJacobianTriggers & NEW_JACOBIAN_TIME_STEP_CHANGE)) {
+    } else if (dtChanged && (_lhsJacobianTriggers & NEW_JACOBIAN_TIME_STEP_CHANGE)) {
         _needNewLHSJacobian = true;
     } // if
 
@@ -86,9 +86,9 @@ pylith::feassemble::Integrator::needNewLHSJacobian(const bool dtChanged) {
 // Check whether LHS lumped Jacobian needs to be recomputed.
 bool
 pylith::feassemble::Integrator::needNewLHSJacobianLumped(const bool dtChanged) {
-    if (_LHSJacobianLumpedTriggers & NEW_JACOBIAN_ALWAYS) {
+    if (_lhsJacobianLumpedTriggers & NEW_JACOBIAN_ALWAYS) {
         _needNewLHSJacobianLumped = true;
-    } else if (dtChanged && (_LHSJacobianLumpedTriggers & NEW_JACOBIAN_TIME_STEP_CHANGE)) {
+    } else if (dtChanged && (_lhsJacobianLumpedTriggers & NEW_JACOBIAN_TIME_STEP_CHANGE)) {
         _needNewLHSJacobianLumped = true;
     } // if
 
@@ -101,9 +101,9 @@ pylith::feassemble::Integrator::needNewLHSJacobianLumped(const bool dtChanged) {
 void
 pylith::feassemble::Integrator::setLHSJacobianTriggers(const NewJacobianTriggers value) {
     if (value == NEW_JACOBIAN_NEVER) {
-        _LHSJacobianTriggers = value;
+        _lhsJacobianTriggers = value;
     } else {
-        _LHSJacobianTriggers |= value;
+        _lhsJacobianTriggers |= value;
     } // if/else
 } // setLHSJacobianTriggers
 
@@ -113,9 +113,9 @@ pylith::feassemble::Integrator::setLHSJacobianTriggers(const NewJacobianTriggers
 void
 pylith::feassemble::Integrator::setLHSJacobianLumpedTriggers(const NewJacobianTriggers value) {
     if (value == NEW_JACOBIAN_NEVER) {
-        _LHSJacobianLumpedTriggers = value;
+        _lhsJacobianLumpedTriggers = value;
     } else {
-        _LHSJacobianLumpedTriggers |= value;
+        _lhsJacobianLumpedTriggers |= value;
     } // if/else
 } // setLHSJacobianLumpedTriggers
 
@@ -125,9 +125,9 @@ pylith::feassemble::Integrator::setLHSJacobianLumpedTriggers(const NewJacobianTr
 void
 pylith::feassemble::Integrator::setRHSJacobianTriggers(const NewJacobianTriggers value) {
     if (value == NEW_JACOBIAN_NEVER) {
-        _RHSJacobianTriggers = value;
+        _rhsJacobianTriggers = value;
     } else {
-        _RHSJacobianTriggers |= value;
+        _rhsJacobianTriggers |= value;
     } // if/else
 } // setRHSJacobianTriggers
 

--- a/libsrc/pylith/feassemble/Integrator.hh
+++ b/libsrc/pylith/feassemble/Integrator.hh
@@ -83,19 +83,19 @@ public:
      *
      * @param[in] value Triggers for needing new LHS Jacobian.
      */
-    void setLHSJacobianTriggers(const NewJacobianTriggers value);
+    void setLHSJacobianTriggers(const int value);
 
     /** Set LHS lumped Jacobian trigger.
      *
      * @param[in] value Triggers for needing new LHS lumped Jacobian.
      */
-    void setLHSJacobianLumpedTriggers(const NewJacobianTriggers value);
+    void setLHSJacobianLumpedTriggers(const int value);
 
     /** Set RHS Jacobian trigger.
      *
      * @param[in] value Triggers for needing new RHS Jacobian.
      */
-    void setRHSJacobianTriggers(const NewJacobianTriggers value);
+    void setRHSJacobianTriggers(const int value);
 
     /** Initialize integration domain, auxiliary field, and derived field. Update observers.
      *

--- a/libsrc/pylith/feassemble/Integrator.hh
+++ b/libsrc/pylith/feassemble/Integrator.hh
@@ -243,9 +243,10 @@ protected:
     bool _needNewRHSJacobian;
     bool _needNewLHSJacobian;
     bool _needNewLHSJacobianLumped;
-    int _LHSJacobianTriggers; // Triggers for needing new LHS Jacobian.
-    int _LHSJacobianLumpedTriggers; // Triggers for needing new LHS lumped Jacobian.
-    int _RHSJacobianTriggers; // Triggers for needing new RHS Jacobian.
+
+    int _lhsJacobianTriggers; // Triggers for needing new LHS Jacobian.
+    int _lhsJacobianLumpedTriggers; // Triggers for needing new LHS lumped Jacobian.
+    int _rhsJacobianTriggers; // Triggers for needing new RHS Jacobian.
 
     // NOT IMPLEMENTED /////////////////////////////////////////////////////////////////////////////////////////////////
 private:

--- a/libsrc/pylith/materials/Elasticity.cc
+++ b/libsrc/pylith/materials/Elasticity.cc
@@ -348,6 +348,7 @@ pylith::materials::Elasticity::_setKernelsRHSJacobian(pylith::feassemble::Integr
         const PetscPointJac Jg1uu = NULL;
         const PetscPointJac Jg2uu = NULL;
         const PetscPointJac Jg3uu = _rheology->getKernelRHSJacobianElasticConstants(coordsys);
+        integrator->setRHSJacobianTriggers(_rheology->getRHSJacobianTriggers());
 
         kernels.resize(1);
         kernels[0] = JacobianKernels("displacement", "displacement", Jg0uu, Jg1uu, Jg2uu, Jg3uu);

--- a/libsrc/pylith/materials/RheologyElasticity.cc
+++ b/libsrc/pylith/materials/RheologyElasticity.cc
@@ -20,6 +20,8 @@
 
 #include "pylith/materials/RheologyElasticity.hh" // implementation of object methods
 
+#include "pylith/feassemble/Integrator.hh" // USES NEW_JACOBIAN_NEVER
+
 #include "pylith/utils/error.hh" // USES PYLITH_METHOD_BEGIN/END
 #include "pylith/utils/journals.hh" // USES PYLITH_COMPONENT_DEBUG
 
@@ -29,7 +31,9 @@
 
 // ---------------------------------------------------------------------------------------------------------------------
 // Default constructor.
-pylith::materials::RheologyElasticity::RheologyElasticity(void) {}
+pylith::materials::RheologyElasticity::RheologyElasticity(void) :
+    _rhsJacobianTriggers(pylith::feassemble::Integrator::NEW_JACOBIAN_NEVER)
+{}
 
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -43,6 +47,14 @@ pylith::materials::RheologyElasticity::~RheologyElasticity(void) {
 // Deallocate PETSc and local data structures.
 void
 pylith::materials::RheologyElasticity::deallocate(void) {}
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Get triggers for needing to compute the elastic constants for the RHS Jacobian.
+int
+pylith::materials::RheologyElasticity::getRHSJacobianTriggers(void) const {
+    return _rhsJacobianTriggers;
+} // getRHSJacobianTriggers
 
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/libsrc/pylith/materials/RheologyElasticity.hh
+++ b/libsrc/pylith/materials/RheologyElasticity.hh
@@ -79,6 +79,12 @@ public:
     virtual
     PetscPointJac getKernelRHSJacobianElasticConstants(const spatialdata::geocoords::CoordSys* coordsys) const = 0;
 
+    /** Get triggers for needing to compute the elastic constants for the RHS Jacobian.
+     *
+     * @returns Triggers for needing to recompute the RHS Jacobian.
+     */
+    int getRHSJacobianTriggers(void) const;
+
     /** Get stress kernel for derived field.
      *
      * @param[in] coordsys Coordinate system.
@@ -105,6 +111,10 @@ public:
     virtual
     void updateKernelConstants(pylith::real_array* kernelConstants,
                                const PylithReal dt) const;
+
+    // PROTECTED MEMBERS ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    int _rhsJacobianTriggers; ///< Triggers for needing to recompute the RHS Jacobian.
 
     // NOT IMPLEMENTED /////////////////////////////////////////////////////////////////////////////////////////////////
 private:


### PR DESCRIPTION
Add data member to `RheologyElasticity` so bulk rheologies can specify when the Jacobian with elastic constants needs to be recomputed.

Elastic rheologies should set the `_rhsJacobianTriggers` data member in their constructor. The default is `NEW_JACOBIAN_NEVER` which means the Jacobian is constant (doesn't change after it has been computed).