### PR TITLE
Replace hardwired 'material-id' name with value given by pylith::topology::Mesh::getCellsLabelName()

### DIFF
--- a/libsrc/pylith/faults/TopologyOps.cc
+++ b/libsrc/pylith/faults/TopologyOps.cc
@@ -184,7 +184,8 @@ pylith::faults::TopologyOps::create(pylith::topology::Mesh* mesh,
     err = DMPlexLabelCohesiveComplete(dm, label, faultBdLabel, PETSC_FALSE, faultMesh.dmMesh());PYLITH_CHECK_ERROR(err);
     err = DMPlexConstructCohesiveCells(dm, label, NULL, &sdm);PYLITH_CHECK_ERROR(err);
 
-    err = DMGetLabel(sdm, "material-id", &mlabel);PYLITH_CHECK_ERROR(err);
+    const char* interfaceLabelName = pylith::topology::Mesh::getCellsLabelName();
+    err = DMGetLabel(sdm, interfaceLabelName, &mlabel);PYLITH_CHECK_ERROR(err);
     if (mlabel) {
         err = DMPlexGetHeightStratum(sdm, 0, &cStart, &cEnd);PYLITH_CHECK_ERROR(err);
         cMax = cStart;

--- a/libsrc/pylith/feassemble/IntegratorDomain.cc
+++ b/libsrc/pylith/feassemble/IntegratorDomain.cc
@@ -59,7 +59,7 @@ pylith::feassemble::IntegratorDomain::IntegratorDomain(pylith::problems::Physics
     _materialMesh(NULL),
     _updateState(NULL) {
     GenericComponent::setName("integratordomain");
-    _labelName = "material-id";
+    _labelName = pylith::topology::Mesh::getCellsLabelName();
 } // constructor
 
 

--- a/libsrc/pylith/feassemble/IntegratorInterface.cc
+++ b/libsrc/pylith/feassemble/IntegratorInterface.cc
@@ -118,7 +118,7 @@ pylith::feassemble::IntegratorInterface::IntegratorInterface(pylith::problems::P
     _interfaceSurfaceLabel("") {
     GenericComponent::setName(_IntegratorInterface::genericComponent);
     _labelValue = 100;
-    _labelName = "material-id";
+    _labelName = pylith::topology::Mesh::getCellsLabelName();
 } // constructor
 
 

--- a/libsrc/pylith/materials/Elasticity.cc
+++ b/libsrc/pylith/materials/Elasticity.cc
@@ -144,7 +144,7 @@ pylith::materials::Elasticity::createIntegrator(const pylith::topology::Field& s
     PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
 
     pylith::feassemble::IntegratorDomain* integrator = new pylith::feassemble::IntegratorDomain(this);assert(integrator);
-    integrator->setLabelName("material-id");
+    integrator->setLabelName(pylith::topology::Mesh::getCellsLabelName());
     integrator->setLabelValue(getMaterialId());
 
     switch (_formulation) {

--- a/libsrc/pylith/materials/IncompressibleElasticity.cc
+++ b/libsrc/pylith/materials/IncompressibleElasticity.cc
@@ -136,7 +136,7 @@ pylith::materials::IncompressibleElasticity::createIntegrator(const pylith::topo
     PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
 
     pylith::feassemble::IntegratorDomain* integrator = new pylith::feassemble::IntegratorDomain(this);assert(integrator);
-    integrator->setLabelName("material-id");
+    integrator->setLabelName(pylith::topology::Mesh::getCellsLabelName());
     integrator->setLabelValue(getMaterialId());
 
     _setKernelsRHSResidual(integrator, solution);

--- a/libsrc/pylith/materials/Material.cc
+++ b/libsrc/pylith/materials/Material.cc
@@ -23,8 +23,7 @@
 #include "pylith/utils/journals.hh" // USES PYLITH_COMPONENT_*
 
 #include <cassert> // USES assert()
-#include <stdexcept> \
-    // USES std::runtime_error
+#include <stdexcept> // USES std::runtime_error
 
 // ---------------------------------------------------------------------------------------------------------------------
 // Default constructor.

--- a/libsrc/pylith/materials/Poroelasticity.cc
+++ b/libsrc/pylith/materials/Poroelasticity.cc
@@ -168,7 +168,7 @@ pylith::materials::Poroelasticity::createIntegrator(const pylith::topology::Fiel
     PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
 
     pylith::feassemble::IntegratorDomain* integrator = new pylith::feassemble::IntegratorDomain(this);assert(integrator);
-    integrator->setLabelName("material-id");
+    integrator->setLabelName(pylith::topology::Mesh::getCellsLabelName());
     integrator->setLabelValue(getMaterialId());
 
     switch (_formulation) {

--- a/libsrc/pylith/meshio/MeshIO.cc
+++ b/libsrc/pylith/meshio/MeshIO.cc
@@ -253,8 +253,9 @@ pylith::meshio::MeshIO::_setMaterials(const int_array& materialIds) { // _setMat
             throw std::runtime_error(msg.str());
         } // if
         PetscErrorCode err = 0;
+        const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
         for (PetscInt c = cStart; c < cEnd; ++c) {
-            err = DMSetLabelValue(dmMesh, "material-id", c, materialIds[c-cStart]);PYLITH_CHECK_ERROR(err);
+            err = DMSetLabelValue(dmMesh, labelName, c, materialIds[c-cStart]);PYLITH_CHECK_ERROR(err);
         } // for
     } // if
 
@@ -265,7 +266,7 @@ pylith::meshio::MeshIO::_setMaterials(const int_array& materialIds) { // _setMat
 // ----------------------------------------------------------------------
 // Get material identifiers for cells.
 void
-pylith::meshio::MeshIO::_getMaterials(int_array* materialIds) const { // _getMaterials
+pylith::meshio::MeshIO::_getMaterials(int_array* materialIds) const {
     PYLITH_METHOD_BEGIN;
 
     assert(materialIds);
@@ -279,8 +280,9 @@ pylith::meshio::MeshIO::_getMaterials(int_array* materialIds) const { // _getMat
     materialIds->resize(cellsStratum.size());
     PetscErrorCode err = 0;
     PetscInt matId = 0;
+    const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
     for (PetscInt c = cStart, index = 0; c < cEnd; ++c) {
-        err = DMGetLabelValue(dmMesh, "material-id", c, &matId);PYLITH_CHECK_ERROR(err);
+        err = DMGetLabelValue(dmMesh, labelName, c, &matId);PYLITH_CHECK_ERROR(err);
         (*materialIds)[index++] = matId;
     } // for
 
@@ -377,10 +379,13 @@ pylith::meshio::MeshIO::_getGroupNames(string_vector* names) const { // _getGrou
     const PetscInt numGroups = numLabels - 3; // Remove depth, celltype, and material labels.
     names->resize(numGroups);
 
+    const std::string& materialLabelName = pylith::topology::Mesh::getCellsLabelName();
     for (int iGroup = 0, iLabel = 0; iLabel < numLabels; ++iLabel) {
         const char* labelName = NULL;
         err = DMGetLabelName(dmMesh, iLabel, &labelName);PYLITH_CHECK_ERROR(err);
-        if ((std::string(labelName) != std::string("depth")) && (std::string(labelName) != std::string("celltype")) && (std::string(labelName) != std::string("material-id"))) {
+        if ((std::string(labelName) != std::string("depth"))
+            && (std::string(labelName) != std::string("celltype"))
+            && (std::string(labelName) != materialLabelName)) {
             (*names)[iGroup++] = labelName;
         } // if
     } // for

--- a/libsrc/pylith/topology/Mesh.cc
+++ b/libsrc/pylith/topology/Mesh.cc
@@ -101,6 +101,14 @@ pylith::topology::Mesh::dmMesh(PetscDM dm,
 }
 
 
+// ---------------------------------------------------------------------------------------------------------------------
+// Get name of label for all mesh cells, including hybrid cells.
+const char* const
+pylith::topology::Mesh::getCellsLabelName(void) {
+    return "material-id";
+} // getCellsLabelName
+
+
 // ----------------------------------------------------------------------
 // Set coordinate system.
 void

--- a/libsrc/pylith/topology/Mesh.hh
+++ b/libsrc/pylith/topology/Mesh.hh
@@ -77,6 +77,13 @@ public:
     void dmMesh(PetscDM dm,
                 const char* label="domain");
 
+    /** Get name of label for all mesh cells, including hybrid cells.
+     *
+     * @returns Name of label.
+     */
+    static
+    const char* const getCellsLabelName(void);
+
     /** Set coordinate system.
      *
      * @param cs Coordinate system.

--- a/libsrc/pylith/topology/MeshOps.cc
+++ b/libsrc/pylith/topology/MeshOps.cc
@@ -299,7 +299,8 @@ pylith::topology::MeshOps::checkMaterialIds(const pylith::topology::Mesh& mesh,
     const PetscInt cEnd = cellsStratum.end();
 
     PetscDMLabel materialsLabel = NULL;
-    err = DMGetLabel(dmMesh, "material-id", &materialsLabel);PYLITH_CHECK_ERROR(err);assert(materialsLabel);
+    const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
+    err = DMGetLabel(dmMesh, labelName, &materialsLabel);PYLITH_CHECK_ERROR(err);assert(materialsLabel);
 
     int *matBegin = &materialIds[0];
     int *matEnd = &materialIds[0] + materialIds.size();

--- a/libsrc/pylith/topology/RefineUniform.cc
+++ b/libsrc/pylith/topology/RefineUniform.cc
@@ -18,10 +18,10 @@
 
 #include <portinfo>
 
-#include "RefineUniform.hh" // implementation of class methods
+#include "pylith/topology/RefineUniform.hh" // implementation of class methods
 
-#include "Mesh.hh" // USES Mesh
-#include "MeshOps.hh" // USES MeshOps
+#include "pylith/topology/Mesh.hh" // USES Mesh
+#include "pylith/topology/MeshOps.hh" // USES MeshOps
 
 #include <cassert> // USES assert()
 #include <sstream> // USES std::ostringstream
@@ -88,13 +88,14 @@ pylith::topology::RefineUniform::refine(Mesh* const newMesh,
 
     newMesh->dmMesh(dmNew);
 
-    // Remove all non-cells from material-id label
+    // Remove all non-cells from material id label
+    const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
     PetscDMLabel matidLabel = NULL;
     PetscIS valuesIS = NULL;
     const PetscInt *values = NULL;
     PetscInt cStart, cEnd, labelNumValues;
     err = DMPlexGetHeightStratum(dmNew, 0, &cStart, &cEnd);PYLITH_CHECK_ERROR(err);
-    err = DMGetLabel(dmNew, "material-id", &matidLabel);PYLITH_CHECK_ERROR(err);
+    err = DMGetLabel(dmNew, labelName, &matidLabel);PYLITH_CHECK_ERROR(err);
     err = DMLabelGetNumValues(matidLabel, &labelNumValues);PYLITH_CHECK_ERROR(err);
     err = DMLabelGetValueIS(matidLabel, &valuesIS);PYLITH_CHECK_ERROR(err);
     err = ISGetIndices(valuesIS, &values);PYLITH_CHECK_ERROR(err);

--- a/libsrc/pylith/topology/ReverseCuthillMcKee.cc
+++ b/libsrc/pylith/topology/ReverseCuthillMcKee.cc
@@ -28,13 +28,15 @@
 void
 pylith::topology::ReverseCuthillMcKee::reorder(topology::Mesh* mesh) {
     assert(mesh);
-    DMLabel dmLabel = NULL;
-    PetscIS permutation = NULL;
-    PetscDM dmOrig = mesh->dmMesh();
-    PetscDM dmNew = NULL;
-    PetscErrorCode err;
+    PetscErrorCode err = 0;
 
-    err = DMGetLabel(dmOrig, "material-id", &dmLabel);PYLITH_CHECK_ERROR(err);
+    PetscDMLabel dmLabel = NULL;
+    PetscDM dmOrig = mesh->dmMesh();
+    const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
+    err = DMGetLabel(dmOrig, labelName, &dmLabel);PYLITH_CHECK_ERROR(err);
+
+    PetscIS permutation = NULL;
+    PetscDM dmNew = NULL;
     err = DMPlexGetOrdering(dmOrig, MATORDERINGRCM, dmLabel, &permutation);PYLITH_CHECK_ERROR(err);
     err = DMPlexPermute(dmOrig, permutation, &dmNew);PYLITH_CHECK_ERROR(err);
     err = ISDestroy(&permutation);PYLITH_CHECK_ERROR(err);
@@ -44,7 +46,7 @@ pylith::topology::ReverseCuthillMcKee::reorder(topology::Mesh* mesh) {
     PetscIS valuesIS = NULL;
     PetscInt numValues = 0;
     const PetscInt* values = NULL;
-    err = DMGetLabel(dmNew, "material-id", &dmLabel);PYLITH_CHECK_ERROR(err);
+    err = DMGetLabel(dmNew, labelName, &dmLabel);PYLITH_CHECK_ERROR(err);
     err = DMLabelGetValueIS(dmLabel, &valuesIS);PYLITH_CHECK_ERROR(err);
     err = ISGetLocalSize(valuesIS, &numValues);PYLITH_CHECK_ERROR(err);
     err = ISGetIndices(valuesIS, &values);PYLITH_CHECK_ERROR(err);


### PR DESCRIPTION
There are a few places where we rely on a label over all of the cells, including hybrid cells. The name given by Mesh::getCellsLabelName() serves this purpose. It is also useful in the integration over domain cells.