### PR TITLE
Fix bug in checking of tolerance type (could be dict, never a map)

### DIFF
--- a/pylith/tests/FullTestApp.py
+++ b/pylith/tests/FullTestApp.py
@@ -252,7 +252,7 @@ def check_data(filename, testcase, mesh, vertexFields=[], cellFields=[], ratio_t
     if not has_h5py():
         return
 
-    if type(ratio_tolerance) is map:
+    if type(ratio_tolerance) is dict:
         separateChecker = True
         defaultRatio = 1e-5
 


### PR DESCRIPTION
Fix bug in checking of tolerance type in `FullTestApp`.

The tolerance is either a `float` or `dict`, never a `map` (which was what the type check was comparing against).

Fixing this leads to test failures for the Terzaghi and Mandel poroelasticity full-scale tests.