### PR TITLE
Add time derivative of field to DirichletUserFn

### DIFF
--- a/libsrc/pylith/bc/AbsorbingDampers.cc
+++ b/libsrc/pylith/bc/AbsorbingDampers.cc
@@ -173,7 +173,6 @@ pylith::bc::AbsorbingDampers::createAuxiliaryField(const pylith::topology::Field
     auxiliaryField->createDiscretization();
     pylith::topology::FieldOps::checkDiscretization(solution, *auxiliaryField);
     auxiliaryField->allocate();
-    auxiliaryField->zeroLocal();
     auxiliaryField->createOutputVector();
 
     assert(_auxiliaryFactory);

--- a/libsrc/pylith/bc/DirichletTimeDependent.cc
+++ b/libsrc/pylith/bc/DirichletTimeDependent.cc
@@ -292,7 +292,6 @@ pylith::bc::DirichletTimeDependent::createAuxiliaryField(const pylith::topology:
     auxiliaryField->createDiscretization();
     pylith::topology::FieldOps::checkDiscretization(solution, *auxiliaryField);
     auxiliaryField->allocate();
-    auxiliaryField->zeroLocal();
     auxiliaryField->createOutputVector();
 
     assert(_auxiliaryFactory);

--- a/libsrc/pylith/bc/DirichletUserFn.cc
+++ b/libsrc/pylith/bc/DirichletUserFn.cc
@@ -38,7 +38,8 @@
 // ---------------------------------------------------------------------------------------------------------------------
 // Default constructor.
 pylith::bc::DirichletUserFn::DirichletUserFn(void) :
-    _fn(NULL) {
+    _fn(NULL),
+    _fnDot(NULL) {
     PyreComponent::setName("dirichletuserfn");
 } // constructor
 
@@ -86,7 +87,7 @@ pylith::bc::DirichletUserFn::getConstrainedDOF(void) const {
 
 
 // ---------------------------------------------------------------------------------------------------------------------
-// Set time history database.
+// Set user function specifying field on boundary.
 void
 pylith::bc::DirichletUserFn::setUserFn(PetscUserFieldFunc fn) {
     PYLITH_COMPONENT_DEBUG("setUserFn(fn="<<fn<<")");
@@ -96,11 +97,29 @@ pylith::bc::DirichletUserFn::setUserFn(PetscUserFieldFunc fn) {
 
 
 // ---------------------------------------------------------------------------------------------------------------------
-// Get time history database.
+// Get user function specifying field on boundary.
 PetscUserFieldFunc
 pylith::bc::DirichletUserFn::getUserFn(void) const {
     return _fn;
 } // getUserFn
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Set user function specifying time derivative of field on boundary.
+void
+pylith::bc::DirichletUserFn::setUserFnDot(PetscUserFieldFunc fn) {
+    PYLITH_COMPONENT_DEBUG("setUserFnDot(fn="<<fn<<")");
+
+    _fnDot = fn;
+} // setUserFnDot
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Get user function specifying time derivative of field on boundary.
+PetscUserFieldFunc
+pylith::bc::DirichletUserFn::getUserFnDot(void) const {
+    return _fnDot;
+} // getUserFnDot
 
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -157,6 +176,7 @@ pylith::bc::DirichletUserFn::createConstraint(const pylith::topology::Field& sol
     constraint->setConstrainedDOF(&_constrainedDOF[0], _constrainedDOF.size());
     constraint->setSubfieldName(_subfieldName.c_str());
     constraint->setUserFn(_fn);
+    constraint->setUserFnDot(_fnDot);
 
     PYLITH_METHOD_RETURN(constraint);
 } // createConstraint

--- a/libsrc/pylith/bc/DirichletUserFn.hh
+++ b/libsrc/pylith/bc/DirichletUserFn.hh
@@ -75,6 +75,18 @@ public:
      */
     PetscUserFieldFunc getUserFn(void) const;
 
+    /** Set user function specifying time derivative of field on boundary.
+     *
+     * @param[in] fn Function specifying time derivative of field on boundary.
+     */
+    void setUserFnDot(PetscUserFieldFunc fn);
+
+    /** Get user function specifying time derivative of field on boundary
+     *
+     * @preturns Function specifying time derivative of field on boundary.
+     */
+    PetscUserFieldFunc getUserFnDot(void) const;
+
     /** Verify configuration is acceptable.
      *
      * @param[in] solution Solution field.
@@ -129,6 +141,7 @@ private:
 
     int_array _constrainedDOF; ///< List of constrained degrees of freedom at each location.
     PetscUserFieldFunc _fn; ///< Function specifying field on boundary.
+    PetscUserFieldFunc _fnDot; ///< Function specifying time derivative of field on boundary.
 
     // NOT IMPLEMENTED /////////////////////////////////////////////////////////////////////////////////////////////////
 private:

--- a/libsrc/pylith/bc/NeumannTimeDependent.cc
+++ b/libsrc/pylith/bc/NeumannTimeDependent.cc
@@ -278,7 +278,6 @@ pylith::bc::NeumannTimeDependent::createAuxiliaryField(const pylith::topology::F
     auxiliaryField->createDiscretization();
     pylith::topology::FieldOps::checkDiscretization(solution, *auxiliaryField);
     auxiliaryField->allocate();
-    auxiliaryField->zeroLocal();
     auxiliaryField->createOutputVector();
 
     assert(_auxiliaryFactory);

--- a/libsrc/pylith/faults/FaultCohesiveKin.cc
+++ b/libsrc/pylith/faults/FaultCohesiveKin.cc
@@ -333,7 +333,6 @@ pylith::faults::FaultCohesiveKin::createAuxiliaryField(const pylith::topology::F
     auxiliaryField->createDiscretization();
     pylith::topology::FieldOps::checkDiscretization(solution, *auxiliaryField);
     auxiliaryField->allocate();
-    auxiliaryField->zeroLocal();
     auxiliaryField->createOutputVector();
 
     // We don't populate the auxiliary field via a spatial database, because they will be set from the earthquake

--- a/libsrc/pylith/faults/KinSrc.cc
+++ b/libsrc/pylith/faults/KinSrc.cc
@@ -124,7 +124,6 @@ pylith::faults::KinSrc::initialize(const pylith::topology::Field& faultAuxField,
     _auxiliaryField->createDiscretization();
     pylith::topology::FieldOps::checkDiscretization(faultAuxField, *_auxiliaryField);
     _auxiliaryField->allocate();
-    _auxiliaryField->zeroLocal();
 
     _auxiliaryFactory->setValuesFromDB();
 

--- a/libsrc/pylith/feassemble/ConstraintUserFn.cc
+++ b/libsrc/pylith/feassemble/ConstraintUserFn.cc
@@ -138,7 +138,7 @@ void
 pylith::feassemble::ConstraintUserFn::setSolutionDot(pylith::topology::Field* solutionDot,
                                                      const double t) {
     PYLITH_METHOD_BEGIN;
-    PYLITH_JOURNAL_DEBUG("setSolutionDot(solution="<<solutionDot->getLabel()<<", t="<<t<<")");
+    PYLITH_JOURNAL_DEBUG("setSolutionDot(solutionDot="<<solutionDot->getLabel()<<", t="<<t<<")");
     if (!_fnDot) { PYLITH_METHOD_END; }
 
     assert(solutionDot);

--- a/libsrc/pylith/materials/Elasticity.cc
+++ b/libsrc/pylith/materials/Elasticity.cc
@@ -211,7 +211,6 @@ pylith::materials::Elasticity::createAuxiliaryField(const pylith::topology::Fiel
     auxiliaryField->createDiscretization();
     pylith::topology::FieldOps::checkDiscretization(solution, *auxiliaryField);
     auxiliaryField->allocate();
-    auxiliaryField->zeroLocal();
     auxiliaryField->createOutputVector();
 
     assert(auxiliaryFactory);
@@ -245,7 +244,6 @@ pylith::materials::Elasticity::createDerivedField(const pylith::topology::Field&
     derivedField->createDiscretization();
     pylith::topology::FieldOps::checkDiscretization(solution, *derivedField);
     derivedField->allocate();
-    derivedField->zeroLocal();
     derivedField->createOutputVector();
 
     PYLITH_METHOD_RETURN(derivedField);

--- a/libsrc/pylith/materials/IncompressibleElasticity.cc
+++ b/libsrc/pylith/materials/IncompressibleElasticity.cc
@@ -186,7 +186,6 @@ pylith::materials::IncompressibleElasticity::createAuxiliaryField(const pylith::
     auxiliaryField->createDiscretization();
     pylith::topology::FieldOps::checkDiscretization(solution, *auxiliaryField);
     auxiliaryField->allocate();
-    auxiliaryField->zeroLocal();
     auxiliaryField->createOutputVector();
 
     assert(auxiliaryFactory);
@@ -220,7 +219,6 @@ pylith::materials::IncompressibleElasticity::createDerivedField(const pylith::to
     derivedField->createDiscretization();
     pylith::topology::FieldOps::checkDiscretization(solution, *derivedField);
     derivedField->allocate();
-    derivedField->zeroLocal();
     derivedField->createOutputVector();
 
     PYLITH_METHOD_RETURN(derivedField);

--- a/libsrc/pylith/materials/Poroelasticity.cc
+++ b/libsrc/pylith/materials/Poroelasticity.cc
@@ -245,7 +245,6 @@ pylith::materials::Poroelasticity::createAuxiliaryField(const pylith::topology::
     auxiliaryField->createDiscretization();
     pylith::topology::FieldOps::checkDiscretization(solution, *auxiliaryField);
     auxiliaryField->allocate();
-    auxiliaryField->zeroLocal();
     auxiliaryField->createOutputVector();
 
     assert(auxiliaryFactory);
@@ -279,7 +278,6 @@ pylith::materials::Poroelasticity::createDerivedField(const pylith::topology::Fi
     derivedField->createDiscretization();
     pylith::topology::FieldOps::checkDiscretization(solution, *derivedField);
     derivedField->allocate();
-    derivedField->zeroLocal();
     derivedField->createOutputVector();
 
     PYLITH_METHOD_RETURN(derivedField);

--- a/libsrc/pylith/meshio/OutputSolnPoints.cc
+++ b/libsrc/pylith/meshio/OutputSolnPoints.cc
@@ -238,7 +238,6 @@ pylith::meshio::OutputSolnPoints::_setupInterpolator(const pylith::topology::Fie
     _pointSoln->createDiscretization();
     _pointSoln->setLabel(solution.getLabel());
     _pointSoln->allocate();
-    _pointSoln->zeroLocal();
 
     PYLITH_METHOD_END;
 } // setupInterpolator

--- a/libsrc/pylith/problems/TimeDependent.cc
+++ b/libsrc/pylith/problems/TimeDependent.cc
@@ -501,7 +501,7 @@ pylith::problems::TimeDependent::setSolutionLocal(const PylithReal t,
         _constraints[i]->setSolution(_solution, t);
         if (_solutionDot) {
             _constraints[i]->setSolutionDot(_solutionDot, t);
-        }
+        } // if
     } // for
 
     // _solution->view("SOLUTION AFTER SETTING VALUES");

--- a/libsrc/pylith/testing/MMSTest.hh
+++ b/libsrc/pylith/testing/MMSTest.hh
@@ -89,7 +89,6 @@ protected:
     pylith::problems::TimeDependent *_problem; ///< Time-dependent problem.
     pylith::topology::Mesh *_mesh; ///< Finite-element mesh.
     pylith::topology::Field *_solution; ///< Solution field.
-    pylith::topology::Field *_solutionDot; ///< Solution time derivative field.
     PetscVec _solutionExactVec; ///< Global vector to use for exact solution.
     PetscVec _solutionDotExactVec; ///< Global vector to use for time derivative of exact solution.
     PylithReal _jacobianConvergenceRate; ///< Expected convergence rate for Jacobiab (when not linear).

--- a/libsrc/pylith/topology/Field.hh
+++ b/libsrc/pylith/topology/Field.hh
@@ -248,7 +248,7 @@ public:
      */
     void createDiscretization(void);
 
-    /// Allocate field and zero local vector.
+    /// Allocate field and zero the local vector.
     void allocate(void);
 
     /// Zero local values (including constrained values).

--- a/tests/libtests/bc/TestAbsorbingDampers.cc
+++ b/tests/libtests/bc/TestAbsorbingDampers.cc
@@ -275,7 +275,6 @@ pylith::bc::TestAbsorbingDampers::testComputeRHSResidual(void) {
 
     // Initialize solution field.
     _solution->allocate();
-    _solution->zeroLocal();
     _solution->createScatter(_solution->mesh(), "global");
 
     // Set solution field.

--- a/tests/libtests/bc/TestNeumannTimeDependent.cc
+++ b/tests/libtests/bc/TestNeumannTimeDependent.cc
@@ -345,7 +345,6 @@ pylith::bc::TestNeumannTimeDependent::testComputeRHSResidual(void) {
 
     // Initialize solution field.
     _solution->allocate();
-    _solution->zeroLocal();
     _solution->createScatter(_solution->mesh(), "global");
 
     // Set solution field.

--- a/tests/libtests/feassemble/TestAuxiliaryFactory.cc
+++ b/tests/libtests/feassemble/TestAuxiliaryFactory.cc
@@ -260,7 +260,6 @@ pylith::feassemble::TestAuxiliaryFactory::testSetValuesFromDB(void) {
     auxiliaryField.subfieldsSetup();
     auxiliaryField.createDiscretization();
     auxiliaryField.allocate();
-    auxiliaryField.zeroLocal();
 
     _factory->setValuesFromDB();
 

--- a/tests/libtests/meshio/TestOutputSolnPoints.cc
+++ b/tests/libtests/meshio/TestOutputSolnPoints.cc
@@ -268,7 +268,6 @@ pylith::meshio::TestOutputSolnPoints::_testInterpolate(const OutputSolnPointsDat
     field.newSection(topology::FieldBase::VERTICES_FIELD, fiberDim);
     field.allocate();
     field.setLabel(fieldName);
-    field.zeroLocal();
     this->_calcField(&field, data);
 
     // Create field for interpolated data.
@@ -278,13 +277,11 @@ pylith::meshio::TestOutputSolnPoints::_testInterpolate(const OutputSolnPointsDat
     fieldInterp.setLabel(field.getLabel());
     fieldInterp.vectorFieldType(field.vectorFieldType());
     fieldInterp.scale(field.scale());
-    fieldInterp.zeroLocal();
 
     // Create field to populate with expected data.
     pylith::topology::Field fieldInterpE(fieldInterp.mesh());
     fieldInterpE.cloneSection(fieldInterp);
     fieldInterpE.allocate();
-    fieldInterpE.zeroLocal();
     this->_calcField(&fieldInterpE, data);
 
     PetscDM pointsMeshDM = output.pointsMesh().dmMesh();CPPUNIT_ASSERT(pointsMeshDM);


### PR DESCRIPTION
Add time derivative of field (fnDot) to DirichletUserFn. We already have the time derivative in ConstraintUserFn. These are needed for time dependent MMS tests.