### PR TITLE
Add flag to subfield into for limiting subfield to only fault degrees of freedom

### DIFF
--- a/libsrc/pylith/faults/FaultCohesiveKin.cc
+++ b/libsrc/pylith/faults/FaultCohesiveKin.cc
@@ -305,8 +305,11 @@ pylith::faults::FaultCohesiveKin::createAuxiliaryField(const pylith::topology::F
     // Set default discretization of auxiliary subfields to match lagrange_multiplier_fault subfield in solution.
     assert(_auxiliaryFactory);
     const pylith::topology::FieldBase::Discretization& discretization = solution.getSubfieldInfo("lagrange_multiplier_fault").fe;
-    _auxiliaryFactory->setSubfieldDiscretization("default", discretization.basisOrder, discretization.quadOrder, -1,
-                                                 discretization.cellBasis, discretization.isBasisContinuous, discretization.feSpace);
+    const PylithInt dimension = -1;
+    const bool isFaultOnly = false;
+    _auxiliaryFactory->setSubfieldDiscretization("default", discretization.basisOrder, discretization.quadOrder, dimension,
+                                                 isFaultOnly, discretization.cellBasis, discretization.feSpace,
+                                                 discretization.isBasisContinuous);
 
     assert(_auxiliaryFactory);
     assert(_normalizer);

--- a/libsrc/pylith/faults/KinSrc.cc
+++ b/libsrc/pylith/faults/KinSrc.cc
@@ -114,8 +114,9 @@ pylith::faults::KinSrc::initialize(const pylith::topology::Field& faultAuxField,
     const char* slipFieldName = faultAuxField.hasSubfield("slip") ? "slip" : "slip_rate";
     const pylith::topology::FieldBase::Discretization& discretization = faultAuxField.getSubfieldInfo(slipFieldName).fe;
     _auxiliaryFactory->setSubfieldDiscretization("default", discretization.basisOrder, discretization.quadOrder,
-                                                 discretization.dimension, discretization.cellBasis, discretization.isBasisContinuous,
-                                                 discretization.feSpace);
+                                                 discretization.dimension, discretization.isFaultOnly,
+                                                 discretization.cellBasis, discretization.feSpace,
+                                                 discretization.isBasisContinuous);
 
     delete _auxiliaryField;_auxiliaryField = new pylith::topology::Field(faultAuxField.getMesh());assert(_auxiliaryField);
     _auxiliaryField->setLabel("kinsrc auxiliary");

--- a/libsrc/pylith/faults/TopologyOps.hh
+++ b/libsrc/pylith/faults/TopologyOps.hh
@@ -96,6 +96,21 @@ public:
                          PointSet& noReplaceCells,
                          const int debug);
 
+    /** Get name of PETSc DM label for interfaces.
+     *
+     * @returns PETSc Label name.
+     */
+    static
+    const char* getInterfacesLabelName(void);
+
+    /** Get PETSc DM label for interfaces, creating if necessary.
+     *
+     * @param[inout] dm PETSc DM holding interfaces label.
+     * @returns PETSc DM label for interfaces.
+     */
+    static
+    PetscDMLabel getInterfacesLabel(PetscDM dm);
+
 }; // class TopologyOps
 
 #endif // pylith_faults_topologyops_hh

--- a/libsrc/pylith/problems/Physics.cc
+++ b/libsrc/pylith/problems/Physics.cc
@@ -115,13 +115,15 @@ pylith::problems::Physics::setAuxiliarySubfieldDiscretization(const char* subfie
                                                               const int quadOrder,
                                                               const int dimension,
                                                               const pylith::topology::FieldBase::CellBasis cellBasis,
-                                                              const bool isBasisContinuous,
-                                                              const pylith::topology::FieldBase::SpaceEnum feSpace) {
+                                                              const pylith::topology::FieldBase::SpaceEnum feSpace,
+                                                              const bool isBasisContinuous) {
     PYLITH_METHOD_BEGIN;
     PYLITH_COMPONENT_DEBUG("setAuxiliarySubfieldDiscretization(subfieldName="<<subfieldName<<", basisOrder="<<basisOrder<<", quadOrder="<<quadOrder<<", dimension="<<dimension<<", cellBasis="<<cellBasis<<", isBasisContinuous="<<isBasisContinuous<<")");
 
     pylith::feassemble::AuxiliaryFactory* factory = _getAuxiliaryFactory();assert(factory);
-    factory->setSubfieldDiscretization(subfieldName, basisOrder, quadOrder, dimension, cellBasis, isBasisContinuous, feSpace);
+    const bool isFaultOnly = false;
+    factory->setSubfieldDiscretization(subfieldName, basisOrder, quadOrder, dimension, isFaultOnly, cellBasis, feSpace,
+                                       isBasisContinuous);
 
     PYLITH_METHOD_END;
 } // setAuxSubfieldDiscretization
@@ -135,13 +137,15 @@ pylith::problems::Physics::setDerivedSubfieldDiscretization(const char* subfield
                                                             const int quadOrder,
                                                             const int dimension,
                                                             const pylith::topology::FieldBase::CellBasis cellBasis,
-                                                            const bool isBasisContinuous,
-                                                            const pylith::topology::FieldBase::SpaceEnum feSpace) {
+                                                            const pylith::topology::FieldBase::SpaceEnum feSpace,
+                                                            const bool isBasisContinuous) {
     PYLITH_METHOD_BEGIN;
     PYLITH_COMPONENT_DEBUG("setDerivedSubfieldDiscretization(subfieldName="<<subfieldName<<", basisOrder="<<basisOrder<<", quadOrder="<<quadOrder<<", dimension="<<dimension<<", cellBasis="<<cellBasis<<", isBasisContinuous="<<isBasisContinuous<<")");
 
     pylith::topology::FieldFactory* factory = _getDerivedFactory();assert(factory);
-    factory->setSubfieldDiscretization(subfieldName, basisOrder, quadOrder, dimension, cellBasis, isBasisContinuous, feSpace);
+    const bool isFaultOnly = false;
+    factory->setSubfieldDiscretization(subfieldName, basisOrder, quadOrder, dimension, isFaultOnly, cellBasis, feSpace,
+                                       isBasisContinuous);
 
     PYLITH_METHOD_END;
 } // setDerivedSubfieldDiscretization

--- a/libsrc/pylith/problems/Physics.hh
+++ b/libsrc/pylith/problems/Physics.hh
@@ -91,16 +91,16 @@ public:
      * @param[in] quadOrder Order of quadrature rule.
      * @param[in] dimension Dimension of points for discretization.
      * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
-     * @param[in] isBasisContinuous True if basis is continuous.
      * @param[in] feSpace Finite-element space.
