### PR TITLE
Editing typos in the developer/contributing documentation

### DIFF
--- a/docs-sphinx/developer/contributing/codelayout.md
+++ b/docs-sphinx/developer/contributing/codelayout.md
@@ -115,7 +115,7 @@ Diagram showing the relationships among objects associated with boundary conditi
 
 ### Interior Interfaces (Faults)
 
-:::{admonition} TO DO
+:::{admonition} TODO
 :class: error
 
 Add class diagram and discussion for FaultCohesiveKin, KinSrc.

--- a/docs-sphinx/developer/contributing/codelayout.md
+++ b/docs-sphinx/developer/contributing/codelayout.md
@@ -87,9 +87,9 @@ The user specifies the parameters for the `Physics` objects, which each create t
 Diagram showing the relationships among objects specifying the physics and the finite-element implementations.
 :::
 
-We generalize the finite-element operations into to main classes: `Integrator` and `Constraint`.
+We generalize the finite-element operations into two main classes: `Integrator` and `Constraint`.
 The `Integrator` is further separated into concrete classes for performing the finite-element integrations over pieces of the domain (`IntegratorDomain`), pieces of the domain boundary (`IntegratorBoundary`), and interior interfaces (`IntegratorInterface`).
-We implement several kinds of constraints, corresponding to how the values of the constrained degrees of freedom and their values are specified.
+We implement several kinds of constraints, corresponding to how the values of the constrained degrees of freedom are specified.
 `ConstraintSpatialDB` gets values for the constrained degrees of freedom from a spatial database; `ConstraintUserFn` gets the values for the constrained degrees of freedom from a function (this object is widely used in tests); `ConstraintSimple` is a special case of `ConstraintUserFn` with the constrained degrees of freedom set programmatically using a label (this object is used for constraining the edges of the fault).
 
 `Problem` holds the `Physics` objects as materials, boundary conditions, and interfaces.
@@ -115,7 +115,7 @@ Diagram showing the relationships among objects associated with boundary conditi
 
 ### Interior Interfaces (Faults)
 
-:::{admonition} TODO
+:::{admonition} TO DO
 :class: error
 
 Add class diagram and discussion for FaultCohesiveKin, KinSrc.
@@ -173,7 +173,7 @@ Starting with the complete initialization of the problem, the flow is controlled
 ### Time-Dependent Problem
 
 In a time-dependent problem the PETSc `TS` object (relabeled `PetscTS` within PyLith) controls the time stepping.
-Within each time step, the `PetscTS` object calls the PETSc linear and nonlinear solvers as needed, which call the following methods of the C++ `pylith::problems::TimeDependent` object as needed `computeRHSResidual()`, `computeRHSJacobian()`, `computeLHSResidual()`, and `computeLHSJacobian()`.
+Within each time step, the `PetscTS` object calls the PETSc linear and nonlinear solvers as needed, which call the following methods of the C++ `pylith::problems::TimeDependent` object as needed: `computeRHSResidual()`, `computeRHSJacobian()`, `computeLHSResidual()`, and `computeLHSJacobian()`.
 The `pylith::problems::TimeDependent` object calls the corresponding methods in the boundary conditions, constraints, and materials objects.
 At the end of each time step, it calls `problems::TimeDependent::poststep()`.  
 
@@ -184,15 +184,15 @@ Everything else is done in C++.
 This facilitates debugging (it is easier to track symbols in the C/C++ debugger) and unit testing, and reduces the amount of information that needs to be passed from Python to C++.
 The PyLith application and a few other utility functions, like writing the parameter file, are limited to Python.
 All other objects have a C++ implementation.
-Objects that have user input have collect the user input in Python using Pyre and pass it to a corresponding C++ object.
+Objects that have user input collect the user input in Python using Pyre and pass it to a corresponding C++ object.
 Objects that do not have user input, such as the integrators and constraints, are limited to C++.
 
 The source code that follows shows the essential ingredients for Python and C++ objects, using the concrete example of the `Material` objects.
 
 :::{warning}
 The examples below show skeleton Python and C++ objects to illustrate the essential ingredients.
-We have omitted documentation and comments that we would normally include and simplified the object hierarchy.
-See [Coding Style]{coding-style.md} for details about the coding style we use in PyLith.
+We have omitted documentation and comments that we would normally include, and simplified the object hierarchy.
+See [Coding Style]{codingstyle.md} for details about the coding style we use in PyLith.
 :::
 
 :::{important}

