### PR TITLE
Fix fault Jacobian integration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ AC_CHECK_HEADER([mpi.h], [], [AC_MSG_ERROR([header 'mpi.h' not found])])
 
 dnl PETSC
 AC_LANG(C)
-CIT_PATH_PETSC([3.16.0])
+CIT_PATH_PETSC([3.16.1])
 CIT_HEADER_PETSC
 CIT_CHECK_LIB_PETSC
 

--- a/libsrc/pylith/fekernels/FaultCohesiveKin.cc
+++ b/libsrc/pylith/fekernels/FaultCohesiveKin.cc
@@ -473,8 +473,7 @@ pylith::fekernels::FaultCohesiveKin::Jf0ul_pos(const PylithInt dim,
 
     const PylithInt spaceDim = dim + 1; // :KLUDGE: dim passed in is spaceDim-1
 
-    const PylithInt gOffN = 0;
-    const PylithInt gOffP = gOffN+spaceDim;
+    const PylithInt gOffP = 0;
     const PylithInt ncols = spaceDim;
 
     for (PylithInt i = 0; i < spaceDim; ++i) {
@@ -518,12 +517,12 @@ pylith::fekernels::FaultCohesiveKin::Jf0lu(const PylithInt dim,
     const PylithInt spaceDim = dim+1; // :KLUDGE: dim passed in is spaceDim-1
 
     const PylithInt gOffN = 0;
-    const PylithInt gOffP = gOffN+spaceDim;
-    const PylithInt ncols = 2*spaceDim;
+    const PylithInt gOffP = gOffN+spaceDim*spaceDim;
+    const PylithInt ncols = spaceDim;
 
     for (PylithInt i = 0; i < spaceDim; ++i) {
-        Jf0[i*ncols+gOffN+i] += -1.0;
-        Jf0[i*ncols+gOffP+i] += +1.0;
+        Jf0[gOffN+i*ncols+i] += -1.0;
+        Jf0[gOffP+i*ncols+i] += +1.0;
     } // for
 } // Jg0lu
 

--- a/tests/mmstests/Makefile.am
+++ b/tests/mmstests/Makefile.am
@@ -17,6 +17,7 @@
 
 SUBDIRS = \
 	elasticity \
+	incompressibleelasticity \
 	faults
 
 


### PR DESCRIPTION
* Update to PETSc 3.16.1
* Update PETSc `knepley/pylith` branch to allow multiple hybrid fields.
* Fix fault Jacobian integration (indexing of result)