### PR TITLE
Clean up .cfg files in full-scale tests

### DIFF
--- a/doc/install/Cluster_CIT-garuda/sample.pylithapp.cfg
+++ b/doc/install/Cluster_CIT-garuda/sample.pylithapp.cfg
@@ -5,5 +5,5 @@ scheduler = pbs
 shell = /bin/bash
 
 [pylithapp.launcher]
-command = mpirun -np ${nodes} -machinefile ${PBS_NODEFILE}
+command = mpiexec -np ${nodes} -machinefile ${PBS_NODEFILE}
 

--- a/doc/install/Cluster_CIT-pangu/sample.pylithapp.cfg
+++ b/doc/install/Cluster_CIT-pangu/sample.pylithapp.cfg
@@ -10,5 +10,5 @@ queue = normal
 #queue = debug
 
 [pylithapp.launcher]
-command = mpirun -np ${nodes} -machinefile ${LSB_DJOB_HOSTFILE}
+command = mpiexec -np ${nodes} -machinefile ${LSB_DJOB_HOSTFILE}
 

--- a/examples/meshing/surface_nurbs/merge_surfs/pylithapp.cfg
+++ b/examples/meshing/surface_nurbs/merge_surfs/pylithapp.cfg
@@ -21,7 +21,7 @@ faultcohesivekin = 1
 # You can view this file using the pylith_parameters application or
 # online at https://geodynamics.github.io/pylith_parameters/.
 dump_parameters.filename = output/faultslip-parameters.json
-#problem.progress_monitor.filename = output/faultslip-progress.txt
+problem.progress_monitor.filename = output/faultslip-progress.txt
 
 # ----------------------------------------------------------------------
 # mesh_generator

--- a/playpen/test_new_powerlaw/pylithapp.cfg
+++ b/playpen/test_new_powerlaw/pylithapp.cfg
@@ -5,7 +5,7 @@
 # in this directory.
 
 [pylithapp.launcher] # WARNING: THIS IS NOT PORTABLE
-command = mpirun -np ${nodes}
+command = mpiexec -np ${nodes}
 
 # ----------------------------------------------------------------------
 # journal

--- a/tests/fullscale/linearelasticity/faults-2d/pylithapp.cfg
+++ b/tests/fullscale/linearelasticity/faults-2d/pylithapp.cfg
@@ -3,7 +3,7 @@
 # problem.progress_monitor.filename = output/SIMULATION-progress.txt
 
 [pylithapp.launcher] # WARNING: THIS IS NOT PORTABLE
-command = mpirun -np ${nodes}
+command = mpiexec -np ${nodes}
 
 # ----------------------------------------------------------------------
 # journal
@@ -44,7 +44,9 @@ coordsys.space_dim = 2
 # ----------------------------------------------------------------------
 [pylithapp.problem]
 defaults.quadrature_order = 1
-solver = nonlinear ; Use nonlinear solver to ensure residual and Jacobian are consistent.
+
+# Use nonlinear solver to ensure residual and Jacobian are consistent.
+solver = nonlinear
 
 solution = pylith.problems.SolnDispLagrange
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/axialdisp.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/axialdisp.cfg
@@ -25,10 +25,11 @@ db_auxiliary_field.data = [2500*kg/m**3, 3.0*km/s, 5.2915026*km/s]
 [pylithapp.problem]
 ic = [domain]
 
-ic.domain.db = spatialdata.spatialdb.SimpleDB
-ic.domain.db.label = Initial conditions for domain
-ic.domain.db.iohandler.filename = axialdisp_ic.spatialdb
-ic.domain.db.query_type = linear
+[pylithapp.problem.ic.domain]
+db = spatialdata.spatialdb.SimpleDB
+db.label = Initial conditions for domain
+db.iohandler.filename = axialdisp_ic.spatialdb
+db.query_type = linear
 
 
 # ----------------------------------------------------------------------

--- a/tests/fullscale/linearelasticity/nofaults-2d/axialdisp_tri.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/axialdisp_tri.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/axialdisp_tri-parameters.json
-#problem.progress_monitor.filename = output/axialdisp_tri-progress.txt
+problem.progress_monitor.filename = output/axialdisp_tri-progress.txt
 
 problem.defaults.name = axialdisp_tri
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/bodyforce.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/bodyforce.cfg
@@ -1,8 +1,5 @@
 [pylithapp]
 
-[pylithapp.launcher] # WARNING: THIS IS NOT PORTABLE
-command = mpirun -np ${nodes}
-
 # ----------------------------------------------------------------------
 # journal
 # ----------------------------------------------------------------------

