### PR TITLE
Fix typos and grammar inDeveloper Doc -Testing

### DIFF
--- a/docs-sphinx/developer/testing/fullscale.md
+++ b/docs-sphinx/developer/testing/fullscale.md
@@ -1,6 +1,6 @@
 # Full-scale tests
 
-The full-scale tests are constructed in Python, making use of the standard Python unittest module.
+The full-scale tests are constructed in Python, making use of the standard Python unit test module.
 A full-scale test involves running a PyLith simulation and using Python code to check output against a known solution.
 Whenever possible, we simulate simple boundary value problems with analytical solutions.
 We run some full-scale tests in parallel on a small number of processes.
@@ -49,4 +49,3 @@ $ valgrind --trace-children=yes \
 
 Walk through an example of a full-scale test.
 :::
-

--- a/docs-sphinx/developer/testing/fullscale.md
+++ b/docs-sphinx/developer/testing/fullscale.md
@@ -1,6 +1,6 @@
 # Full-scale tests
 
-The full-scale tests are constructed in Python, making use of the standard Python unit test module.
+The full-scale tests are constructed in Python, making use of the standard Python `unittest` module.
 A full-scale test involves running a PyLith simulation and using Python code to check output against a known solution.
 Whenever possible, we simulate simple boundary value problems with analytical solutions.
 We run some full-scale tests in parallel on a small number of processes.

--- a/docs-sphinx/developer/testing/index.md
+++ b/docs-sphinx/developer/testing/index.md
@@ -8,7 +8,7 @@ We use full-scale tests for verifying integration for complete simulations in bo
 When these tests, an example, or user simulation suggests a bug exists, we leverage the test suite.
 In general, the most efficient strategy for debugging is to first try to expose the bug in a serial unit test, followed by an MMS Test, a serial full-scale test, and finally a parallel full-scale test.
 This may require creating new tests if the bug is not exposed by current tests.
-The PyLith developers make extensive use debuggers, such as `gdb` and `lldb`, and memory management analysis tools, such as `valgrind`, to detect and squash bugs. These are discussed in {ref}`developer-debugging-tools`.
+The PyLith developers make extensive use of debuggers, such as `gdb` and `lldb`, and memory management analysis tools, such as `valgrind`, to detect and squash bugs. These are discussed in {ref}`developer-debugging-tools`.
 
 ```{toctree}
 libtests.md

--- a/docs-sphinx/developer/testing/libtests.md
+++ b/docs-sphinx/developer/testing/libtests.md
@@ -8,10 +8,10 @@ For a given C++ class in `libsrc/pylith`, we create a separate test class in `te
 For example, we create `pylith::problems::TestPhysics` in `tests/libtsts/problems/TestPhysics.*` to test the `pylith::problems::Physics` class in `libsrc/pylith/problems/Physics.*`.
 For simple classes that can be fully tested with a single test case, we put the class declaration and implementation in a single `.cc` file.
 For classes that require testing with multiple alternative test cases, we usually define both the test class and a data class in a header file (for example `TestSolutionFactory.hh`).
-The classes are implemented in a corresponding `.cc` file (for example, `TestSolutionFactory.cc`) with the test cases defined and implemented in a `_Cases.cc` file (for example, `TestSolutionFactory_Cases.cc`.
+The classes are implemented in a corresponding `.cc` file (for example, `TestSolutionFactory.cc`) with the test cases defined and implemented in a `_Cases.cc` file (for example, `TestSolutionFactory_Cases.cc`).
 
 The test class inherits from `CppUnit::TestFixture` and defines a list of test methods.
-The class methods `setUp()` and `tearDown`() are run before and after each test, respectively.
+The class methods `setUp()` and `tearDown()` are run before and after each test, respectively.
 If a class requires significant initialization, we usually put that in protected methods.
 
 ## CppUnit macros
@@ -29,7 +29,7 @@ If a class requires significant initialization, we usually put that in protected
   * **`CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, valueExpected, valueTest);`**
   * **`CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE(msg, valueExpected, valueTest, tolernace);`**
 
-Within the test implementations we use `CPPUNIT_ASSERT(condition)` where we would normally use `assert(condition)`.
+Within the test implementations, we use `CPPUNIT_ASSERT(condition)` where we would normally use `assert(condition)`.
 This results in the corresponding test failing and the remaining tests are executed.
 If an `assert(condition)` fails, the test driver aborts and the remaining tests are not executed.
 

--- a/docs-sphinx/developer/testing/mmstests.md
+++ b/docs-sphinx/developer/testing/mmstests.md
@@ -18,7 +18,7 @@ In mathematical terms, the residual test is that the residual computed for a kno
   || F(\vec{s}) - G(\vec{s}) || \le \epsilon,
 \end{equation}
 where $F(\vec{s})$ is the LHS residual and $G(\vec{s})$ is the RHS residual.
-In the Talor series Jacobian test, we verify that
+In the Taylor series Jacobian test, we verify that
 \begin{equation}
   || F(\vec{s} + \epsilon \vec{\delta s}) - F(\vec{s}) - \epsilon J \vec{v} || < \epsilon^2,
 \end{equation}
@@ -60,7 +60,7 @@ When one of the Jacobian tests fails, we focus on the finite-difference Jacobian
 
 ## Example
 
-In `tests/mmstests/elasticity` we create a suite of MMS tests that all use a single material (`Elasticity`), a single Dirichlet boundary condition, and a data object to hold test-specific parameters.
+In `tests/mmstests/elasticity`, we create a suite of MMS tests that all use a single material (`Elasticity`), a single Dirichlet boundary condition, and a data object to hold test-specific parameters.
 The `pylith::mmstests::TestElasticity` object holds these parameters with the `pylith::mmstests::TestIsotropicLinearElasticity` object adding a rheology.
 The individual test cases, such as `pylith::mmstests::TestIsotropicLinearElasticity2D_UniformStrain` provides the problem-specific parameters, such as analytical functions for the solution and auxiliary fields and sets up the problem.
 Child classes specify different cell shapes and orders for the basis functions and numerical quadrature.


### PR DESCRIPTION
Fixes miscellaneous typos and omitted commas in the sphinx developer documentation Testing section.