+     * @param[in] isBasisContinuous True if basis is continuous.
      */
     void setAuxiliarySubfieldDiscretization(const char* subfieldName,
                                             const int basisOrder,
                                             const int quadOrder,
                                             const int dimension,
                                             const pylith::topology::FieldBase::CellBasis cellBasis,
-                                            const bool isBasisContinuous,
-                                            const pylith::topology::FieldBase::SpaceEnum feSpace);
+                                            const pylith::topology::FieldBase::SpaceEnum feSpace,
+                                            const bool isBasisContinuous);
 
     /** Set discretization information for derived subfield.
      *
@@ -109,16 +109,16 @@ public:
      * @param[in] quadOrder Order of quadrature rule.
      * @param[in] dimension Dimension of points for discretization.
      * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
-     * @param[in] isBasisContinuous True if basis is continuous.
      * @param[in] feSpace Finite-element space.
+     * @param[in] isBasisContinuous True if basis is continuous.
      */
     void setDerivedSubfieldDiscretization(const char* subfieldName,
                                           const int basisOrder,
                                           const int quadOrder,
                                           const int dimension,
                                           const pylith::topology::FieldBase::CellBasis cellBasis,
-                                          const bool isBasisContinuous,
-                                          const pylith::topology::FieldBase::SpaceEnum feSpace);
+                                          const pylith::topology::FieldBase::SpaceEnum feSpace,
+                                          const bool isBasisContinuous);
 
     /** Register observer to receive notifications.
      *

--- a/libsrc/pylith/testing/FieldTester.cc
+++ b/libsrc/pylith/testing/FieldTester.cc
@@ -86,9 +86,10 @@ pylith::testing::FieldTester::checkSubfieldInfo(const pylith::topology::Field& f
     CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.basisOrder, fe.basisOrder);
     CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.quadOrder, fe.quadOrder);
     CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.dimension, fe.dimension);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.isFaultOnly, fe.isFaultOnly);
     CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.cellBasis, fe.cellBasis);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.isBasisContinuous, fe.isBasisContinuous);
     CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.feSpace, fe.feSpace);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.c_str(), feE.isBasisContinuous, fe.isBasisContinuous);
 
     PYLITH_METHOD_END;
 } // checkSubfieldInfo

--- a/libsrc/pylith/topology/Field.hh
+++ b/libsrc/pylith/topology/Field.hh
@@ -199,9 +199,10 @@ public:
      * @param[in] basisOrder Order of basis functions for discretization.
      * @param[in] quadOrder Order of numerical quadrature for discretization.
      * @param[in] dimension Dimension of points for discretization.
+     * @param[in] isFaultOnly True if subfield is limited to fault degrees of freedom.
      * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
-     * @param[in] isBasisContinuous True if basis is continuous.
      * @param[in] feSpace Finite-element space (POLYNOMIAL_SPACE or POINT_SPACE).
+     * @param[in] isBasisContinuous True if basis is continuous.
      */
     void subfieldAdd(const char *name,
                      const char* alias,
@@ -212,9 +213,10 @@ public:
                      const int basisOrder,
                      const int quadOrder,
                      const int dimension,
+                     const bool isFaultOnly,
                      const CellBasis cellBasis,
-                     const bool isBasisContinuous,
-                     const SpaceEnum feSpace);
+                     const SpaceEnum feSpace,
+                     const bool isBasisContinuous);
 
     /** Add subfield to current field.
      *

--- a/libsrc/pylith/topology/FieldBase.hh
+++ b/libsrc/pylith/topology/FieldBase.hh
@@ -102,6 +102,7 @@ public:
                     const VectorFieldEnum vectorFieldTypeValue=SCALAR,
                     const PylithReal scaleValue=1.0,
                     const validatorfn_type validatorValue=NULL,
+                    bool isFaultOnlyValue=false,
                     bool hasHistoryValue=false,
                     const size_t historySizeValue=0) :
             label(labelValue),
@@ -122,24 +123,27 @@ public:
         int quadOrder; ///< Order of quadrature scheme.
         int dimension; ///< Dimension of point(s) for discretization.
         int components; ///< Number of components for field.
+        bool isFaultOnly; ///< Subfield is limited to fault degrees of freedom.
         CellBasis cellBasis; ///< Cell basis (simplex, tensor, default).
-        bool isBasisContinuous; ///< Is basis continuous?
         SpaceEnum feSpace; ///< Finite-element space.
+        bool isBasisContinuous; ///< Is basis continuous?
 
         Discretization(const int basisOrderValue=1,
                        const int quadOrderValue=1,
                        const int dimensionValue=-1,
                        const int componentsValue=-1,
+                       bool isFaultOnlyValue=false,
                        const CellBasis cellBasisValue=DEFAULT_BASIS,
-                       const bool isBasisContinuousValue=true,
-                       const SpaceEnum feSpaceValue=POLYNOMIAL_SPACE) :
+                       const SpaceEnum feSpaceValue=POLYNOMIAL_SPACE,
+                       const bool isBasisContinuousValue=true) :
             basisOrder(basisOrderValue),
             quadOrder(quadOrderValue),
             dimension(dimensionValue),
             components(componentsValue),
+            isFaultOnly(isFaultOnlyValue),
             cellBasis(cellBasisValue),
-            isBasisContinuous(isBasisContinuousValue),
-            feSpace(feSpaceValue)
+            feSpace(feSpaceValue),
+            isBasisContinuous(isBasisContinuousValue)
         {}
 
 
@@ -148,28 +152,32 @@ public:
             if (quadOrder          != rhs.quadOrder) {return false;}
             if (dimension          != rhs.dimension) {return false;}
             if (components         != rhs.components) {return false;}
+            if (isFaultOnly  != rhs.isFaultOnly) {return false;}
             if (cellBasis          != rhs.cellBasis) {return false;}
-            if (isBasisContinuous  != rhs.isBasisContinuous) {return false;}
             if (feSpace            != rhs.feSpace) {return false;}
+            if (isBasisContinuous  != rhs.isBasisContinuous) {return false;}
             // return true;
             return false;
-        }
+        } // operator=
 
         bool operator<(const Discretization rhs) const {
             return true;
-            if (basisOrder         < rhs.basisOrder) {return true;}
-            if (basisOrder        == rhs.basisOrder) {
-                if (quadOrder        < rhs.quadOrder) {return true;}
-                if (quadOrder       == rhs.quadOrder) {
-                    if (dimension      < rhs.dimension) {return true;}
-                    if (dimension     == rhs.dimension) {
-                        if (components   < rhs.components) {return true;}
-                        if (components  == rhs.components) {
-                            if (cellBasis        < rhs.cellBasis) {return true;}
-                            if (cellBasis       == rhs.cellBasis) {
-                                if (isBasisContinuous  < rhs.isBasisContinuous) {return true;}
-                                if (isBasisContinuous == rhs.isBasisContinuous) {
-                                    if (feSpace          < rhs.feSpace) {return true;}
+            if (basisOrder < rhs.basisOrder) {return true;}
+            if (basisOrder == rhs.basisOrder) {
+                if (quadOrder < rhs.quadOrder) {return true;}
+                if (quadOrder == rhs.quadOrder) {
+                    if (dimension < rhs.dimension) {return true;}
+                    if (dimension == rhs.dimension) {
+                        if (components < rhs.components) {return true;}
+                        if (components == rhs.components) {
+                            if (isFaultOnly < rhs.isFaultOnly) {return true;}
+                            if (isFaultOnly == rhs.isFaultOnly) {
+                                if (cellBasis < rhs.cellBasis) {return true;}
+                                if (cellBasis == rhs.cellBasis) {
+                                    if (feSpace < rhs.feSpace) {return true;}
+                                    if (feSpace == rhs.feSpace) {
+                                        if (isBasisContinuous  < rhs.isBasisContinuous) {return true;}
+                                    }
                                 }
                             }
                         }
@@ -177,7 +185,7 @@ public:
                 }
             }
             return false;
-        }
+        } // operator<
 
     }; // Discretization
 

--- a/libsrc/pylith/topology/FieldFactory.cc
+++ b/libsrc/pylith/topology/FieldFactory.cc
@@ -66,9 +66,10 @@ pylith::topology::FieldFactory::setSubfieldDiscretization(const char* subfieldNa
                                                           const int basisOrder,
                                                           const int quadOrder,
                                                           const int dimension,
+                                                          const bool isFaultOnly,
                                                           const pylith::topology::FieldBase::CellBasis cellBasis,
-                                                          const bool isBasisContinuous,
-                                                          const pylith::topology::FieldBase::SpaceEnum feSpace) {
+                                                          const pylith::topology::FieldBase::SpaceEnum feSpace,
+                                                          const bool isBasisContinuous) {
     PYLITH_METHOD_BEGIN;
     PYLITH_JOURNAL_DEBUG("setSubfieldDiscretization(subfieldName="<<subfieldName<<", basisOrder="<<basisOrder<<", quadOrder="<<quadOrder<<", dimension="<<dimension<<", cellBasis="<<cellBasis<<", isBasisContinuous="<<isBasisContinuous<<")");
     assert(dimension != 0);
@@ -78,8 +79,9 @@ pylith::topology::FieldFactory::setSubfieldDiscretization(const char* subfieldNa
     feInfo.quadOrder = quadOrder;
     feInfo.dimension = dimension;
     feInfo.cellBasis = cellBasis;
-    feInfo.isBasisContinuous = isBasisContinuous;
+    feInfo.isFaultOnly = isFaultOnly;
     feInfo.feSpace = feSpace;
+    feInfo.isBasisContinuous = isBasisContinuous;
     _subfieldDiscretizations[subfieldName] = feInfo;
 
     PYLITH_METHOD_END;

--- a/libsrc/pylith/topology/FieldFactory.hh
+++ b/libsrc/pylith/topology/FieldFactory.hh
@@ -55,6 +55,7 @@ public:
      * @param[in] basisOrder Polynomial order for basis.
      * @param[in] quadOrder Order of quadrature rule.
      * @param[in] dimension Dimension of points for discretization.
+     * @param[in] isFaultOnly True if subfield is limited to fault degrees of freedom.
      * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
      * @param[in] isBasisContinuous True if basis is continuous.
      * @param[in] feSpace Finite-element space.
@@ -63,9 +64,10 @@ public:
                                    const int basisOrder,
                                    const int quadOrder,
                                    const int dimension,
+                                   const bool isFaultOnly,
                                    const pylith::topology::FieldBase::CellBasis cellBasis,
-                                   const bool isBasisContinuous,
-                                   const pylith::topology::FieldBase::SpaceEnum feSpace);
+                                   const pylith::topology::FieldBase::SpaceEnum feSpace,
+                                   const bool isBasisContinuous);
 
     /** Get discretization information for subfield.
      *

--- a/libsrc/pylith/topology/FieldOps.cc
+++ b/libsrc/pylith/topology/FieldOps.cc
@@ -54,7 +54,8 @@ pylith::topology::FieldOps::createFE(const FieldBase::Discretization& feinfo,
     err = DMGetDimension(dm, &dim);PYLITH_CHECK_ERROR(err);
     dim = (feinfo.dimension < 0) ? dim : feinfo.dimension;assert(dim > 0);
     FieldBase::Discretization feKey = FieldBase::Discretization(feinfo.basisOrder, feinfo.quadOrder, dim, numComponents,
-                                                                feinfo.cellBasis, feinfo.isBasisContinuous, feinfo.feSpace);
+                                                                feinfo.isFaultOnly, feinfo.cellBasis, feinfo.feSpace,
+                                                                feinfo.isBasisContinuous);
     std::map<FieldBase::Discretization, pylith::topology::FE>::const_iterator hasFE = pylith::topology::FieldOps::feStore.find(feKey);
 
     if (hasFE == pylith::topology::FieldOps::feStore.end()) {

--- a/modulesrc/problems/Physics.i
+++ b/modulesrc/problems/Physics.i
@@ -78,16 +78,16 @@ public:
              * @param[in] quadOrder Order of quadrature rule.
              * @param[in] dimension Dimension of points for discretization.
              * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
-             * @param[in] isBasisContinuous True if basis is continuous.
              * @param[in] feSpace Finite-element space.
+             * @param[in] isBasisContinuous True if basis is continuous.
              */
             void setAuxiliarySubfieldDiscretization(const char* subfieldName,
                                                     const int basisOrder,
                                                     const int quadOrder,
                                                     const int dimension,
                                                     const pylith::topology::FieldBase::CellBasis cellBasis,
-                                                    const bool isBasisContinuous,
-                                                    const pylith::topology::FieldBase::SpaceEnum feSpace);
+                                                    const pylith::topology::FieldBase::SpaceEnum feSpace,
+                                                    const bool isBasisContinuous);
 
             /** Set discretization information for derived subfield.
              *
@@ -96,16 +96,16 @@ public:
              * @param[in] quadOrder Order of quadrature rule.
              * @param[in] dimension Dimension of points for discretization.
              * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
-             * @param[in] isBasisContinuous True if basis is continuous.
              * @param[in] feSpace Finite-element space.
+             * @param[in] isBasisContinuous True if basis is continuous.
              */
             void setDerivedSubfieldDiscretization(const char* subfieldName,
                                                   const int basisOrder,
                                                   const int quadOrder,
                                                   const int dimension,
                                                   const pylith::topology::FieldBase::CellBasis cellBasis,
-                                                  const bool isBasisContinuous,
-                                                  const pylith::topology::FieldBase::SpaceEnum feSpace);
+                                                  const pylith::topology::FieldBase::SpaceEnum feSpace,
+                                                  const bool isBasisContinuous);
 
             /** Register observer to receive notifications.
              *

--- a/modulesrc/topology/Field.i
+++ b/modulesrc/topology/Field.i
@@ -144,22 +144,23 @@ public:
             /// Zero local values (including constrained values).
             void zeroLocal(void);
 
-            /** Add subfield to current field.
+            /** Add subfield to current field (for use from SWIG).
              *
              * Should be followed by calls to subfieldsSetup() and allocate().
              *
-             * @param[in] name Programatic name for subfield.
-             * @param[in] alias User-specified name for subfield.
+             * @param[in] name Programatic name of subfield.
+             * @param[in] alias User-specified alias for subfield.
              * @param[in] fieldType Type of vector field.
-             * @param[in] components Names of components in subfield.
-             * @param[in] numComponents Number of components in subfield.
-             * @param[in] basisOrder Polynomial order for basis.
-             * @param[in] quadOrder Order of quadrature rule.
+             * @param[in] components Array of names of field components.
+             * @param[in] numComponents Size of array.
+             * @param[in] scale Dimensional scale associated with field.
+             * @param[in] basisOrder Order of basis functions for discretization.
+             * @param[in] quadOrder Order of numerical quadrature for discretization.
              * @param[in] dimension Dimension of points for discretization.
+             * @param[in] isFaultOnly True if subfield is limited to fault degrees of freedom.
              * @param[in] cellBasis Type of basis functions to use (e.g., simplex, tensor, or default).
+             * @param[in] feSpace Finite-element space (POLYNOMIAL_SPACE or POINT_SPACE).
              * @param[in] isBasisContinuous True if basis is continuous.
-             * @param[in] feSpace Finite-element space (polynomial or point).
-             * @param[in] scale Scale for dimensionalizing field.
              */
             %apply(const char* const* string_list, const int list_len) {
                 (const char* components[], const int numComponents)
@@ -173,9 +174,10 @@ public:
                              const int basisOrder,
                              const int quadOrder,
                              const int dimension,
+                             const bool isFaultOnly,
                              const CellBasis cellBasis,
-                             const bool isBasisContinuous,
-                             const SpaceEnum feSpace);
+                             const SpaceEnum feSpace,
+                             const bool isBasisContinuous);
 
             %clear(const char* components[], const int numComponents);
 

