### PR TITLE
Updates for using weak form key with integration part. Some small code clean up.

### DIFF
--- a/docker/pylith-testenv
+++ b/docker/pylith-testenv
@@ -52,7 +52,7 @@ ENV PETSC_DIR=${INSTALL_DIR}/petsc  PETSC_ARCH=arch-pylith
 RUN git clone --branch knepley/pylith --single-branch https://gitlab.com/petsc/petsc.git ${PETSC_DIR}
 WORKDIR ${PETSC_DIR}
 
-RUN python3 ./configure --download-chaco=1 --download-ml=1 --download-f2cblaslapack=1 --with-hdf5=1 --with-hdf5-include=${HDF5_INCDIR} --with-hdf5-lib=${HDF5_LIBDIR}/lib/libhdf5.so --with-zlib=1 --LIBS=-lz --with-debugging=1 --with-fc=0 --with-64-bit-points=1 --with-large-file-io=1 CPPFLAGS="-I${INSTALL_DIR}/depenencies/include" LDFLAGS="-L${INSTALL_DIR}/dependencies/lib" CFLAGS="-g -O" && make -j$(nproc) && make check
+RUN python3 ./configure --download-chaco=1 --download-ml=1 --download-f2cblaslapack=1 --with-hdf5=1 --with-hdf5-include=${HDF5_INCDIR} --with-hdf5-lib=${HDF5_LIBDIR}/libhdf5.so --with-zlib=1 --LIBS=-lz --with-debugging=1 --with-fc=0 --with-64-bit-points=1 --with-large-file-io=1 CPPFLAGS="-I${INSTALL_DIR}/depenencies/include" LDFLAGS="-L${INSTALL_DIR}/dependencies/lib" CFLAGS="-g -O" && make -j$(nproc) && make check
 
 
 # ------------------------------------------------------------------------------

--- a/libsrc/pylith/feassemble/Integrator.hh
+++ b/libsrc/pylith/feassemble/Integrator.hh
@@ -39,6 +39,16 @@ class pylith::feassemble::Integrator : public pylith::feassemble::PhysicsImpleme
     // PUBLIC ENUM /////////////////////////////////////////////////////////////////////////////////////////////////////
 public:
 
