### PR TITLE
Update PETSc interface for boundary integration (now uses key)

### DIFF
--- a/libsrc/pylith/feassemble/IntegratorBoundary.cc
+++ b/libsrc/pylith/feassemble/IntegratorBoundary.cc
@@ -327,15 +327,17 @@ pylith::feassemble::_IntegratorBoundary::computeResidual(pylith::topology::Field
     } // Move to initialization phase
 
     // Compute the local residual
-    // solution.mesh().view(":mesh.txt:ascii_info_detail"); // :DEBUG:
+    PetscFormKey key;
+    key.label = dmLabel;
+    key.value = labelValue;
+    key.part = pylith::feassemble::Integrator::RESIDUAL_LHS; // Update when initialization moves.
+
     assert(solution.getLocalVector());
     assert(residual->getLocalVector());
     for (size_t i = 0; i < kernels.size(); ++i) {
-        const PetscInt numLabelValues = 1;
-        const PetscInt i_field = solution.getSubfieldInfo(kernels[i].subfield.c_str()).index;
-        err = DMPlexComputeBdResidualSingle(dmSoln, t, weakForm, dmLabel, numLabelValues, &labelValue, i_field,
-                                            solution.getLocalVector(), solutionDot.getLocalVector(),
-                                            residual->getLocalVector());PYLITH_CHECK_ERROR(err);
+        key.field = solution.getSubfieldInfo(kernels[i].subfield.c_str()).index;
+        err = DMPlexComputeBdResidualSingle(dmSoln, t, weakForm, key, solution.getLocalVector(),
+                                            solutionDot.getLocalVector(), residual->getLocalVector());PYLITH_CHECK_ERROR(err);
     } // for
 
     PYLITH_METHOD_END;

--- a/tests/fullscale/linearelasticity/nofaults-2d/TestGravityIncompressible.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/TestGravityIncompressible.py
@@ -32,7 +32,8 @@ from gravity_incompressible_soln import AnalyticalSoln
 class TestCase(FullTestCase):
     """Test suite for testing PyLith with gravitational body forces (no initial stress).
     """
-    DIRICHLET_BOUNDARIES = ["bc_xneg", "bc_xpos", "bc_yneg", "bc_ypos"]
+    DIRICHLET_BOUNDARIES = ["bc_xneg", "bc_xpos", "bc_yneg"]
+    OUTPUT_BOUNDARIES = ["bc_ypos"]
 
     def setUp(self):
         """Setup for test.
@@ -49,6 +50,13 @@ class TestCase(FullTestCase):
         filename = "output/{}-domain.h5".format(self.NAME)
         vertexFields = ["displacement", "pressure"]
         check_data(filename, self, self.DOMAIN, vertexFields=vertexFields)
+        return
+
+    def test_boundary_solution(self):
+        vertexFields = ["displacement", "pressure"]
+        for bc in self.OUTPUT_BOUNDARIES:
+            filename = "output/{}-{}.h5".format(self.NAME, bc)
+            check_data(filename, self, self.BOUNDARIES[bc], vertexFields=vertexFields)
         return
 
     def test_material_info(self):

--- a/tests/fullscale/linearelasticity/nofaults-3d/TestGravity.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/TestGravity.py
@@ -50,12 +50,12 @@ class TestCase(FullTestCase):
         check_data(filename, self, self.DOMAIN, vertexFields=vertexFields)
 
     def test_material_info(self):
-        vertexFields = ["density", "bulk_modulus",
+        cellFields = ["density", "bulk_modulus",
                         "shear_modulus", "gravitational_acceleration"]
         for material in self.MATERIALS:
             filename = "output/{}-{}_info.h5".format(self.NAME, material)
             check_data(filename, self,
-                       self.MATERIALS[material], vertexFields=vertexFields)
+                       self.MATERIALS[material], cellFields=cellFields)
 
     def test_material_solution(self):
         vertexFields = ["displacement", "cauchy_strain", "cauchy_stress"]
@@ -65,11 +65,11 @@ class TestCase(FullTestCase):
                        self.MATERIALS[material], vertexFields=vertexFields)
 
     def test_bcdirichlet_info(self):
-        vertexFields = ["initial_amplitude"]
+        cellFields = ["initial_amplitude"]
         for bc in self.DIRICHLET_BOUNDARIES:
             filename = "output/{}-{}_info.h5".format(self.NAME, bc)
             check_data(filename, self,
-                       self.BOUNDARIES[bc], vertexFields=vertexFields)
+                       self.BOUNDARIES[bc], cellFields=cellFields)
 
     def test_bcdirichlet_solution(self):
         vertexFields = ["displacement"]

--- a/tests/fullscale/linearelasticity/nofaults-3d/TestGravityIncompressible.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/TestGravityIncompressible.py
@@ -32,7 +32,8 @@ from gravity_incompressible_soln import AnalyticalSoln
 class TestCase(FullTestCase):
     """Test suite for testing PyLith with gravitational body forces (no initial stress).
     """
-    DIRICHLET_BOUNDARIES = ["bc_xneg", "bc_xpos", "bc_yneg", "bc_ypos", "bc_zneg", "groundsurf"]
+    DIRICHLET_BOUNDARIES = ["bc_xneg", "bc_xpos", "bc_yneg", "bc_ypos", "bc_zneg"]
+    OUTPUT_BOUNDARIES = ["bc_ypos"]
 
     def setUp(self):
         """Setup for test.
@@ -47,6 +48,13 @@ class TestCase(FullTestCase):
         filename = "output/{}-domain.h5".format(self.NAME)
         vertexFields = ["displacement", "pressure"]
         check_data(filename, self, self.DOMAIN, vertexFields=vertexFields)
+
+    def test_boundary_solution(self):
+        vertexFields = ["displacement", "pressure"]
+        for bc in self.OUTPUT_BOUNDARIES:
+            filename = "output/{}-{}.h5".format(self.NAME, bc)
+            check_data(filename, self, self.BOUNDARIES[bc], vertexFields=vertexFields)
+        return
 
     def test_material_info(self):
         cellFields = ["density", "bulk_modulus", "shear_modulus", "gravitational_acceleration"]


### PR DESCRIPTION
* Updates for changes to PETSc boundary integration interface (now uses key).
* Small fixes to gravity examples (vertex fields -> cell fields; boundary solution).