--- a/pylith/materials/RheologyElasticity.py
+++ b/pylith/materials/RheologyElasticity.py
@@ -65,7 +65,7 @@ class RheologyElasticity(PetscComponent, ModuleRheology):
             else:
                 quadOrder = subfield.quadOrder
             material.setAuxiliarySubfieldDiscretization(fieldName, subfield.basisOrder, quadOrder, subfield.dimension,
-                                                        subfield.cellBasis, subfield.isBasisContinuous, subfield.feSpace)
+                                                        subfield.cellBasis, subfield.feSpace, subfield.isBasisContinuous)
         return
 
     # PRIVATE METHODS ////////////////////////////////////////////////////

--- a/pylith/materials/RheologyIncompressibleElasticity.py
+++ b/pylith/materials/RheologyIncompressibleElasticity.py
@@ -66,7 +66,7 @@ class RheologyIncompressibleElasticity(PetscComponent, ModuleRheology):
             else:
                 quadOrder = subfield.quadOrder
             material.setAuxiliarySubfieldDiscretization(fieldName, subfield.basisOrder, quadOrder, subfield.dimension,
-                                                        subfield.cellBasis, subfield.isBasisContinuous, subfield.feSpace)
+                                                        subfield.cellBasis, subfield.feSpace, subfield.isBasisContinuous)
         return
 
     # PRIVATE METHODS ////////////////////////////////////////////////////

