### PR TITLE
Update to use PETSc 3.15.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ AC_CHECK_HEADER([mpi.h], [], [AC_MSG_ERROR([header 'mpi.h' not found])])
 
 dnl PETSC
 AC_LANG(C)
-CIT_PATH_PETSC([3.15.3])
+CIT_PATH_PETSC([3.15.4])
 CIT_HEADER_PETSC
 CIT_CHECK_LIB_PETSC
 

--- a/tests/libtests/meshio/data/hex8_cell_t10.vtk
+++ b/tests/libtests/meshio/data/hex8_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 16 double

--- a/tests/libtests/meshio/data/hex8_mat_cell_t10.vtk
+++ b/tests/libtests/meshio/data/hex8_mat_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 8 double

--- a/tests/libtests/meshio/data/hex8_mat_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/hex8_mat_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 8 double

--- a/tests/libtests/meshio/data/hex8_points_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/hex8_points_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+points
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 4 double

--- a/tests/libtests/meshio/data/hex8_surf_cell_t10.vtk
+++ b/tests/libtests/meshio/data/hex8_surf_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 6 double

--- a/tests/libtests/meshio/data/hex8_surf_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/hex8_surf_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 6 double

--- a/tests/libtests/meshio/data/hex8_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/hex8_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 16 double

--- a/tests/libtests/meshio/data/quad4_cell_t10.vtk
+++ b/tests/libtests/meshio/data/quad4_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 6 double

--- a/tests/libtests/meshio/data/quad4_mat_cell_t10.vtk
+++ b/tests/libtests/meshio/data/quad4_mat_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 4 double

--- a/tests/libtests/meshio/data/quad4_mat_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/quad4_mat_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 4 double

--- a/tests/libtests/meshio/data/quad4_points_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/quad4_points_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+points
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 3 double

--- a/tests/libtests/meshio/data/quad4_surf_cell_t10.vtk
+++ b/tests/libtests/meshio/data/quad4_surf_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 3 double

--- a/tests/libtests/meshio/data/quad4_surf_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/quad4_surf_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 3 double

--- a/tests/libtests/meshio/data/quad4_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/quad4_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 6 double

--- a/tests/libtests/meshio/data/tet4_cell_t10.vtk
+++ b/tests/libtests/meshio/data/tet4_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 8 double

--- a/tests/libtests/meshio/data/tet4_mat_cell_t10.vtk
+++ b/tests/libtests/meshio/data/tet4_mat_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 8 double

--- a/tests/libtests/meshio/data/tet4_mat_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/tet4_mat_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 8 double

--- a/tests/libtests/meshio/data/tet4_points_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/tet4_points_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+points
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 4 double

--- a/tests/libtests/meshio/data/tet4_surf_cell_t10.vtk
+++ b/tests/libtests/meshio/data/tet4_surf_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 4 double

--- a/tests/libtests/meshio/data/tet4_surf_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/tet4_surf_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 4 double

--- a/tests/libtests/meshio/data/tet4_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/tet4_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 8 double

--- a/tests/libtests/meshio/data/tri3_cell_t10.vtk
+++ b/tests/libtests/meshio/data/tri3_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 6 double

--- a/tests/libtests/meshio/data/tri3_mat_cell_t10.vtk
+++ b/tests/libtests/meshio/data/tri3_mat_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 3 double

--- a/tests/libtests/meshio/data/tri3_mat_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/tri3_mat_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 3 double

--- a/tests/libtests/meshio/data/tri3_points_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/tri3_points_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+points
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 3 double

--- a/tests/libtests/meshio/data/tri3_surf_cell_t10.vtk
+++ b/tests/libtests/meshio/data/tri3_surf_cell_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 2 double

--- a/tests/libtests/meshio/data/tri3_surf_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/tri3_surf_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 2 double

--- a/tests/libtests/meshio/data/tri3_vertex_t10.vtk
+++ b/tests/libtests/meshio/data/tri3_vertex_t10.vtk
@@ -1,5 +1,5 @@
 # vtk DataFile Version 2.0
-Simplicial Mesh Example
+domain
 ASCII
 DATASET UNSTRUCTURED_GRID
 POINTS 6 double


### PR DESCRIPTION
Update VTK output test files to account for better naming of "domain" in PETSc VTK output.