--- a/docs-sphinx/developer/contributing/newmaterial.md
+++ b/docs-sphinx/developer/contributing/newmaterial.md
@@ -9,12 +9,12 @@ There are four basic tasks for adding new physics in the form of a governing equ
 2. Derive the pointwise functions for the residuals and Jacobians. Determine flags that will be used to indicate which terms to include.
 
 3. Determine which parameters in the pointwise functions could vary in space as well as any state variables. We bundle all state variables and spatially varying parameters into a field called the auxiliary field. Each material has a separate auxiliary field.
-  
+
 4. Parameters that are spatially uniform are treated separately from the parameters in the auxliary field.
 
 `Material` is responsible for the terms in the governing equations associated with the domain (i.e., volume integrals in a 3D domain and surface integrals in a 2D domain).
 A separate object implements the bulk rheology for a specific governing equation.
-{numref}`fig-developer-material-classes` shows the objects used to implement multiple rheologies for the elasticity equation, an isotropic, linear elastic rheology for incompressible elasticity, and an isotropic, linear elastic rheology for poroelasticity.
+{numref}`fig-developer-material-classes` shows the objects used to implement multiple rheologies for the elasticity equation: an isotropic, linear elastic rheology for incompressible elasticity, and an isotropic, linear elastic rheology for poroelasticity.
 The `Elasticity` object describes the physics for the elasticity equation, including the pointwise functions and flags for turning on optional terms (such as inertia) in the governing equation, and `RheologyElasticity` defines the interface for bulk elastic rheologies.
 
 
@@ -40,7 +40,7 @@ Each governing equation implementation inherits from the abstract `Material` cla
     * `SolnDispPres` Solution composed of displacement and mean stress (pressure) fields.
     * `SolnDispLagrange` Solution composed of displacement and Lagrange multiplier fields.
     * `SolnDispPresLagrange` Solution composed of displacement, mean stress (pressure), and Lagrange multiplier subfields.
-    * SolnDispVelLagrange` Solution composed of displacement, velocity, and Lagrange multiplier subfields.
+    * `SolnDispVelLagrange` Solution composed of displacement, velocity, and Lagrange multiplier subfields.
 * Define auxiliary subfields.
 
     The auxiliary subfields for a governing equation are defined as facilities in a Pyre Component. For example, the ones for `Elasticity` are in `AuxFieldsElasticity`. The order of the subfields is defined _not_ by the order they are listed in the Pyre component, but by the order they are added to the auxiliary field in the C++ object. The auxiliary subfields bulk rheologies are defined in the same way.
@@ -63,7 +63,7 @@ Class diagram for the solution field, solution subfields, and pre-defined contai
 
 * Define auxiliary subfields.
 
-  We build the auxiliary field using classes derived from `pylith::feassemble::AuxiliaryFactory`. The method corresponding to each subfield specifies the name of the subfield, its components, and scale for nondimensionalizing. We generally create a single auxiliary factory object for each governing equation but not each bulk constitutive model, because constitutive models for the same governing equation often have many of the same subfields. For example, most of our bulk constitutive models for the elasticity contain density, bulk modulus, and shear modulus auxiliary subfields.
+  We build the auxiliary field using classes derived from `pylith::feassemble::AuxiliaryFactory`. The method corresponding to each subfield specifies the name of the subfield, its components, and scale for nondimensionalizing. We generally create a single auxiliary factory object for each governing equation, but not each bulk constitutive model, because constitutive models for the same governing equation often have many of the same subfields. For example, most of our bulk constitutive models for the elasticity contain density, bulk modulus, and shear modulus auxiliary subfields.
 
   :::{important}
   Within the concrete implementation of the material and bulk rheology objects, we add the subfields to the auxiliary field.

--- a/docs-sphinx/developer/contributing/petscfem.md
+++ b/docs-sphinx/developer/contributing/petscfem.md
@@ -5,15 +5,15 @@ Most of the finite-element details are encapsulated in PETSc routines that compu
 In fact, adding materials and boundary conditions requires calling only a few PETSc finite-element functions to register the point-wise functions.
 A new material may need to add to the library of solution subfields and auxiliary subfields, but adding these fields is also done at a high-level.
 
-The remainder of this section discusses three aspects of the finite-element implementation handled by PyLith to give you a peek of what is doing on under the hood.
+The remainder of this section discusses three aspects of the finite-element implementation handled by PyLith to give you a peek of what is going on under the hood.
 
 ## DMPlex
 
 The finite-element mesh is stored as a `DMPlex` object.
 This is a particular implementation of the PETSc Data Management (`DM`, called `PetscDM` within PyLith) object.
-Within a `DMPlex` object vertices, edges, faces, and cells are all called points.
+Within a `DMPlex` object, vertices, edges, faces, and cells are all called points.
 The points are numbered sequentially, beginning with cells, followed by vertices, edges, and then faces.
-Treating all topological pieces of the mesh the same way, as points in an abstract graph, allows us to write algorithms which apply to very different meshes without change. 
+Treating all topological pieces of the mesh the same way, as points in an abstract graph, allows us to write algorithms which apply to very different meshes without change.
 For example, we can write a finite element assembly loop that applies to meshes of any dimension, with any cell shape, with (almost) any finite element.
 
 ### Point Depth and Height
@@ -155,7 +155,7 @@ These three operations are done by different PETSc functions and integrator obje
 `DMPlexComputeResidual_Internal`
 : Compute the contribution to the LHS or RHS residual for a single material.
 This function and the functions it calls handle looping over the cells in the material, integrating the weak form for each of the fields, and adding them to the residual.
-A more appropriate name would be `DMPlexComputeResidualSingle` and that may be used in the future.
+A more appropriate name would be `DMPlexComputeResidualSingle`, and that may be used in the future.
 This function is called from `IntegratorDomain`.
 
 `DMPlexComputeBdResidualSingle`
@@ -283,7 +283,7 @@ caption: Function prototype for pointwise functions for integrating the residual
 
 ```{code-block} c++
 ---