--- a/pylith/materials/RheologyPoroelasticity.py
+++ b/pylith/materials/RheologyPoroelasticity.py
@@ -66,7 +66,7 @@ class RheologyPoroelasticity(PetscComponent, ModuleRheology):
             else:
                 quadOrder = subfield.quadOrder
             material.setAuxiliarySubfieldDiscretization(fieldName, subfield.basisOrder, quadOrder, subfield.dimension,
-                                                        subfield.cellBasis, subfield.isBasisContinuous, subfield.feSpace)
+                                                        subfield.cellBasis, subfield.feSpace, subfield.isBasisContinuous)
         return
 
     # PRIVATE METHODS ////////////////////////////////////////////////////

--- a/pylith/problems/Physics.py
+++ b/pylith/problems/Physics.py
@@ -88,7 +88,7 @@ class Physics(PetscComponent, ModulePhysics):
                 quadOrder = subfield.quadOrder
             ModulePhysics.setAuxiliarySubfieldDiscretization(self, fieldName, subfield.basisOrder, quadOrder,
                                                              subfield.dimension, subfield.cellBasis,
-                                                             subfield.isBasisContinuous, subfield.feSpace)
+                                                             subfield.feSpace, subfield.isBasisContinuous)
 
         for subfield in self.derivedSubfields.components():
             fieldName = subfield.aliases[-1]
@@ -99,7 +99,7 @@ class Physics(PetscComponent, ModulePhysics):
                 quadOrder = subfield.quadOrder
             ModulePhysics.setDerivedSubfieldDiscretization(self, fieldName, subfield.basisOrder, quadOrder,
                                                            subfield.dimension, subfield.cellBasis,
-                                                           subfield.isBasisContinuous, subfield.feSpace)
+                                                           subfield.feSpace, subfield.isBasisContinuous)
 
         for observer in self.observers.components():
             observer.preinitialize(problem, identifier)

--- a/pylith/problems/Solution.py
+++ b/pylith/problems/Solution.py
@@ -67,9 +67,10 @@ class Solution(PetscComponent):
                 quadOrder = problem.defaults.quadOrder
             else:
                 quadOrder = subfield.quadOrder
-            self.field.subfieldAdd(subfield.fieldName, subfield.userAlias, subfield.vectorFieldType, subfield.componentNames,
-                                   subfield.scale.value, subfield.basisOrder, quadOrder, subfield.dimension,
-                                   subfield.cellBasis, subfield.isBasisContinuous, subfield.feSpace)
+            self.field.subfieldAdd(subfield.fieldName, subfield.userAlias, subfield.vectorFieldType, 
+                                   subfield.componentNames, subfield.scale.value, subfield.basisOrder, 
+                                   quadOrder, subfield.dimension, subfield.isFaultOnly,
+                                   subfield.cellBasis, subfield.feSpace, subfield.isBasisContinuous)
         return
 
     # PRIVATE METHODS ////////////////////////////////////////////////////

--- a/pylith/problems/SolutionSubfield.py
+++ b/pylith/problems/SolutionSubfield.py
@@ -57,6 +57,7 @@ class SolutionSubfield(Subfield):
         self.fieldComponents = None
         self.vectorFieldType = None
         self.scale = None
+        self.isFaultOnly = False
         return
 
     def initialize(self, normalizer, spaceDim):

