### PR TITLE
Updates for changes to PETSc boundary integration API and setting auxiliary vector

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,7 +107,7 @@ AC_CHECK_HEADER([mpi.h], [], [AC_MSG_ERROR([header 'mpi.h' not found])])
 
 dnl PETSC
 AC_LANG(C)
-CIT_PATH_PETSC([3.14.5])
+CIT_PATH_PETSC([3.15.0])
 CIT_HEADER_PETSC
 CIT_CHECK_LIB_PETSC
 

--- a/libsrc/pylith/faults/KinSrc.cc
+++ b/libsrc/pylith/faults/KinSrc.cc
@@ -164,10 +164,10 @@ pylith::faults::KinSrc::updateSlip(PetscVec slipLocalVec,
     // Create local vector for slip for this source.
     PetscErrorCode err = 0;
     PetscDM faultAuxiliaryDM = faultAuxiliaryField->dmMesh();
-    err = PetscObjectCompose((PetscObject) faultAuxiliaryDM, "dmAux",
-                             (PetscObject) _auxiliaryField->dmMesh());PYLITH_CHECK_ERROR(err);
-    err = PetscObjectCompose((PetscObject) faultAuxiliaryDM, "A",
-                             (PetscObject) _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
+    PetscDMLabel dmLabel = NULL;
+    PetscInt labelValue = 0;
+    err = DMSetAuxiliaryVec(faultAuxiliaryDM, dmLabel, labelValue,
+                            _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
     err = DMProjectFieldLocal(faultAuxiliaryDM, t, slipLocalVec, subfieldKernels, INSERT_VALUES,
                               slipLocalVec);PYLITH_CHECK_ERROR(err);
 
@@ -201,10 +201,10 @@ pylith::faults::KinSrc::updateSlipRate(PetscVec slipRateLocalVec,
     // Create local vector for slip for this source.
     PetscErrorCode err = 0;
     PetscDM faultAuxiliaryDM = faultAuxiliaryField->dmMesh();
-    err = PetscObjectCompose((PetscObject) faultAuxiliaryDM, "dmAux",
-                             (PetscObject) _auxiliaryField->dmMesh());PYLITH_CHECK_ERROR(err);
-    err = PetscObjectCompose((PetscObject) faultAuxiliaryDM, "A",
-                             (PetscObject) _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
+    PetscDMLabel dmLabel = NULL;
+    PetscInt labelValue = 0;
+    err = DMSetAuxiliaryVec(faultAuxiliaryDM, dmLabel, labelValue,
+                            _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
     err = DMProjectFieldLocal(faultAuxiliaryDM, t, slipRateLocalVec, subfieldKernels, INSERT_VALUES,
                               slipRateLocalVec);PYLITH_CHECK_ERROR(err);
 

--- a/libsrc/pylith/feassemble/ConstraintSimple.cc
+++ b/libsrc/pylith/feassemble/ConstraintSimple.cc
@@ -110,8 +110,9 @@ pylith::feassemble::ConstraintSimple::initialize(const pylith::topology::Field& 
         throw std::logic_error(msg.str());
     }
     err = DMPlexRestoreTransitiveClosure(solution.dmMesh(), point, PETSC_FALSE, &clSize, &closure);PYLITH_CHECK_ERROR(err);
-    err = PetscDSAddBoundary(ds, DM_BC_ESSENTIAL, _constraintLabel.c_str(), _constraintLabel.c_str(), i_field,
-                             _constrainedDOF.size(), &_constrainedDOF[0], (void (*)(void))_fn, NULL, 1, &labelId, context);
+    err = DMGetLabel(solution.dmMesh(), _constraintLabel.c_str(), &label);PYLITH_CHECK_ERROR(err);
+    err = PetscDSAddBoundary(ds, DM_BC_ESSENTIAL, _constraintLabel.c_str(), label, 1, &labelId, i_field,
+                             _constrainedDOF.size(), &_constrainedDOF[0], (void (*)(void))_fn, NULL, context, NULL);
     PYLITH_CHECK_ERROR(err);
     err = DMViewFromOptions(dm, NULL, "-constraint_simple_dm_view");PYLITH_CHECK_ERROR(err);
     {

--- a/libsrc/pylith/feassemble/ConstraintSpatialDB.cc
+++ b/libsrc/pylith/feassemble/ConstraintSpatialDB.cc
@@ -77,8 +77,8 @@ pylith::feassemble::ConstraintSpatialDB::initialize(const pylith::topology::Fiel
     // :KLUDGE: Potentially we may have multiple PetscDS objects. This assumes that the first one (with a NULL label) is
     // the correct one.
     PetscDS prob = NULL;
+    PetscDMLabel label = NULL;
     PetscDM dmSoln = solution.dmMesh();assert(dmSoln);
-    DMLabel label;
     PetscErrorCode err = DMGetDS(dmSoln, &prob);PYLITH_CHECK_ERROR(err);assert(prob);
 
     void* context = NULL;
@@ -130,7 +130,6 @@ pylith::feassemble::ConstraintSpatialDB::setSolution(pylith::topology::Field* so
 
     PetscErrorCode err = 0;
     PetscDM dmSoln = solution->dmMesh();
-    PetscDM dmAux = _auxiliaryField->dmMesh();
 
     // Set auxiliary data
     PetscDMLabel dmLabel = NULL;

--- a/libsrc/pylith/feassemble/ConstraintSpatialDB.cc
+++ b/libsrc/pylith/feassemble/ConstraintSpatialDB.cc
@@ -78,14 +78,16 @@ pylith::feassemble::ConstraintSpatialDB::initialize(const pylith::topology::Fiel
     // the correct one.
     PetscDS prob = NULL;
     PetscDM dmSoln = solution.dmMesh();assert(dmSoln);
+    DMLabel label;
     PetscErrorCode err = DMGetDS(dmSoln, &prob);PYLITH_CHECK_ERROR(err);assert(prob);
 
     void* context = NULL;
     const int labelId = 1;
     const PylithInt numConstrained = _constrainedDOF.size();
     const PetscInt i_field = solution.subfieldInfo(_subfieldName.c_str()).index;
-    err = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL_BD_FIELD, _constraintLabel.c_str(), _constraintLabel.c_str(), i_field,
-                             numConstrained, &_constrainedDOF[0], (void (*)())_kernelConstraint, NULL, 1, &labelId, context);PYLITH_CHECK_ERROR(err);
+    err = DMGetLabel(dmSoln, _constraintLabel.c_str(), &label);PYLITH_CHECK_ERROR(err);
+    err = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL_BD_FIELD, _constraintLabel.c_str(), label, 1, &labelId, i_field,
+                             numConstrained, &_constrainedDOF[0], (void (*)())_kernelConstraint, NULL, context, NULL);PYLITH_CHECK_ERROR(err);
 
     PYLITH_METHOD_END;
 } // initialize

--- a/libsrc/pylith/feassemble/ConstraintSpatialDB.cc
+++ b/libsrc/pylith/feassemble/ConstraintSpatialDB.cc
@@ -130,13 +130,13 @@ pylith::feassemble::ConstraintSpatialDB::setSolution(pylith::topology::Field* so
     PetscDM dmSoln = solution->dmMesh();
     PetscDM dmAux = _auxiliaryField->dmMesh();
 
-    // Get label for constraint.
-    PetscDMLabel dmLabel = NULL;
-    err = DMGetLabel(dmSoln, _constraintLabel.c_str(), &dmLabel);PYLITH_CHECK_ERROR(err);
-
     // Set auxiliary data
-    err = PetscObjectCompose((PetscObject) dmSoln, "dmAux", (PetscObject) dmAux);PYLITH_CHECK_ERROR(err);
-    err = PetscObjectCompose((PetscObject) dmSoln, "A", (PetscObject) _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
+    PetscDMLabel dmLabel = NULL;
+    PetscInt labelValue = 0;
+    err = DMSetAuxiliaryVec(dmSoln, dmLabel, labelValue, _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
+
+    // Get label for constraint.
+    err = DMGetLabel(dmSoln, _constraintLabel.c_str(), &dmLabel);PYLITH_CHECK_ERROR(err);
 
     void* context = NULL;
     const int labelId = 1;

--- a/libsrc/pylith/feassemble/ConstraintUserFn.cc
+++ b/libsrc/pylith/feassemble/ConstraintUserFn.cc
@@ -72,12 +72,14 @@ pylith::feassemble::ConstraintUserFn::initialize(const pylith::topology::Field& 
     // the correct one.
     PetscErrorCode err = 0;
     PetscDS prob = NULL;
+    DMLabel label = NULL;
     void* context = NULL;
     const PylithInt labelId = 1;
     err = DMGetDS(solution.dmMesh(), &prob);PYLITH_CHECK_ERROR(err);
     const PetscInt i_field = solution.subfieldInfo(_subfieldName.c_str()).index;
-    err = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL, _constraintLabel.c_str(), _constraintLabel.c_str(), i_field,
-                             _constrainedDOF.size(), &_constrainedDOF[0], (void (*)(void))_fn, NULL, 1, &labelId, context);
+    err = DMGetLabel(solution.dmMesh(), _constraintLabel.c_str(), &label);PYLITH_CHECK_ERROR(err);
+    err = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL, _constraintLabel.c_str(), label, 1, &labelId, i_field,
+                             _constrainedDOF.size(), &_constrainedDOF[0], (void (*)(void))_fn, NULL, context, NULL);
     PYLITH_CHECK_ERROR(err);
 
     PYLITH_METHOD_END;

--- a/libsrc/pylith/feassemble/IntegratorBoundary.cc
+++ b/libsrc/pylith/feassemble/IntegratorBoundary.cc
@@ -313,7 +313,7 @@ pylith::feassemble::_IntegratorBoundary::computeResidual(pylith::topology::Field
     PetscDMLabel dmLabel = NULL;
     err = DMGetLabel(dmSoln, integrator->getMarkerLabel(), &dmLabel);PYLITH_CHECK_ERROR(err);
     const PetscInt labelValue = integrator->getLabelValue();
-    err = DMSetAuxiliaryVec(dmSoln, dmLabel, labelValue, auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
+    err = DMSetAuxiliaryVec(dmSoln, NULL, 0, auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
 
     // solution.mesh().view(":mesh.txt:ascii_info_detail"); // :DEBUG:
 

--- a/libsrc/pylith/feassemble/IntegratorBoundary.cc
+++ b/libsrc/pylith/feassemble/IntegratorBoundary.cc
@@ -307,17 +307,13 @@ pylith::feassemble::_IntegratorBoundary::computeResidual(pylith::topology::Field
     PetscDM dmSoln = solution.dmMesh();assert(dmSoln);
     err = DMGetDS(dmSoln, &prob);PYLITH_CHECK_ERROR(err);assert(prob);
 
-    // Get auxiliary data
-    PetscDM dmAux = auxiliaryField->dmMesh();assert(dmAux);
-    err = PetscObjectCompose((PetscObject) dmSoln, "dmAux", (PetscObject) dmAux);PYLITH_CHECK_ERROR(err);
-    err = PetscObjectCompose((PetscObject) dmSoln, "A", (PetscObject) auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
-
     // Compute the local residual
     assert(solution.localVector());
     assert(residual->localVector());
     PetscDMLabel dmLabel = NULL;
     err = DMGetLabel(dmSoln, integrator->getMarkerLabel(), &dmLabel);PYLITH_CHECK_ERROR(err);
-    const int labelValue = integrator->getLabelValue();
+    const PetscInt labelValue = integrator->getLabelValue();
+    err = DMSetAuxiliaryVec(dmSoln, dmLabel, labelValue, auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
 
     // solution.mesh().view(":mesh.txt:ascii_info_detail"); // :DEBUG:
 

--- a/libsrc/pylith/feassemble/IntegratorBoundary.cc
+++ b/libsrc/pylith/feassemble/IntegratorBoundary.cc
@@ -318,9 +318,11 @@ pylith::feassemble::_IntegratorBoundary::computeResidual(pylith::topology::Field
     // solution.mesh().view(":mesh.txt:ascii_info_detail"); // :DEBUG:
 
     for (size_t i = 0; i < kernels.size(); ++i) {
+        PetscWeakForm wf;
         const PetscInt i_field = solution.subfieldInfo(kernels[i].subfield.c_str()).index;
         err = PetscDSSetBdResidual(prob, i_field, kernels[i].r0, kernels[i].r1);PYLITH_CHECK_ERROR(err);
-        err = DMPlexComputeBdResidualSingle(dmSoln, t, dmLabel, 1, &labelValue, i_field, solution.localVector(), solutionDot.localVector(), residual->localVector());PYLITH_CHECK_ERROR(err);
+        err = PetscDSGetWeakForm(prob, &wf);PYLITH_CHECK_ERROR(err);
+        err = DMPlexComputeBdResidualSingle(dmSoln, t, wf, dmLabel, 1, &labelValue, i_field, solution.localVector(), solutionDot.localVector(), residual->localVector());PYLITH_CHECK_ERROR(err);
     } // for
 
     PYLITH_METHOD_END;

--- a/libsrc/pylith/feassemble/IntegratorBoundary.cc
+++ b/libsrc/pylith/feassemble/IntegratorBoundary.cc
@@ -320,8 +320,8 @@ pylith::feassemble::_IntegratorBoundary::computeResidual(pylith::topology::Field
     for (size_t i = 0; i < kernels.size(); ++i) {
         PetscWeakForm wf;
         const PetscInt i_field = solution.subfieldInfo(kernels[i].subfield.c_str()).index;
-        err = PetscDSSetBdResidual(prob, i_field, kernels[i].r0, kernels[i].r1);PYLITH_CHECK_ERROR(err);
         err = PetscDSGetWeakForm(prob, &wf);PYLITH_CHECK_ERROR(err);
+        err = PetscWeakFormSetIndexBdResidual(wf, dmLabel, labelValue, i_field, 0, kernels[i].r0, 0, kernels[i].r1);PYLITH_CHECK_ERROR(err);
         err = DMPlexComputeBdResidualSingle(dmSoln, t, wf, dmLabel, 1, &labelValue, i_field, solution.localVector(), solutionDot.localVector(), residual->localVector());PYLITH_CHECK_ERROR(err);
     } // for
 

--- a/libsrc/pylith/feassemble/IntegratorDomain.cc
+++ b/libsrc/pylith/feassemble/IntegratorDomain.cc
@@ -284,9 +284,9 @@ pylith::feassemble::IntegratorDomain::computeLHSJacobianLumpedInv(pylith::topolo
     } // for
 
     // Get auxiliary data
-    PetscDM dmAux = _auxiliaryField->dmMesh();assert(dmAux);
-    err = PetscObjectCompose((PetscObject) dmSoln, "dmAux", (PetscObject) dmAux);PYLITH_CHECK_ERROR(err);
-    err = PetscObjectCompose((PetscObject) dmSoln, "A", (PetscObject) _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
+    PetscDMLabel dmLabel = NULL;
+    PetscInt labelValue = 0;
+    err = DMSetAuxiliaryVec(dmSoln, dmLabel, labelValue, _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
 
     PetscVec vecRowSum = NULL;
     err = DMGetLocalVector(dmSoln, &vecRowSum);PYLITH_CHECK_ERROR(err);
@@ -336,8 +336,10 @@ pylith::feassemble::IntegratorDomain::_updateStateVars(const PylithReal t,
 
     PetscErrorCode err = 0;
     PetscDM stateVarsDM = _updateState->stateVarsDM();
-    err = PetscObjectCompose((PetscObject) stateVarsDM, "dmAux", (PetscObject) _auxiliaryField->dmMesh());PYLITH_CHECK_ERROR(err);
-    err = PetscObjectCompose((PetscObject) stateVarsDM, "A", (PetscObject) _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
+    PetscDMLabel dmLabel = NULL;
+    PetscInt labelValue = 0;
+    err = DMSetAuxiliaryVec(stateVarsDM, dmLabel, labelValue,
+                            _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
     err = DMProjectFieldLocal(stateVarsDM, t, solution.localVector(), kernelsStateVars, INSERT_VALUES,
                               _updateState->stateVarsLocalVector());PYLITH_CHECK_ERROR(err);
     _updateState->restore(_auxiliaryField);
@@ -375,9 +377,9 @@ pylith::feassemble::IntegratorDomain::_computeDerivedField(const PylithReal t,
 
     PetscDM derivedDM = _derivedField->dmMesh();
     assert(_auxiliaryField);
-    err = PetscObjectCompose((PetscObject) derivedDM, "dmAux", (PetscObject) _auxiliaryField->dmMesh());PYLITH_CHECK_ERROR(err);
-    err = PetscObjectCompose((PetscObject) derivedDM, "A", (PetscObject) _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
-
+    PetscDMLabel dmLabel = NULL;
+    PetscInt labelValue = 0;
+    err = DMSetAuxiliaryVec(derivedDM, dmLabel, labelValue, _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
     err = DMProjectFieldLocal(derivedDM, t, solution.localVector(), kernelsArray, INSERT_VALUES, _derivedField->localVector());PYLITH_CHECK_ERROR(err);
     delete[] kernelsArray;kernelsArray = NULL;
 
@@ -412,7 +414,6 @@ pylith::feassemble::IntegratorDomain::_computeResidual(pylith::topology::Field* 
     PetscErrorCode err;
 
     PetscDM dmSoln = solution.dmMesh();
-    PetscDM dmAux = _auxiliaryField->dmMesh();
 
     PetscHashFormKey key;
     key.label = NULL;
@@ -430,8 +431,9 @@ pylith::feassemble::IntegratorDomain::_computeResidual(pylith::topology::Field* 
     } // for
 
     // Get auxiliary data
-    err = PetscObjectCompose((PetscObject) dmSoln, "dmAux", (PetscObject) dmAux);PYLITH_CHECK_ERROR(err);
-    err = PetscObjectCompose((PetscObject) dmSoln, "A", (PetscObject) _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
+    PetscDMLabel dmLabel = NULL;
+    PetscInt labelValue = 0;
+    err = DMSetAuxiliaryVec(dmSoln, dmLabel, labelValue, _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
 
     // Compute the local residual
     assert(solution.localVector());
@@ -468,7 +470,6 @@ pylith::feassemble::IntegratorDomain::_computeJacobian(PetscMat jacobianMat,
     PetscIS cellsIS = NULL;
     PetscErrorCode err;
     PetscDM dmSoln = solution.dmMesh();
-    PetscDM dmAux = _auxiliaryField->dmMesh();
 
     PetscHashFormKey key;
     key.label = NULL;
@@ -487,8 +488,9 @@ pylith::feassemble::IntegratorDomain::_computeJacobian(PetscMat jacobianMat,
     } // for
 
     // Get auxiliary data
-    err = PetscObjectCompose((PetscObject) dmSoln, "dmAux", (PetscObject) dmAux);PYLITH_CHECK_ERROR(err);
-    err = PetscObjectCompose((PetscObject) dmSoln, "A", (PetscObject) _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
+    PetscDMLabel dmLabel = NULL;
+    PetscInt labelValue = 0;
+    err = DMSetAuxiliaryVec(dmSoln, dmLabel, labelValue, _auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
 
     // Compute the local Jacobian
     assert(solution.localVector());

--- a/libsrc/pylith/feassemble/IntegratorInterface.cc
+++ b/libsrc/pylith/feassemble/IntegratorInterface.cc
@@ -469,7 +469,6 @@ pylith::feassemble::_IntegratorInterface::computeJacobian(PetscMat jacobianMat,
         const PetscInt i_fieldBasis = solution.subfieldInfo(kernels[i].subfieldBasis.c_str()).index;
         err = PetscDSSetBdJacobian(prob, i_fieldTrial, i_fieldBasis, kernels[i].j0, kernels[i].j1, kernels[i].j2, kernels[i].j3);PYLITH_CHECK_ERROR(err);
     } // for
-    PetscDSView(prob, PETSC_VIEWER_STDOUT_WORLD);
 
     assert(solution.localVector());
     err = DMPlexComputeJacobian_Hybrid_Internal(dmSoln, cohesiveCells, t, s_tshift, solution.localVector(),

--- a/libsrc/pylith/feassemble/IntegratorInterface.cc
+++ b/libsrc/pylith/feassemble/IntegratorInterface.cc
@@ -385,8 +385,9 @@ pylith::feassemble::_IntegratorInterface::computeResidual(pylith::topology::Fiel
     err = DMGetCellDS(dmSoln, cellIndices[0], &prob);PYLITH_CHECK_ERROR(err);
 
     // Get auxiliary data
-    err = PetscObjectCompose((PetscObject) dmSoln, "dmAux", (PetscObject) dmAux);PYLITH_CHECK_ERROR(err);
-    err = PetscObjectCompose((PetscObject) dmSoln, "A", (PetscObject) auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
+    PetscDMLabel dmLabel = NULL;
+    PetscInt labelValue = 0;
+    err = DMSetAuxiliaryVec(dmSoln, dmLabel, labelValue, auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
 
     PetscHashFormKey keys[3];
     keys[0].label = NULL;
@@ -458,8 +459,9 @@ pylith::feassemble::_IntegratorInterface::computeJacobian(PetscMat jacobianMat,
     err = DMGetCellDS(dmSoln, cellIndices[0], &prob);PYLITH_CHECK_ERROR(err);
 
     // Get auxiliary data
-    err = PetscObjectCompose((PetscObject) dmSoln, "dmAux", (PetscObject) dmAux);PYLITH_CHECK_ERROR(err);
-    err = PetscObjectCompose((PetscObject) dmSoln, "A", (PetscObject) auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
+    PetscDMLabel dmLabel = NULL;
+    PetscInt labelValue = 0;
+    err = DMSetAuxiliaryVec(dmSoln, dmLabel, labelValue, auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
 
     // Compute the local Jacobian
     for (size_t i = 0; i < kernels.size(); ++i) {
@@ -467,6 +469,7 @@ pylith::feassemble::_IntegratorInterface::computeJacobian(PetscMat jacobianMat,
         const PetscInt i_fieldBasis = solution.subfieldInfo(kernels[i].subfieldBasis.c_str()).index;
         err = PetscDSSetBdJacobian(prob, i_fieldTrial, i_fieldBasis, kernels[i].j0, kernels[i].j1, kernels[i].j2, kernels[i].j3);PYLITH_CHECK_ERROR(err);
     } // for
+    PetscDSView(prob, PETSC_VIEWER_STDOUT_WORLD);
 
     assert(solution.localVector());
     err = DMPlexComputeJacobian_Hybrid_Internal(dmSoln, cohesiveCells, t, s_tshift, solution.localVector(),

--- a/libsrc/pylith/problems/TimeDependent.cc
+++ b/libsrc/pylith/problems/TimeDependent.cc
@@ -304,7 +304,6 @@ pylith::problems::TimeDependent::initialize(void) {
     err = TSCreate(mesh.comm(), &_ts);PYLITH_CHECK_ERROR(err);assert(_ts);
     err = TSSetType(_ts, TSBEULER);PYLITH_CHECK_ERROR(err); // Backward Euler is default time stepping method.
     err = TSSetExactFinalTime(_ts, TS_EXACTFINALTIME_STEPOVER);PYLITH_CHECK_ERROR(err); // Ok to step over final time.
-    err = TSSetFromOptions(_ts);PYLITH_CHECK_ERROR(err);
     err = TSSetApplicationContext(_ts, (void*)this);PYLITH_CHECK_ERROR(err);
 
     // Set time stepping paramters.
@@ -379,6 +378,9 @@ pylith::problems::TimeDependent::initialize(void) {
         PYLITH_COMPONENT_FIREWALL("Unknown time stepping formulation '" << _formulation << "'.");
     } // default
     } // switch
+
+    err = TSSetFromOptions(_ts);PYLITH_CHECK_ERROR(err);
+    err = TSSetUp(_ts);PYLITH_CHECK_ERROR(err);
 
 #if 0
     // Set solve type for solution fields defined over the domain (not Lagrange multipliers).

--- a/libsrc/pylith/testing/MMSTest.cc
+++ b/libsrc/pylith/testing/MMSTest.cc
@@ -187,7 +187,7 @@ pylith::testing::MMSTest::testJacobianFiniteDiff(void) {
 
     pythia::journal::debug_t debug(GenericComponent::getName());
     if (debug.state()) {
-        err = PetscOptionsSetValue(NULL, "-snes_test_jacobian_view", "::ascii_info_detail");CPPUNIT_ASSERT(!err);
+        err = PetscOptionsSetValue(NULL, "-snes_test_jacobian_view", "");CPPUNIT_ASSERT(!err);
     } // if
     err = PetscOptionsSetValue(NULL, "-snes_test_jacobian", "1.0e-6");CPPUNIT_ASSERT(!err);
     err = PetscOptionsSetValue(NULL, "-snes_error_if_not_converged", "false");CPPUNIT_ASSERT(!err);

--- a/tests/libtests/topology/TestFieldMesh.cc
+++ b/tests/libtests/topology/TestFieldMesh.cc
@@ -614,11 +614,15 @@ pylith::topology::TestFieldMesh::_initialize(void) {
     _field->subfieldAdd(_data->descriptionB, _data->discretizationB);
     _field->subfieldsSetup();
 
-    err = DMAddBoundary(_field->dmMesh(), DM_BC_ESSENTIAL, "bcA", _data->bcALabel, 0, _data->bcANumConstrainedDOF,
-                        _data->bcAConstrainedDOF, NULL, NULL, 1, &_data->bcALabelId, NULL);CPPUNIT_ASSERT(!err);
-    err = DMAddBoundary(_field->dmMesh(), DM_BC_ESSENTIAL, "bcB", _data->bcBLabel, 0, _data->bcBNumConstrainedDOF,
-                        _data->bcBConstrainedDOF, NULL, NULL, 1, &_data->bcBLabelId, NULL);CPPUNIT_ASSERT(!err);
-
+    PetscDMLabel labelA = NULL, labelB = NULL;
+    err = DMGetLabel(_field->dmMesh(), _data->bcALabel, &labelA);CPPUNIT_ASSERT(!err);
+    err = DMGetLabel(_field->dmMesh(), _data->bcBLabel, &labelB);CPPUNIT_ASSERT(!err);
+    const PetscInt numLabelValues = 1;
+    const PetscInt i_field = 1;
+    err = DMAddBoundary(_field->dmMesh(), DM_BC_ESSENTIAL, "bcA", labelA, numLabelValues, &_data->bcALabelId, i_field,
+                        _data->bcANumConstrainedDOF, _data->bcAConstrainedDOF, NULL, NULL, NULL, NULL);CPPUNIT_ASSERT(!err);
+    err = DMAddBoundary(_field->dmMesh(), DM_BC_ESSENTIAL, "bcB", labelB, numLabelValues, &_data->bcBLabelId, i_field,
+                        _data->bcBNumConstrainedDOF, _data->bcBConstrainedDOF, NULL, NULL, NULL, NULL);CPPUNIT_ASSERT(!err);
     // Allocate field.
     _field->allocate();
 


### PR DESCRIPTION
* Need to use `PetscWeakForm` for boundary integration.
* Use `DMSetAuxiliaryVector()` instead of `PetscObjectCompose()` to set auxiliary vector in integration and projection.

For now, PETSc uses (label=NULL, labelValue=0) when getting the auxiliary vector from the PetscDM, so we must do the same when setting the auxiliary vector. Later, PETSc will use the label and label value.

Closes #260 