+    enum ResidualPart {
+        RESIDUAL_LHS=0, // LHS residual.
+        RESIDUAL_RHS=1, // RHS residual.
+    };
+
+    enum JacobianPart {
+        JACOBIAN_LHS=0, // LHS Jacobian.
+        JACOBIAN_LHS_LUMPED_INV=1, // Inverse of LHS lumped Jacobian.
+    };
+
     enum NewJacobianTriggers {
         NEW_JACOBIAN_NEVER=0x0, // Never needs new Jacobian.
         NEW_JACOBIAN_ALWAYS=0x1, // Always needs new Jacobian.

--- a/libsrc/pylith/feassemble/IntegratorBoundary.cc
+++ b/libsrc/pylith/feassemble/IntegratorBoundary.cc
@@ -314,8 +314,9 @@ pylith::feassemble::_IntegratorBoundary::computeResidual(pylith::topology::Field
       // Must use PetscWeakFormAddBdResidual() when moved to initialization.
         for (size_t i = 0; i < kernels.size(); ++i) {
             const PetscInt i_field = solution.subfieldInfo(kernels[i].subfield.c_str()).index;
-            err = PetscWeakFormSetIndexBdResidual(weakForm, dmLabel, labelValue, i_field, 0, 0, kernels[i].r0, 0,
-                                                  kernels[i].r1);PYLITH_CHECK_ERROR(err);
+            const PetscInt i_part = pylith::feassemble::Integrator::RESIDUAL_LHS;
+            err = PetscWeakFormSetIndexBdResidual(weakForm, dmLabel, labelValue, i_field, i_part,
+                                                  0, kernels[i].r0, 0, kernels[i].r1);PYLITH_CHECK_ERROR(err);
         } // for
         if (debug.state()) {
             err = PetscDSView(dsSoln, PETSC_VIEWER_STDOUT_WORLD);PYLITH_CHECK_ERROR(err);

--- a/libsrc/pylith/feassemble/IntegratorBoundary.cc
+++ b/libsrc/pylith/feassemble/IntegratorBoundary.cc
@@ -314,7 +314,7 @@ pylith::feassemble::_IntegratorBoundary::computeResidual(pylith::topology::Field
       // Must use PetscWeakFormAddBdResidual() when moved to initialization.
         for (size_t i = 0; i < kernels.size(); ++i) {
             const PetscInt i_field = solution.subfieldInfo(kernels[i].subfield.c_str()).index;
-            err = PetscWeakFormSetIndexBdResidual(weakForm, dmLabel, labelValue, i_field, 0, kernels[i].r0, 0,
+            err = PetscWeakFormSetIndexBdResidual(weakForm, dmLabel, labelValue, i_field, 0, 0, kernels[i].r0, 0,
                                                   kernels[i].r1);PYLITH_CHECK_ERROR(err);
         } // for
         if (debug.state()) {

--- a/libsrc/pylith/feassemble/IntegratorDomain.cc
+++ b/libsrc/pylith/feassemble/IntegratorDomain.cc
@@ -298,8 +298,10 @@ pylith::feassemble::IntegratorDomain::computeLHSJacobianLumpedInv(pylith::topolo
         for (size_t i = 0; i < kernels.size(); ++i) {
             const PetscInt i_fieldTrial = solution.subfieldInfo(kernels[i].subfieldTrial.c_str()).index;
             const PetscInt i_fieldBasis = solution.subfieldInfo(kernels[i].subfieldBasis.c_str()).index;
-            err = PetscWeakFormSetIndexJacobian(weakForm, dmLabel, labelValue, i_fieldTrial, i_fieldBasis, 0,
-                                                0, kernels[i].j0, 0, kernels[i].j1, 0, kernels[i].j2, 0, kernels[i].j3);
+            const PetscInt i_part = pylith::feassemble::Integrator::JACOBIAN_LHS_LUMPED_INV;
+            const PetscInt index = 0;
+            err = PetscWeakFormSetIndexJacobian(weakForm, dmLabel, labelValue, i_fieldTrial, i_fieldBasis, i_part,
+                                                index, kernels[i].j0, index, kernels[i].j1, index, kernels[i].j2, index, kernels[i].j3);
             PYLITH_CHECK_ERROR(err);
         } // for
         pythia::journal::debug_t debug(GenericComponent::getName());
@@ -318,7 +320,7 @@ pylith::feassemble::IntegratorDomain::computeLHSJacobianLumpedInv(pylith::topolo
     PetscFormKey key;
     key.label = dmLabel;
     key.value = _labelValue;
-    key.part  = 0;
+    key.part = pylith::feassemble::Integrator::JACOBIAN_LHS_LUMPED_INV;
 
     PetscIS cellsIS = NULL;
     assert(jacobianInv->localVector());
@@ -452,8 +454,11 @@ pylith::feassemble::IntegratorDomain::_computeResidual(pylith::topology::Field* 
         // Must use PetscWeakFormAddBdResidual() when moved to initialization.
         for (size_t i = 0; i < kernels.size(); ++i) {
             const PetscInt i_field = solution.subfieldInfo(kernels[i].subfield.c_str()).index;
-            err = PetscWeakFormSetIndexResidual(weakForm, dmLabel, _labelValue, i_field, 0, 0, kernels[i].r0, 0,
-                                                kernels[i].r1);PYLITH_CHECK_ERROR(err);
+            const PetscInt i_part = pylith::feassemble::Integrator::RESIDUAL_LHS; // :TODO: Update when moved to
+                                                                                  // initialization.
+            const PetscInt index = 0;
+            err = PetscWeakFormSetIndexResidual(weakForm, dmLabel, _labelValue, i_field, i_part,
+                                                index, kernels[i].r0, index, kernels[i].r1);PYLITH_CHECK_ERROR(err);
         } // for
         pythia::journal::debug_t debug(GenericComponent::getName());
         if (debug.state()) {
@@ -467,7 +472,7 @@ pylith::feassemble::IntegratorDomain::_computeResidual(pylith::topology::Field* 
     PetscFormKey key;
     key.label = dmLabel;
     key.value = _labelValue;
-    key.part  = 0;
+    key.part = pylith::feassemble::Integrator::RESIDUAL_LHS; // Update when initialization moves.
 
     PYLITH_JOURNAL_DEBUG("DMPlexComputeResidual_Internal() with label name '"<<_labelName<<"' and value '"<<_labelValue<<").");
     assert(solution.localVector());
@@ -518,8 +523,10 @@ pylith::feassemble::IntegratorDomain::_computeJacobian(PetscMat jacobianMat,
         for (size_t i = 0; i < kernels.size(); ++i) {
             const PetscInt i_fieldTrial = solution.subfieldInfo(kernels[i].subfieldTrial.c_str()).index;
             const PetscInt i_fieldBasis = solution.subfieldInfo(kernels[i].subfieldBasis.c_str()).index;
-            err = PetscWeakFormSetIndexJacobian(weakForm, dmLabel, _labelValue, i_fieldTrial, i_fieldBasis, 0,
-                                                0, kernels[i].j0, 0, kernels[i].j1, 0, kernels[i].j2, 0, kernels[i].j3);
+            const PetscInt i_part = pylith::feassemble::Integrator::JACOBIAN_LHS;
+            const PetscInt index = 0;
+            err = PetscWeakFormSetIndexJacobian(weakForm, dmLabel, _labelValue, i_fieldTrial, i_fieldBasis, i_part,
+                                                index, kernels[i].j0, index, kernels[i].j1, index, kernels[i].j2, index, kernels[i].j3);
             PYLITH_CHECK_ERROR(err);
         } // for
         pythia::journal::debug_t debug(GenericComponent::getName());
@@ -534,7 +541,7 @@ pylith::feassemble::IntegratorDomain::_computeJacobian(PetscMat jacobianMat,
     PetscFormKey key;
     key.label = dmLabel;
     key.value = _labelValue;
-    key.part  = 0;
+    key.part = pylith::feassemble::Integrator::JACOBIAN_LHS;
 
     PYLITH_JOURNAL_DEBUG("DMPlexComputeJacobian_Internal() with label name '"<<_labelName<<"' and value '"<<_labelValue<<".");
     assert(solution.localVector());

--- a/libsrc/pylith/feassemble/IntegratorInterface.cc
+++ b/libsrc/pylith/feassemble/IntegratorInterface.cc
@@ -36,7 +36,7 @@
 #include <stdexcept> // USES std::runtime_error
 
 extern "C" PetscErrorCode DMPlexComputeResidual_Hybrid_Internal(PetscDM dm,
-                                                                PetscHashFormKey key[],
+                                                                PetscFormKey key[],
                                                                 PetscIS cellIS,
                                                                 PetscReal time,
                                                                 PetscVec locX,
@@ -46,7 +46,7 @@ extern "C" PetscErrorCode DMPlexComputeResidual_Hybrid_Internal(PetscDM dm,
                                                                 void *user);
 
 extern "C" PetscErrorCode DMPlexComputeJacobian_Hybrid_Internal(PetscDM dm,
-                                                                PetscHashFormKey key[],
+                                                                PetscFormKey key[],
                                                                 PetscIS cellIS,
                                                                 PetscReal t,
                                                                 PetscReal X_tShift,
@@ -389,16 +389,19 @@ pylith::feassemble::_IntegratorInterface::computeResidual(pylith::topology::Fiel
     PetscInt labelValue = 0;
     err = DMSetAuxiliaryVec(dmSoln, dmLabel, labelValue, auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
 
-    PetscHashFormKey keys[3];
+    PetscFormKey keys[3];
     keys[0].label = NULL;
     keys[0].value = 0;
     keys[0].field = 0;
+    keys[0].part  = 0;
     keys[1].label = NULL;
     keys[1].value = 0;
     keys[1].field = 0;
+    keys[1].part  = 0;
     keys[2].label = NULL;
     keys[2].value = 0;
     keys[2].field = 0;
+    keys[2].part  = 0;
 
     // Compute the local residual
     assert(solution.localVector());
@@ -462,16 +465,19 @@ pylith::feassemble::_IntegratorInterface::computeJacobian(PetscMat jacobianMat,
     PetscInt labelValue = 0;
     err = DMSetAuxiliaryVec(dmSoln, dmLabel, labelValue, auxiliaryField->localVector());PYLITH_CHECK_ERROR(err);
 
-    PetscHashFormKey keys[3];
+    PetscFormKey keys[3];
     keys[0].label = NULL;
     keys[0].value = 0;
     keys[0].field = 0;
+    keys[0].part  = 0;
     keys[1].label = NULL;
     keys[1].value = 0;
     keys[1].field = 0;
+    keys[1].part  = 0;
     keys[2].label = NULL;
     keys[2].value = 0;
     keys[2].field = 0;
+    keys[2].part  = 0;
 
     // Compute the local Jacobian
     for (size_t i = 0; i < kernels.size(); ++i) {

--- a/libsrc/pylith/meshio/MeshBuilder.cc
+++ b/libsrc/pylith/meshio/MeshBuilder.cc
@@ -41,26 +41,28 @@ pylith::meshio::MeshBuilder::buildMesh(topology::Mesh* mesh,
                                        const int numCells,
                                        const int numCorners,
                                        const int meshDim,
-                                       const bool isParallel)
-{ // buildMesh
+                                       const bool isParallel) { // buildMesh
     PYLITH_METHOD_BEGIN;
 
     assert(mesh);
     assert(coordinates);
-    MPI_Comm comm  = mesh->comm();
-    PetscInt dim  = meshDim;
+    MPI_Comm comm = mesh->comm();
+    PetscInt dim = meshDim;
     PetscErrorCode err;
 
     { // Check to make sure every vertex is in at least one cell.
       // This is required by PETSc
         std::vector<bool> vertexInCell(numVertices, false);
         const int size = cells.size();
-        for (int i=0; i < size; ++i)
+        for (int i = 0; i < size; ++i) {
             vertexInCell[cells[i]] = true;
+        }
         int count = 0;
-        for (int i=0; i < numVertices; ++i)
-            if (!vertexInCell[i])
+        for (int i = 0; i < numVertices; ++i) {
+            if (!vertexInCell[i]) {
                 ++count;
+            }
+        }
         if (count > 0) {
             std::ostringstream msg;
             msg << "Mesh contains " << count << " vertices that are not in any cells.";
@@ -72,25 +74,26 @@ pylith::meshio::MeshBuilder::buildMesh(topology::Mesh* mesh,
     PetscDM dmMesh = NULL;
     PetscBool interpolate = PETSC_TRUE; /* interpolate = interpolate ? PETSC_TRUE : PETSC_FALSE; */
 
-    err = MPI_Bcast(&dim, 1, MPIU_INT, 0, comm); PYLITH_CHECK_ERROR(err);
-    err = MPI_Bcast(&spaceDim, 1, MPIU_INT, 0, comm); PYLITH_CHECK_ERROR(err);
+    err = MPI_Bcast(&dim, 1, MPIU_INT, 0, comm);PYLITH_CHECK_ERROR(err);
+    err = MPI_Bcast(&spaceDim, 1, MPIU_INT, 0, comm);PYLITH_CHECK_ERROR(err);
     const PetscInt bound = numCells*numCorners;
     for (PetscInt coff = 0; coff < bound; coff += numCorners) {
-      DMPolytopeType ct;
+        DMPolytopeType ct;
 
-      if (dim < 3) continue;
-      switch (numCorners) {
+        if (dim < 3) { continue;}
+        switch (numCorners) {
         case 4: ct = DM_POLYTOPE_TETRAHEDRON;break;
         case 6: ct = DM_POLYTOPE_TRI_PRISM;break;
         case 8: ct = DM_POLYTOPE_HEXAHEDRON;break;
         default: continue;
-      }
-      err = DMPlexInvertCell(ct, (int *) &cells[coff]); PYLITH_CHECK_ERROR(err);
+        }
+        err = DMPlexInvertCell(ct, (int *) &cells[coff]);PYLITH_CHECK_ERROR(err);
     }
-    err = DMPlexCreateFromCellList(comm, dim, numCells, numVertices, numCorners, interpolate, &cells[0], spaceDim, &(*coordinates)[0], &dmMesh); PYLITH_CHECK_ERROR(err);
+    err = DMPlexCreateFromCellListPetsc(comm, dim, numCells, numVertices, numCorners, interpolate, &cells[0], spaceDim, &(*coordinates)[0], &dmMesh);PYLITH_CHECK_ERROR(err);
     mesh->dmMesh(dmMesh);
 
     PYLITH_METHOD_END;
 } // buildMesh
+
 
 // End of file

--- a/libsrc/pylith/topology/FieldQuery.cc
+++ b/libsrc/pylith/topology/FieldQuery.cc
@@ -400,6 +400,7 @@ pylith::topology::_FieldQuery::findQueryIndices(FieldQuery::DBQueryContext* cont
         if (!foundName) {
             std::ostringstream msg;
             if (0 == numDBValues) {
+                delete dbValues;dbValues = NULL;
                 msg << "No values found in spatial database '"
                     << context->db->getLabel() << "'. Did you forget to open the database?";
                 throw std::logic_error(msg.str());
@@ -410,9 +411,11 @@ pylith::topology::_FieldQuery::findQueryIndices(FieldQuery::DBQueryContext* cont
                 msg << "\n  " << dbValues[iValueDB];
             } // for
             msg << "\n";
+            delete dbValues;dbValues = NULL;
             throw std::out_of_range(msg.str());
         } // if
     } // for
+    delete[] dbValues;dbValues = NULL;
 
     context->queryValues.resize(numDBValues);
 } // findQueryIndices

--- a/tests/libtests/meshio/TestMeshIO.cc
+++ b/tests/libtests/meshio/TestMeshIO.cc
@@ -119,7 +119,7 @@ pylith::meshio::TestMeshIO::_createMesh(void) { // _createMesh
     for (PylithInt coff = 0; coff < bound; coff += data->numCorners) {
         err = DMPlexInvertCell_Private(data->cellDim, data->numCorners, &cells[coff]);PYLITH_CHECK_ERROR(err);
     } // for
-    err = DMPlexCreateFromCellList(_mesh->comm(), data->cellDim, data->numCells, data->numVertices, data->numCorners, interpolateMesh, cells, data->spaceDim, data->vertices, &dmMesh);PYLITH_CHECK_ERROR(err);
+    err = DMPlexCreateFromCellListPetsc(_mesh->comm(), data->cellDim, data->numCells, data->numVertices, data->numCorners, interpolateMesh, cells, data->spaceDim, data->vertices, &dmMesh);PYLITH_CHECK_ERROR(err);
     delete [] cells;
     _mesh->dmMesh(dmMesh);
 

--- a/tests/libtests/topology/TestFieldMesh.cc
+++ b/tests/libtests/topology/TestFieldMesh.cc
@@ -613,14 +613,16 @@ pylith::topology::TestFieldMesh::_initialize(void) {
     _field->subfieldAdd(_data->descriptionA, _data->discretizationA);
     _field->subfieldAdd(_data->descriptionB, _data->discretizationB);
     _field->subfieldsSetup();
+    _field->createDiscretization();
 
     PetscDMLabel labelA = NULL, labelB = NULL;
     err = DMGetLabel(_field->dmMesh(), _data->bcALabel, &labelA);CPPUNIT_ASSERT(!err);
     err = DMGetLabel(_field->dmMesh(), _data->bcBLabel, &labelB);CPPUNIT_ASSERT(!err);
     const PetscInt numLabelValues = 1;
-    const PetscInt i_field = 1;
+    PetscInt i_field = 0;
     err = DMAddBoundary(_field->dmMesh(), DM_BC_ESSENTIAL, "bcA", labelA, numLabelValues, &_data->bcALabelId, i_field,
                         _data->bcANumConstrainedDOF, _data->bcAConstrainedDOF, NULL, NULL, NULL, NULL);CPPUNIT_ASSERT(!err);
+    i_field = 1;
     err = DMAddBoundary(_field->dmMesh(), DM_BC_ESSENTIAL, "bcB", labelB, numLabelValues, &_data->bcBLabelId, i_field,
                         _data->bcBNumConstrainedDOF, _data->bcBConstrainedDOF, NULL, NULL, NULL, NULL);CPPUNIT_ASSERT(!err);
     // Allocate field.

--- a/tests/mmstests/elasticity/Makefile.am
+++ b/tests/mmstests/elasticity/Makefile.am
@@ -84,7 +84,7 @@ endif
 dist_noinst_DATA = \
 	data/tri.mesh \
 	data/quad.mesh \
-        data/quad_distorted.mesh \
+	data/quad_distorted.mesh \
 	data/tet.mesh \
 	data/hex.mesh \
 	data/tri_twocells.mesh \

--- a/tests/mmstests/elasticity/TestIsotropicLinearElasticity2D_UniformStrain.cc
+++ b/tests/mmstests/elasticity/TestIsotropicLinearElasticity2D_UniformStrain.cc
@@ -370,9 +370,7 @@ class pylith::mmstests::TestIsotropicLinearElasticity2D_UniformStrain_QuadQ1Dist
     } // setUp
 
 }; // TestIsotropicLinearElasticity2D_UniformStrain_QuadQ1Distorted
-// :TODO: This test exposes a known bug in PETSc with distorted quad cells.
-// Once @knepley fixes the error, we will enable test.
-// CPPUNIT_TEST_SUITE_REGISTRATION(pylith::mmstests::TestIsotropicLinearElasticity2D_UniformStrain_QuadQ1Distorted);
+CPPUNIT_TEST_SUITE_REGISTRATION(pylith::mmstests::TestIsotropicLinearElasticity2D_UniformStrain_QuadQ1Distorted);
 
 // ---------------------------------------------------------------------------------------------------------------------
 class pylith::mmstests::TestIsotropicLinearElasticity2D_UniformStrain_QuadQ2 :


### PR DESCRIPTION
* Updates for changes to PETSc weak form key (add integration part).
* Add distorted quad mesh to MMS elasticity test.
* A couple small fixes for simple memory errors.

Closes #285
Closes #274