--- a/pylith/problems/SubfieldLagrangeFault.py
+++ b/pylith/problems/SubfieldLagrangeFault.py
@@ -52,6 +52,7 @@ class SubfieldLagrangeFault(SolutionSubfield):
         self.vectorFieldType = Field.VECTOR
         self.scale = normalizer.getPressureScale()
         self._setComponents(spaceDim)
+        self.isFaultOnly = True
         return
 
     # PRIVATE METHODS ////////////////////////////////////////////////////

--- a/tests/libtests/feassemble/TestAuxiliaryFactory.cc
+++ b/tests/libtests/feassemble/TestAuxiliaryFactory.cc
@@ -106,25 +106,26 @@ pylith::feassemble::TestAuxiliaryFactory::testQueryDB(void) {
 // Test setSubfieldDiscretization() and getSubfieldDiscretization().
 void
 pylith::feassemble::TestAuxiliaryFactory::testSubfieldDiscretization(void) {
-    pylith::topology::FieldBase::Discretization feDisp(2, 2, -1, 2, pylith::topology::FieldBase::SIMPLEX_BASIS,
-                                                       true, pylith::topology::FieldBase::POLYNOMIAL_SPACE);
-    pylith::topology::FieldBase::Discretization feVel(3, 2, 1, 2, pylith::topology::FieldBase::SIMPLEX_BASIS,
-                                                      false, pylith::topology::FieldBase::POINT_SPACE);
+    pylith::topology::FieldBase::Discretization feDisp(2, 2, -1, 2, false, pylith::topology::FieldBase::SIMPLEX_BASIS,
+                                                       pylith::topology::FieldBase::POLYNOMIAL_SPACE, true);
+    pylith::topology::FieldBase::Discretization feVel(3, 2, 1, 2, true, pylith::topology::FieldBase::SIMPLEX_BASIS,
+                                                      pylith::topology::FieldBase::POINT_SPACE, false);
 
     CPPUNIT_ASSERT(_factory);
     _factory->setSubfieldDiscretization("displacement", feDisp.basisOrder, feDisp.quadOrder, feDisp.dimension,
-                                        feDisp.cellBasis, feDisp.isBasisContinuous, feDisp.feSpace);
+                                        feDisp.isFaultOnly, feDisp.cellBasis, feDisp.feSpace, feDisp.isBasisContinuous);
     _factory->setSubfieldDiscretization("velocity", feVel.basisOrder, feVel.quadOrder, feVel.dimension,
-                                        feVel.cellBasis, feVel.isBasisContinuous, feVel.feSpace);
+                                        feVel.isFaultOnly, feVel.cellBasis, feVel.feSpace, feVel.isBasisContinuous);
 
     { // Check displacement discretization
         const pylith::topology::FieldBase::Discretization& feTest = _factory->getSubfieldDiscretization("displacement");
         CPPUNIT_ASSERT_EQUAL(feDisp.basisOrder, feTest.basisOrder);
         CPPUNIT_ASSERT_EQUAL(feDisp.quadOrder, feTest.quadOrder);
         CPPUNIT_ASSERT_EQUAL(feDisp.dimension, feTest.dimension);
+        CPPUNIT_ASSERT_EQUAL(feDisp.isFaultOnly, feTest.isFaultOnly);
         CPPUNIT_ASSERT_EQUAL(feDisp.cellBasis, feTest.cellBasis);
-        CPPUNIT_ASSERT_EQUAL(feDisp.isBasisContinuous, feTest.isBasisContinuous);
         CPPUNIT_ASSERT_EQUAL(feDisp.feSpace, feTest.feSpace);
+        CPPUNIT_ASSERT_EQUAL(feDisp.isBasisContinuous, feTest.isBasisContinuous);
     } // Check displacement discretization
 
     { // Check velocity discretization
@@ -132,9 +133,10 @@ pylith::feassemble::TestAuxiliaryFactory::testSubfieldDiscretization(void) {
         CPPUNIT_ASSERT_EQUAL(feVel.basisOrder, feTest.basisOrder);
         CPPUNIT_ASSERT_EQUAL(feVel.quadOrder, feTest.quadOrder);
         CPPUNIT_ASSERT_EQUAL(feVel.dimension, feTest.dimension);
+        CPPUNIT_ASSERT_EQUAL(feVel.isFaultOnly, feTest.isFaultOnly);
         CPPUNIT_ASSERT_EQUAL(feVel.cellBasis, feTest.cellBasis);
-        CPPUNIT_ASSERT_EQUAL(feVel.isBasisContinuous, feTest.isBasisContinuous);
         CPPUNIT_ASSERT_EQUAL(feVel.feSpace, feTest.feSpace);
+        CPPUNIT_ASSERT_EQUAL(feVel.isBasisContinuous, feTest.isBasisContinuous);
     } // Check velocity discretization
 
     { // default for unknown discretization
@@ -142,9 +144,10 @@ pylith::feassemble::TestAuxiliaryFactory::testSubfieldDiscretization(void) {
         CPPUNIT_ASSERT_EQUAL(1, feTest.basisOrder);
         CPPUNIT_ASSERT_EQUAL(1, feTest.quadOrder);
         CPPUNIT_ASSERT_EQUAL(-1, feTest.dimension);
+        CPPUNIT_ASSERT_EQUAL(false, feTest.isFaultOnly);
         CPPUNIT_ASSERT_EQUAL(pylith::topology::FieldBase::DEFAULT_BASIS, feTest.cellBasis);
-        CPPUNIT_ASSERT_EQUAL(true, feTest.isBasisContinuous);
         CPPUNIT_ASSERT_EQUAL(pylith::topology::FieldBase::POLYNOMIAL_SPACE, feTest.feSpace);
+        CPPUNIT_ASSERT_EQUAL(true, feTest.isBasisContinuous);
     }
 } // testSubfieldDiscretization
 

--- a/tests/libtests/materials/TestAuxiliaryFactoryElastic.cc
+++ b/tests/libtests/materials/TestAuxiliaryFactoryElastic.cc
@@ -68,7 +68,7 @@ pylith::materials::TestAuxiliaryFactoryElastic::setUp(void) {
         pylith::topology::FieldQuery::validatorPositive
         );
     info.fe = pylith::topology::Field::Discretization(
-        2, 2, _auxDim, 1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, _auxDim, 1, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, true
         );
     info.index = 0;
     _data->subfields["density"] = info;
@@ -86,7 +86,7 @@ pylith::materials::TestAuxiliaryFactoryElastic::setUp(void) {
         pylith::topology::FieldQuery::validatorNonnegative
         );
     info.fe = pylith::topology::Field::Discretization(
-        1, 2, _auxDim, 1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        1, 2, _auxDim, 1, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, true
         );
     info.index = 1;
     _data->subfields["shear_modulus"] = info;
@@ -104,7 +104,7 @@ pylith::materials::TestAuxiliaryFactoryElastic::setUp(void) {
         pylith::topology::FieldQuery::validatorPositive
         );
     info.fe = pylith::topology::Field::Discretization(
-        1, 2, _auxDim, 1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        1, 2, _auxDim, 1, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, true
         );
     info.index = 2;
     _data->subfields["bulk_modulus"] = info;
@@ -126,7 +126,7 @@ pylith::materials::TestAuxiliaryFactoryElastic::setUp(void) {
         _data->normalizer->getPressureScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        2, 2, _auxDim, _auxDim, pylith::topology::Field::DEFAULT_BASIS, false, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, _auxDim, _auxDim, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, false
         );
     info.index = 3;
     _data->subfields["reference_stress"] = info;
@@ -148,7 +148,7 @@ pylith::materials::TestAuxiliaryFactoryElastic::setUp(void) {
         1.0
         );
     info.fe = pylith::topology::Field::Discretization(
-        2, 2, _auxDim, _auxDim, pylith::topology::Field::DEFAULT_BASIS, false, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, _auxDim, _auxDim, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, false
         );
     info.index = 4;
     _data->subfields["reference_strain"] = info;
@@ -265,7 +265,8 @@ pylith::materials::TestAuxiliaryFactoryElastic::_initialize(void) {
     for (subfield_iter iter = _data->subfields.begin(); iter != _data->subfields.end(); ++iter) {
         const char* subfieldName = iter->first.c_str();
         const pylith::topology::Field::Discretization& fe = iter->second.fe;
-        _factory->setSubfieldDiscretization(subfieldName, fe.basisOrder, fe.quadOrder, fe.dimension, fe.cellBasis, fe.isBasisContinuous, fe.feSpace);
+        _factory->setSubfieldDiscretization(subfieldName, fe.basisOrder, fe.quadOrder, fe.dimension, fe.isFaultOnly,
+                                            fe.cellBasis, fe.feSpace, fe.isBasisContinuous);
     } // for
     CPPUNIT_ASSERT(_data->normalizer);
     _factory->initialize(_auxiliaryField, *_data->normalizer, _data->dimension);

--- a/tests/libtests/materials/TestAuxiliaryFactoryElasticity.cc
+++ b/tests/libtests/materials/TestAuxiliaryFactoryElasticity.cc
@@ -63,7 +63,7 @@ pylith::materials::TestAuxiliaryFactoryElasticity::setUp(void) {
         pylith::topology::FieldQuery::validatorPositive
         );
     info.fe = pylith::topology::Field::Discretization(
-        1, 2, _auxDim, 1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        1, 2, _auxDim, 1, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, true
         );
     info.index = 0;
     _data->subfields["density"] = info;
@@ -82,7 +82,7 @@ pylith::materials::TestAuxiliaryFactoryElasticity::setUp(void) {
         _data->normalizer->getPressureScale() / _data->normalizer->getLengthScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        2, 2, _auxDim, _auxDim, pylith::topology::Field::DEFAULT_BASIS, false, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, _auxDim, _auxDim, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, false
         );
     info.index = 1;
     _data->subfields["body_force"] = info;
@@ -101,7 +101,7 @@ pylith::materials::TestAuxiliaryFactoryElasticity::setUp(void) {
         _data->normalizer->getLengthScale() / pow(_data->normalizer->getTimeScale(), 2)
         );
     info.fe = pylith::topology::Field::Discretization(
-        2, 2, _auxDim, _auxDim, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, _auxDim, _auxDim, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, true
         );
     info.index = 2;
     _data->subfields["gravitational_acceleration"] = info;
@@ -212,8 +212,8 @@ pylith::materials::TestAuxiliaryFactoryElasticity::_initialize(void) {
     for (subfield_iter iter = _data->subfields.begin(); iter != _data->subfields.end(); ++iter) {
         const char* subfieldName = iter->first.c_str();
         const pylith::topology::Field::Discretization& fe = iter->second.fe;
-        _factory->setSubfieldDiscretization(subfieldName, fe.basisOrder, fe.quadOrder, fe.dimension, fe.cellBasis,
-                                            fe.isBasisContinuous, fe.feSpace);
+        _factory->setSubfieldDiscretization(subfieldName, fe.basisOrder, fe.quadOrder, fe.dimension, fe.isFaultOnly, fe.cellBasis,
+                                            fe.feSpace, fe.isBasisContinuous);
     } // for
     CPPUNIT_ASSERT(_data->normalizer);
     _factory->initialize(_auxiliaryField, *_data->normalizer, _data->dimension);

--- a/tests/libtests/problems/TestPhysics.cc
+++ b/tests/libtests/problems/TestPhysics.cc
@@ -25,6 +25,7 @@
 #include "pylith/topology/Field.hh" // USES Field
 #include "pylith/feassemble/AuxiliaryFactory.hh" // USES AuxiliaryFactory
 #include "pylith/utils/types.hh" // USES PylithReal
+#include "pylith/utils/error.hh" // USES PYLITH_METHOD_*
 
 #include "pylith/testing/ObserverPhysicsStub.hh" // USES ObserversPhysicsStub
 #include "pylith/problems/ObserversPhysics.hh" // USES ObserversPhysics
@@ -104,8 +105,8 @@ pylith::problems::TestPhysics::testSetAuxiliarySubfieldDiscretization(void) {
     PYLITH_METHOD_BEGIN;
 
     CPPUNIT_ASSERT(_physics);
-    _physics->setAuxiliarySubfieldDiscretization("fieldA", 1, 2, 3, true, pylith::topology::Field::POLYNOMIAL_SPACE);
-    _physics->setAuxiliarySubfieldDiscretization("fieldB", 2, 3, 4, false, pylith::topology::Field::POINT_SPACE);
+    _physics->setAuxiliarySubfieldDiscretization("fieldA", 1, 2, 3, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, true);
+    _physics->setAuxiliarySubfieldDiscretization("fieldB", 2, 3, 4, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POINT_SPACE, true);
 
     const pylith::feassemble::AuxiliaryFactory* factory = _physics->_getAuxiliaryFactory();CPPUNIT_ASSERT(factory);
 

--- a/tests/libtests/problems/TestSolutionFactory.cc
+++ b/tests/libtests/problems/TestSolutionFactory.cc
@@ -63,7 +63,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getLengthScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        1, 2, -1, -1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        1, 2, -1, -1, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, true
         );
     info.index = 0;
     _data->subfields["displacement"] = info;
@@ -82,7 +82,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getLengthScale() / _data->normalizer->getTimeScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        2, 3, -1, -1, pylith::topology::Field::DEFAULT_BASIS, false, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 3, -1, -1, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, false
         );
     info.index = 1;
     _data->subfields["velocity"] = info;
@@ -99,7 +99,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getPressureScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        2, 2, -1, -1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, -1, -1, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, true
         );
     info.index = 0;
     _data->subfields["pressure"] = info;
@@ -116,7 +116,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getLengthScale() / _data->normalizer->getLengthScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        2, 2, -1, -1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, -1, -1, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, true
         );
     info.index = 1;
     _data->subfields["trace_strain"] = info;