-caption: Function prototype for pointwise for integrating the Jacobian over the domain (materials).
+caption: Function prototype for pointwise functions for integrating the Jacobian over the domain (materials).
 ---
 /** PetscPointJac prototype.
  *

--- a/docs-sphinx/developer/contributing/rebuilding.md
+++ b/docs-sphinx/developer/contributing/rebuilding.md
@@ -79,7 +79,7 @@ Each target can be run using `make TARGET` where `TARGET` is one of the followin
 : Run the entire test suite.
 
 :::{tip}
-On a machine with multiple cores, faster builds of the C++ code (library and C++ unit tests) are available using the `-jNTHREADS` command line argument, where `NTHREADS` is the number of threads to yse.
+On a machine with multiple cores, faster builds of the C++ code (library and C++ unit tests) are available using the `-jNTHREADS` command line argument, where `NTHREADS` is the number of threads to use.
 We usually set the number of threads equal to twice the number of physical cores.
 :::
 

--- a/docs-sphinx/developer/contributing/workflow.md
+++ b/docs-sphinx/developer/contributing/workflow.md
@@ -49,7 +49,7 @@ We recommend adding your SSH public key to your GitHub account and/or creating a
 See [GitHub Docs: Connecting To GitHub with SSH](https://help.github.com/articles/connecting-to-github-with-ssh/) and [GitHub Docs: Creating a personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) for more information.
 This provides additional security and eliminates the need for you to enter your username and password whenever you push to your repository.
 
-For additional security consider setting up your GitHub account to use two-factor authentication.
+For additional security, consider setting up your GitHub account to use two-factor authentication.
 See [GitHub Docs: Securing your account with two-factor authentication](https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/).
 
 We also recommend signing your commits using GPG or S/MIME. See [GitHub Docs: Managing commit signature verification](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification) for more information.
@@ -151,7 +151,7 @@ You still need to delete this local branch and then check it out again if it is 
 (sec-developer-feature-branch)=
 ## Creating a New Feature Branch
 
-Before creating a new feature branch, you should merge updates from the upstream repository as described in {ref}`sec-developer-merge-upstream.
+Before creating a new feature branch, you should merge updates from the upstream repository as described in {ref}`sec-developer-merge-upstream`.
 
 ```{code-block} bash
 ---
@@ -254,7 +254,7 @@ This will return the repository to the state immediately before the rebasing pro
 (sec-developer-pull-request)=
 ## Making Pull Requests
 
-Once you have completed implementing, testing, and documenting a new feature on a branch in your fork and wish to contribute it back to the geodynamics/pylith repository, you open a pull request. 
+Once you have completed implementing, testing, and documenting a new feature on a branch in your fork and wish to contribute it back to the geodynamics/pylith repository, you open a pull request.
 See [GitHub Docs: About pull requests](https://help.github.com/articles/about-pull-requests/) for more information.
 
 :::{tip}


### PR DESCRIPTION
Small changes like adding missing punctuation and deleting redundant words, and a couple of formatting errors. There is one reference to "coding-style.md" that I changed to "codingstyle.md" since that is the name of the file as it appears in the developer/contributing directory.