### PR TITLE
Limit boundary and point solution output to only fields over domain.

### DIFF
--- a/libsrc/pylith/meshio/OutputSoln.cc
+++ b/libsrc/pylith/meshio/OutputSoln.cc
@@ -211,18 +211,4 @@ pylith::meshio::OutputSoln::_writeSolnStep(const PylithReal t,
 } // _writeSolnStep
 
 
-// ---------------------------------------------------------------------------------------------------------------------
-// Get names of subfields for output.
-pylith::string_vector
-pylith::meshio::OutputSoln::_expandSubfieldNames(const pylith::topology::Field& solution) const {
-    PYLITH_METHOD_BEGIN;
-
-    if ((1 == _subfieldNames.size()) && (std::string("all") == _subfieldNames[0])) {
-        PYLITH_METHOD_RETURN(solution.subfieldNames());
-    } // if
-
-    PYLITH_METHOD_RETURN(_subfieldNames);
-} // _expandSubfieldNames
-
-
 // End of file

--- a/libsrc/pylith/meshio/OutputSoln.hh
+++ b/libsrc/pylith/meshio/OutputSoln.hh
@@ -126,14 +126,6 @@ protected:
                         const PylithInt tindex,
                         const pylith::topology::Field& solution);
 
-    /** Get names of subfields for output.
-     *
-     * Expand "all" into list of actual fields in the solution field.
-     *
-     * @param[in] solution Solution field.
-     */
-    pylith::string_vector _expandSubfieldNames(const pylith::topology::Field& solution) const;
-
     // PROTECTED MEMBERS ///////////////////////////////////////////////////////////////////////////////////////////////
 protected:
 

--- a/libsrc/pylith/meshio/OutputSolnBoundary.cc
+++ b/libsrc/pylith/meshio/OutputSolnBoundary.cc
@@ -21,6 +21,7 @@
 #include "OutputSolnBoundary.hh" // implementation of class methods
 
 #include "pylith/topology/Field.hh" // USES Field
+#include "pylith/topology/FieldOps.hh" // USES FieldOps
 #include "pylith/topology/Mesh.hh" // USES Mesh
 #include "pylith/topology/MeshOps.hh" // USES createLowerDimMesh()
 #include "pylith/meshio/OutputSubfield.hh" // USES OutputSubfield
@@ -107,7 +108,7 @@ pylith::meshio::OutputSolnBoundary::_writeSolnStep(const PylithReal t,
         assert(_boundaryMesh);
     } // if
 
-    const pylith::string_vector& subfieldNames = _expandSubfieldNames(solution);
+    const pylith::string_vector& subfieldNames = pylith::topology::FieldOps::getSubfieldNamesDomain(solution);
     PetscVec solutionVector = solution.outputVector();assert(solutionVector);
 
     _openSolnStep(t, *_boundaryMesh);

--- a/libsrc/pylith/meshio/OutputSolnPoints.cc
+++ b/libsrc/pylith/meshio/OutputSolnPoints.cc
@@ -25,6 +25,7 @@
 
 #include "pylith/topology/Mesh.hh" // USES Mesh
 #include "pylith/topology/Field.hh" // USES Field
+#include "pylith/topology/FieldOps.hh" // USES FieldOps
 #include "pylith/meshio/OutputSubfield.hh" // USES OutputSubfield
 #include "pylith/topology/MeshOps.hh" // USES MeshOps::nondimensionalize()
 #include "pylith/topology/Stratum.hh" // USES Stratum
@@ -124,7 +125,8 @@ pylith::meshio::OutputSolnPoints::_writeSolnStep(const PylithReal t,
     _openSolnStep(t, *_pointMesh);
     if (writePointNames) { _writePointNames(); }
 
-    const pylith::string_vector& subfieldNames = _expandSubfieldNames(solution);
+    const pylith::string_vector& subfieldNames = pylith::topology::FieldOps::getSubfieldNamesDomain(solution);
+
     const size_t numSubfieldNames = subfieldNames.size();
     for (size_t iField = 0; iField < numSubfieldNames; iField++) {
         OutputSubfield* subfield = NULL;


### PR DESCRIPTION
Fix memory error associated with attempt to write Lagrange multiplier field over the boundary (or points) when writing solution fields. Use `FieldOps::getSubfieldNamesDomain()` to limit fields to only those over the domain (as was being doing for `OutputSolnDomain`.