@@ -135,7 +135,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getPressureScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        2, 2, -1, -1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POLYNOMIAL_SPACE
+        2, 2, -1, -1, true, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POLYNOMIAL_SPACE, true
         );
     info.index = 1;
     _data->subfields["lagrange_multiplier_fault"] = info;
@@ -152,7 +152,7 @@ pylith::problems::TestSolutionFactory::setUp(void) {
         _data->normalizer->getTemperatureScale()
         );
     info.fe = pylith::topology::Field::Discretization(
-        2, 3, -1, -1, pylith::topology::Field::DEFAULT_BASIS, true, pylith::topology::Field::POINT_SPACE
+        2, 3, -1, -1, false, pylith::topology::Field::DEFAULT_BASIS, pylith::topology::Field::POINT_SPACE, true
         );
     info.index = 1;
     _data->subfields["temperature"] = info;

--- a/tests/libtests/topology/TestFieldMesh.cc
+++ b/tests/libtests/topology/TestFieldMesh.cc
@@ -274,8 +274,8 @@ pylith::topology::TestFieldMesh::testSubfieldAccessors(void) {
         } // for
         CPPUNIT_ASSERT_EQUAL(_data->discretizationA.basisOrder, infoA.fe.basisOrder);
         CPPUNIT_ASSERT_EQUAL(_data->discretizationA.quadOrder, infoA.fe.quadOrder);