--- a/tests/fullscale/linearelasticity/nofaults-2d/gravity_incompressible_quad.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/gravity_incompressible_quad.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_incompressible_quad-parameters.json
-#problem.progress_monitor.filename = output/gravity_incompressible_quad-progress.txt
+problem.progress_monitor.filename = output/gravity_incompressible_quad-progress.txt
 
 problem.defaults.name = gravity_incompressible_quad
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/gravity_incompressible_tri.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/gravity_incompressible_tri.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_incompressible_tri-parameters.json
-#problem.progress_monitor.filename = output/gravity_incompressible_tri-progress.txt
+problem.progress_monitor.filename = output/gravity_incompressible_tri-progress.txt
 
 problem.defaults.name = gravity_incompressible_tri
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/gravity_quad.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/gravity_quad.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_quad-parameters.json
-#problem.progress_monitor.filename = output/gravity_quad-progress.txt
+problem.progress_monitor.filename = output/gravity_quad-progress.txt
 
 problem.defaults.name = gravity_quad
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/gravity_refstate_quad.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/gravity_refstate_quad.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_refstate_quad-parameters.json
-#problem.progress_monitor.filename = output/gravity_refstate_quad-progress.txt
+problem.progress_monitor.filename = output/gravity_refstate_quad-progress.txt
 
 problem.defaults.name = gravity_refstate_quad
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/gravity_refstate_tri.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/gravity_refstate_tri.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_refstate_tri-parameters.json
-#problem.progress_monitor.filename = output/gravity_refstate_tri -progress.txt
+problem.progress_monitor.filename = output/gravity_refstate_tri -progress.txt
 
 problem.defaults.name = gravity_refstate_tri
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/gravity_tri.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/gravity_tri.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_tri-parameters.json
-#problem.progress_monitor.filename = output/gravity_tri-progress.txt
+problem.progress_monitor.filename = output/gravity_tri-progress.txt
 
 problem.defaults.name = gravity_tri
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/pylithapp.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/pylithapp.cfg
@@ -3,7 +3,7 @@
 # problem.progress_monitor.filename = output/SIMULATION-progress.txt
 
 [pylithapp.launcher] # WARNING: THIS IS NOT PORTABLE
-command = mpirun -np ${nodes}
+command = mpiexec -np ${nodes}
 
 # ----------------------------------------------------------------------
 # journal
@@ -40,7 +40,9 @@ coordsys.space_dim = 2
 # ----------------------------------------------------------------------
 [pylithapp.problem]
 defaults.quadrature_order = 1
-solver = nonlinear ; Use nonlinear solver to ensure residual and Jacobian are consistent.
+
+# Use nonlinear solver to ensure residual and Jacobian are consistent.
+solver = nonlinear
 
 [pylithapp.problem.solution.subfields.displacement]
 basis_order = 1

--- a/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_quad.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_quad.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/sheartraction_quad-parameters.json
-#problem.progress_monitor.filename = output/sheartraction_quad-progress.txt
+problem.progress_monitor.filename = output/sheartraction_quad-progress.txt
 
 problem.defaults.name = sheartraction_quad
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_rate_quad.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_rate_quad.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/sheartraction_rate_quad-parameters.json
-#problem.progress_monitor.filename = output/sheartraction_rate_quad-progress.txt
+problem.progress_monitor.filename = output/sheartraction_rate_quad-progress.txt
 
 problem.defaults.name = sheartraction_rate_quad
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_rate_tri.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_rate_tri.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/sheartraction_rate_tri-parameters.json
-#problem.progress_monitor.filename = output/sheartraction_rate_tri-progress.txt
+problem.progress_monitor.filename = output/sheartraction_rate_tri-progress.txt
 
 problem.defaults.name = sheartraction_rate_tri
 