-        CPPUNIT_ASSERT_EQUAL(_data->discretizationA.isBasisContinuous, infoA.fe.isBasisContinuous);
         CPPUNIT_ASSERT_EQUAL(_data->discretizationA.feSpace, infoA.fe.feSpace);
+        CPPUNIT_ASSERT_EQUAL(_data->discretizationA.isBasisContinuous, infoA.fe.isBasisContinuous);
     } // Test getSubfieldInfo() for subfield A.
 
     { // Test getSubfieldInfo() for subfield B.
@@ -292,8 +292,8 @@ pylith::topology::TestFieldMesh::testSubfieldAccessors(void) {
         } // for
         CPPUNIT_ASSERT_EQUAL(_data->discretizationB.basisOrder, infoB.fe.basisOrder);
         CPPUNIT_ASSERT_EQUAL(_data->discretizationB.quadOrder, infoB.fe.quadOrder);
-        CPPUNIT_ASSERT_EQUAL(_data->discretizationB.isBasisContinuous, infoB.fe.isBasisContinuous);
         CPPUNIT_ASSERT_EQUAL(_data->discretizationB.feSpace, infoB.fe.feSpace);
+        CPPUNIT_ASSERT_EQUAL(_data->discretizationB.isBasisContinuous, infoB.fe.isBasisContinuous);
     } // Test getSubfieldInfo() for subfield B.
 
     CPPUNIT_ASSERT_THROW(_field->getSubfieldInfo("aabbccdd"), std::runtime_error);

--- a/tests/libtests/topology/TestFieldMesh_Cases.cc
+++ b/tests/libtests/topology/TestFieldMesh_Cases.cc
@@ -60,8 +60,8 @@ namespace pylith {
 
                 _data->discretizationA.basisOrder = 1;
                 _data->discretizationA.quadOrder = 1;
-                _data->discretizationA.isBasisContinuous = true;
                 _data->discretizationA.feSpace = pylith::topology::FieldBase::POLYNOMIAL_SPACE;
+                _data->discretizationA.isBasisContinuous = true;
 
                 static const PylithScalar _subfieldAValues[4*2] = {
                     1.1, 1.2,
@@ -91,8 +91,8 @@ namespace pylith {
 
                 _data->discretizationB.basisOrder = 1;
                 _data->discretizationB.quadOrder = 1;
-                _data->discretizationB.isBasisContinuous = true;
                 _data->discretizationB.feSpace = pylith::topology::FieldBase::POLYNOMIAL_SPACE;
+                _data->discretizationB.isBasisContinuous = true;
 
                 static const PylithScalar _subfieldBValues[4*1] = {
                     1.3,

--- a/tests/libtests/topology/TestReverseCuthillMcKee.cc
+++ b/tests/libtests/topology/TestReverseCuthillMcKee.cc
@@ -167,8 +167,6 @@ pylith::topology::TestReverseCuthillMcKee::testReorder(void) {
     Field::Discretization discretization;
     discretization.basisOrder = 1;
     discretization.quadOrder = 1;
-    discretization.isBasisContinuous = true;
-    discretization.feSpace = FieldBase::POLYNOMIAL_SPACE;
     fieldOrig.subfieldAdd(description, discretization);
     fieldOrig.subfieldsSetup();
     fieldOrig.createDiscretization();

--- a/tests/mmstests/elasticity/TestElasticity.cc
+++ b/tests/mmstests/elasticity/TestElasticity.cc
@@ -96,7 +96,7 @@ pylith::mmstests::TestElasticity::_initialize(void) {
         const pylith::topology::FieldBase::Discretization& info = _data->auxDiscretizations[i];
         _material->setAuxiliarySubfieldDiscretization(_data->auxSubfields[i], info.basisOrder, info.quadOrder,
                                                       _data->spaceDim, pylith::topology::FieldBase::DEFAULT_BASIS,
-                                                      info.isBasisContinuous, info.feSpace);
+                                                      info.feSpace, info.isBasisContinuous);
     } // for
 
     // Set up problem.

--- a/tests/mmstests/faults/TestFaultKin.cc
+++ b/tests/mmstests/faults/TestFaultKin.cc
@@ -99,7 +99,7 @@ pylith::mmstests::TestFaultKin::_initialize(void) {
     for (int i = 0; i < _data->matNumAuxSubfields; ++i) {
         const pylith::topology::FieldBase::Discretization& info = _data->matAuxDiscretizations[i];
         _material->setAuxiliarySubfieldDiscretization(_data->matAuxSubfields[i], info.basisOrder, info.quadOrder,
-                                                      _data->spaceDim, info.cellBasis, info.isBasisContinuous, info.feSpace);
+                                                      _data->spaceDim, info.cellBasis, info.feSpace, info.isBasisContinuous);
     } // for
 
     // Set up fault
@@ -114,7 +114,7 @@ pylith::mmstests::TestFaultKin::_initialize(void) {
     for (int i = 0; i < _data->faultNumAuxSubfields; ++i) {
         const pylith::topology::FieldBase::Discretization& info = _data->faultAuxDiscretizations[i];
         _fault->setAuxiliarySubfieldDiscretization(_data->faultAuxSubfields[i], info.basisOrder, info.quadOrder,
-                                                   _data->spaceDim-1, info.cellBasis, info.isBasisContinuous, info.feSpace);
+                                                   _data->spaceDim-1, info.cellBasis, info.feSpace, info.isBasisContinuous);
     } // for
 
     // Set up problem.

--- a/tests/mmstests/faults/TestFaultKin2D_RigidBlocksStatic.cc
+++ b/tests/mmstests/faults/TestFaultKin2D_RigidBlocksStatic.cc
@@ -327,7 +327,7 @@ class pylith::mmstests::TestFaultKin2D_RigidBlocksStatic_TriP1 :
         _data->numSolnSubfields = 2;
         static const pylith::topology::Field::Discretization _solnDiscretizations[2] = {
             pylith::topology::Field::Discretization(1, 1), // disp
-            pylith::topology::Field::Discretization(1, 1, 1), // lagrange_multiplier_fault
+            pylith::topology::Field::Discretization(1, 1, 1, -1, true), // lagrange_multiplier_fault
         };
         _data->solnDiscretizations = const_cast<pylith::topology::Field::Discretization*>(_solnDiscretizations);
 
@@ -364,7 +364,7 @@ class pylith::mmstests::TestFaultKin2D_RigidBlocksStatic_TriP2 :
         _data->numSolnSubfields = 2;
         static const pylith::topology::Field::Discretization _solnDiscretizations[2] = {
             pylith::topology::Field::Discretization(2, 2), // disp
-            pylith::topology::Field::Discretization(2, 2, 1), // lagrange_multiplier_fault
+            pylith::topology::Field::Discretization(2, 2, 1, -1, true), // lagrange_multiplier_fault
         };
         _data->solnDiscretizations = const_cast<pylith::topology::Field::Discretization*>(_solnDiscretizations);
 
@@ -401,7 +401,7 @@ class pylith::mmstests::TestFaultKin2D_RigidBlocksStatic_TriP3 :
         _data->numSolnSubfields = 2;
         static const pylith::topology::Field::Discretization _solnDiscretizations[2] = {
             pylith::topology::Field::Discretization(3, 3), // disp
-            pylith::topology::Field::Discretization(3, 3, 1), // lagrange_multiplier_fault
+            pylith::topology::Field::Discretization(3, 3, 1, -1, true), // lagrange_multiplier_fault
         };
         _data->solnDiscretizations = const_cast<pylith::topology::Field::Discretization*>(_solnDiscretizations);
 
@@ -438,7 +438,7 @@ class pylith::mmstests::TestFaultKin2D_RigidBlocksStatic_TriP4 :
         _data->numSolnSubfields = 2;
         static const pylith::topology::Field::Discretization _solnDiscretizations[2] = {
             pylith::topology::Field::Discretization(4, 4), // disp
-            pylith::topology::Field::Discretization(4, 4, 1), // lagrange_multiplier_fault
+            pylith::topology::Field::Discretization(4, 4, 1, -1, true), // lagrange_multiplier_fault
         };
         _data->solnDiscretizations = const_cast<pylith::topology::Field::Discretization*>(_solnDiscretizations);
 
@@ -463,7 +463,7 @@ class pylith::mmstests::TestFaultKin2D_RigidBlocksStatic_QuadQ1 :
         _data->numSolnSubfields = 2;
         static const pylith::topology::Field::Discretization _solnDiscretizations[2] = {
             pylith::topology::Field::Discretization(1, 1), // disp
-            pylith::topology::Field::Discretization(1, 1, 1), // lagrange_multiplier_fault
+            pylith::topology::Field::Discretization(1, 1, 1, -1, true), // lagrange_multiplier_fault
         };
         _data->solnDiscretizations = const_cast<pylith::topology::Field::Discretization*>(_solnDiscretizations);
 
@@ -500,7 +500,7 @@ class pylith::mmstests::TestFaultKin2D_RigidBlocksStatic_QuadQ2 :
         _data->numSolnSubfields = 2;
         static const pylith::topology::Field::Discretization _solnDiscretizations[2] = {
             pylith::topology::Field::Discretization(2, 2), // disp
-            pylith::topology::Field::Discretization(2, 2, 1), // lagrange_multiplier_fault
+            pylith::topology::Field::Discretization(2, 2, 1, -1, true), // lagrange_multiplier_fault
         };
         _data->solnDiscretizations = const_cast<pylith::topology::Field::Discretization*>(_solnDiscretizations);
 
@@ -537,7 +537,7 @@ class pylith::mmstests::TestFaultKin2D_RigidBlocksStatic_QuadQ3 :
         _data->numSolnSubfields = 2;
         static const pylith::topology::Field::Discretization _solnDiscretizations[2] = {
             pylith::topology::Field::Discretization(3, 3), // disp
-            pylith::topology::Field::Discretization(3, 3, 1), // lagrange_multiplier_fault
+            pylith::topology::Field::Discretization(3, 3, 1, -1, true), // lagrange_multiplier_fault
         };
         _data->solnDiscretizations = const_cast<pylith::topology::Field::Discretization*>(_solnDiscretizations);
 
@@ -574,7 +574,7 @@ class pylith::mmstests::TestFaultKin2D_RigidBlocksStatic_QuadQ4 :
         _data->numSolnSubfields = 2;
         static const pylith::topology::Field::Discretization _solnDiscretizations[2] = {
             pylith::topology::Field::Discretization(4, 4), // disp
-            pylith::topology::Field::Discretization(4, 4, 1), // lagrange_multiplier_fault
+            pylith::topology::Field::Discretization(4, 4, 1, -1, true), // lagrange_multiplier_fault
         };
         _data->solnDiscretizations = const_cast<pylith::topology::Field::Discretization*>(_solnDiscretizations);
 

--- a/tests/mmstests/incompressibleelasticity/TestIncompressibleElasticity.cc
+++ b/tests/mmstests/incompressibleelasticity/TestIncompressibleElasticity.cc
@@ -98,7 +98,7 @@ pylith::mmstests::TestIncompressibleElasticity::_initialize(void) {
         const pylith::topology::FieldBase::Discretization& info = _data->auxDiscretizations[i];
         _material->setAuxiliarySubfieldDiscretization(_data->auxSubfields[i], info.basisOrder, info.quadOrder,
                                                       _data->spaceDim, pylith::topology::FieldBase::DEFAULT_BASIS,
-                                                      info.isBasisContinuous, info.feSpace);
+                                                      info.feSpace, info.isBasisContinuous);
     } // for
 
     // Set up problem.


### PR DESCRIPTION
Replace two hardwired checks in Problem that rely on the `lagrange_multiplier_fault` subfield name with more robust methods for handling the special case of a subfield over the fault degrees of freedom.

Add a flag to Field::Discretization limiting a subfield to only fault degrees of freedom. This should eventually be replaced by a flag to limit a subfield to label(s) and label value(s) when PETSc DMPlex supports it.