--- a/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_tri.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_tri.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/sheartraction_tri-parameters.json
-#problem.progress_monitor.filename = output/sheartraction_tri-progress.txt
+problem.progress_monitor.filename = output/sheartraction_tri-progress.txt
 
 problem.defaults.name = sheartraction_tri
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/axialdisp_hex.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/axialdisp_hex.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/axialdisp_hex-parameters.json
-#problem.progress_monitor.filename = output/axialdisp_hex-progress.txt
+problem.progress_monitor.filename = output/axialdisp_hex-progress.txt
 
 problem.defaults.name = axialdisp_hex
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/axialdisp_tet.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/axialdisp_tet.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/axialdisp_tet-parameters.json
-#problem.progress_monitor.filename = output/axialdisp_tet-progress.txt
+problem.progress_monitor.filename = output/axialdisp_tet-progress.txt
 
 problem.defaults.name = axialdisp_tet
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/gravity_hex.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/gravity_hex.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_hex-parameters.json
-#problem.progress_monitor.filename = output/gravity_hex-progress.txt
+problem.progress_monitor.filename = output/gravity_hex-progress.txt
 
 problem.defaults.name = gravity_hex
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/gravity_incompressible_hex.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/gravity_incompressible_hex.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_incompressible_hex-parameters.json
-#problem.progress_monitor.filename = output/gravity_incompressible_hex-progress.txt
+problem.progress_monitor.filename = output/gravity_incompressible_hex-progress.txt
 
 problem.defaults.name = gravity_incompressible_hex
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/gravity_incompressible_tet.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/gravity_incompressible_tet.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_incompressible_tet-parameters.json
-#problem.progress_monitor.filename = output/gravity_incompressible_tet-progress.txt
+problem.progress_monitor.filename = output/gravity_incompressible_tet-progress.txt
 
 problem.defaults.name = gravity_incompressible_tet
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/gravity_refstate_hex.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/gravity_refstate_hex.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_refstate_hex-parameters.json
-#problem.progress_monitor.filename = output/gravity_refstate_hex-progress.txt
+problem.progress_monitor.filename = output/gravity_refstate_hex-progress.txt
 
 problem.defaults.name = gravity_refstate_hex
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/gravity_refstate_tet.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/gravity_refstate_tet.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_refstate_tet-parameters.json
-#problem.progress_monitor.filename = output/gravity_refstate_tet -progress.txt
+problem.progress_monitor.filename = output/gravity_refstate_tet -progress.txt
 
 problem.defaults.name = gravity_refstate_tet
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/gravity_tet.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/gravity_tet.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/gravity_tet-parameters.json
-#problem.progress_monitor.filename = output/gravity_tet-progress.txt
+problem.progress_monitor.filename = output/gravity_tet-progress.txt
 
 problem.defaults.name = gravity_tet
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/pylithapp.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/pylithapp.cfg
@@ -3,7 +3,7 @@
 # problem.progress_monitor.filename = output/SIMULATION-progress.txt
 
 [pylithapp.launcher] # WARNING: THIS IS NOT PORTABLE
-command = mpirun -np ${nodes}
+command = mpiexec -np ${nodes}
 
 # ----------------------------------------------------------------------
 # journal

--- a/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_hex.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_hex.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/sheartraction_hex-parameters.json
-#problem.progress_monitor.filename = output/sheartraction_hex-progress.txt
+problem.progress_monitor.filename = output/sheartraction_hex-progress.txt
 
 problem.defaults.name = sheartraction_hex
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_rate_hex.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_rate_hex.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/sheartraction_rate_hex-parameters.json
-#problem.progress_monitor.filename = output/sheartraction_rate_hex-progress.txt
+problem.progress_monitor.filename = output/sheartraction_rate_hex-progress.txt
 
 problem.defaults.name = sheartraction_rate_hex
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_rate_tet.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_rate_tet.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/sheartraction_rate_tet-parameters.json
-#problem.progress_monitor.filename = output/sheartraction_rate_tet-progress.txt
+problem.progress_monitor.filename = output/sheartraction_rate_tet-progress.txt
 
 problem.defaults.name = sheartraction_rate_tet
 

--- a/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_tet.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_tet.cfg
@@ -1,6 +1,6 @@
 [pylithapp]
 dump_parameters.filename = output/sheartraction_tet-parameters.json
-#problem.progress_monitor.filename = output/sheartraction_tet-progress.txt
+problem.progress_monitor.filename = output/sheartraction_tet-progress.txt
 
 problem.defaults.name = sheartraction_tet
 

--- a/tests/fullscale/linearporoelasticity/mandel/mandel.cfg
+++ b/tests/fullscale/linearporoelasticity/mandel/mandel.cfg
@@ -3,7 +3,7 @@
 # problem.progress_monitor.filename = output/SIMULATION-progress.txt
 
 [pylithapp.launcher] # WARNING: THIS IS NOT PORTABLE
-#command = mpirun -np ${nodes}
+#command = mpiexec -np ${nodes}
 
 # ----------------------------------------------------------------------
 # journal

--- a/tests/fullscale/linearporoelasticity/terzaghi/terzaghi.cfg
+++ b/tests/fullscale/linearporoelasticity/terzaghi/terzaghi.cfg
@@ -3,7 +3,7 @@
 # problem.progress_monitor.filename = output/SIMULATION-progress.txt
 
 [pylithapp.launcher] # WARNING: THIS IS NOT PORTABLE
-#command = mpirun -np ${nodes}
+#command = mpiexec -np ${nodes}
 
 # ----------------------------------------------------------------------
 # journal

--- a/tests/fullscale/viscoelasticity/nofaults-2d/pylithapp.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/pylithapp.cfg
@@ -2,7 +2,7 @@
 
 [pylithapp.launcher]
 # dry = True
-command = mpirun -np ${nodes}
+command = mpiexec -np ${nodes}
 
 # ----------------------------------------------------------------------
 # journal

--- a/tests/fullscale/viscoelasticity/nofaults-3d/pylithapp.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/pylithapp.cfg
@@ -2,7 +2,7 @@
 
 [pylithapp.launcher]
 # dry = True
-command = mpirun -np ${nodes}
+command = mpiexec -np ${nodes}
 
 # ----------------------------------------------------------------------
 # journal


### PR DESCRIPTION
* Remove inline comment.
* Replace use of mpirun with mpiexec because it is standardized.
* Turn on setting filename for progress monitor output.