### PR TITLE
Governingeqns elasticity infstrain

### DIFF
--- a/docs-sphinx/user/governingeqns/elasticity-infstrain/dynamic.md
+++ b/docs-sphinx/user/governingeqns/elasticity-infstrain/dynamic.md
@@ -1,0 +1,84 @@
+# Dynamic
+
+For compatibility with PETSc TS algorithms, we want to turn the second order equation {math:numref}`eqn:elasticity:strong:form` into two first order
+equations.
+We introduce the velocity as a unknown, $\vec{v}=\frac{\partial u}{\partial t}$, which leads to
+%
+\begin{equation}
+\begin{aligned}
+% Displacement-velocity
+\frac{\partial \vec{u}}{\partial t} &= \vec{v} \text{ in } \Omega, \\
+% Elasticity
+\rho(\vec{x}) \frac{\partial\vec{v}}{\partial t} &= \vec{f}(\vec{x},t) + \boldsymbol{\nabla} \cdot \boldsymbol{\sigma}(\vec{u}) \text{ in } \Omega, \\
+% Neumann
+\boldsymbol{\sigma} \cdot \vec{n} &= \vec{\tau}(\vec{x},t) \text{ on } \Gamma_\tau, \\
+% Dirichlet
+\vec{u} &= \vec{u}_0(\vec{x},t) \text{ on } \Gamma_u.
+\end{aligned}
+\end{equation}
+%
+We create the weak form by taking the dot product with the trial function ${\vec{\psi}_\mathit{trial}^{u}}$ or ${\vec{\psi}_\mathit{trial}^{v}}$ and integrating over the domain:
+%
+\begin{gather}
+% Displacement-velocity
+\int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot \frac{\partial \vec{u}}{\partial t} \, d\Omega = \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{v} \, d\Omega, \\
+% Elasticity
+\int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} \, d\Omega = \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \left( \vec{f}(t) + \boldsymbol{\nabla} \cdot \boldsymbol{\sigma} (\vec{u}) \right) \, d\Omega.
+\end{gather}
+%
+Using the divergence theorem and incorporating the Neumann boundaries, we can rewrite the second equation as
+%
+\begin{equation}
+\int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} \, d\Omega= \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega  + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma.
+\end{equation}
+%
+For explicit time stepping, we want $F(t,s,\dot{s})=\dot{s}$, so we solve an augmented system in which we multiply the RHS residual function by the inversion of the lumped LHS Jacobian,
+%
+\begin{gather}
+F^*(t,s,\dot{s}) = G^*(t,s) \text{, where} \\
+F^*(t,s,\dot{s}) = \dot{s} \text{ and} \\
+G^*(t,s) = J_F^{-1} G(t,s).
+\end{gather}
+%
+With the augmented system, we have
+%
+\begin{gather}
+% Displacement-velocity
+\frac{\partial \vec{u}}{\partial t}  = M_u^{-1} \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{v} \, d\Omega, \\
+% Elasticity
+\frac{\partial \vec{v}}{\partial t} = M_v^{-1} \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \left( \vec{f}(t) + \boldsymbol{\nabla} \cdot \boldsymbol{\sigma} (\vec{u}) \right) \, d\Omega, \\
+% Mu
+M_u = \mathit{Lump}\left( \int_\Omega {\psi_\mathit{trial}^{u}}_i \delta_{ij} {\psi_\mathit{basis}^{u}}_j \, d\Omega \right), \\
+% Mv
+M_v = \mathit{Lump}\left( \int_\Omega {\psi_\mathit{trial}^{v}}_i \rho(\vec{x}) \delta_{ij} {\psi_\mathit{basis}^{v}}_j \, d\Omega \right).
+\end{gather}
+%
+## Residual Pointwise Functions
+
+With explicit time stepping the PETSc TS assumes the LHS is $\dot{s}$, so we only need the RHS residual functions:
+%
+\begin{equation}
+\begin{aligned}
+% Gu
+G^u(t,s) &= \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot {\color{blue}\underbrace{\color{black}\vec{v}}_{\color{blue}{\vec{g}^u_0}}} \, d\Omega, \\
+% Gv
+G^v(t,s) &=  \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot {\color{blue}\underbrace{\color{black}\vec{f}(\vec{x},t)}_{\color{blue}{\vec{g}^v_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{v}} : {\color{blue}\underbrace{\color{black}-\boldsymbol{\sigma}(\vec{u})}_{\color{blue}{\boldsymbol{g^v_1}}}} \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot{\color{blue}\underbrace{\color{black}\vec{\tau}(\vec{x},t)}_{\color{blue}{\vec{g}^v_0}}} \, d\Gamma,
+\end{aligned}
+\end{equation}
+%
+In the second equation these are the same pointwise functions as in the quasistatic case, only now they are on the RHS instead of the LHS.
+
+## Jacobian Pointwise Functions
+
+These are the pointwise functions associated with $M_u$ and $M_v$ for computing the lumped LHS Jacobian.
+We premultiply the RHS residual function by the inverse of the lumped LHS Jacobian while $s_\mathit{tshift}$ remains on the LHS with $\dot{s}$. As a result, we use LHS Jacobian pointwise functions, but set $s_\mathit{tshift}=1$.
+The LHS Jacobians are:
+%
+\begin{equation}
+\begin{aligned}
+% J_F uu
+M_u = J_F^{uu} &= \frac{\partial F^u}{\partial u} + s_\mathit{tshift} \frac{\partial F^u}{\partial \dot{u}} = \int_\Omega {\psi_\mathit{trial}^{u}}_i{\color{blue}\underbrace{\color{black}s_\mathit{tshift} \delta_{ij}}_{\color{blue}{J^{uu}_{f0}}}} {\psi_\mathit{basis}^{u}}_j  \, d\Omega, \\
+% J_F vv
+M_v = J_F^{vv} &= \frac{\partial F^v}{\partial v} + s_\mathit{tshift} \frac{\partial F^v}{\partial \dot{v}} = \int_\Omega {\psi_\mathit{trial}^{v}}_i {\color{blue}  \underbrace{\color{black}\rho(\vec{x}) s_\mathit{tshift} \delta_{ij}}_{\color{blue}{J ^{vv}_{f0}}}} {\psi_\mathit{basis}^{v}}_j \, d\Omega
+\end{aligned}
+\end{equation}

--- a/docs-sphinx/user/governingeqns/elasticity-infstrain/dynamic.md
+++ b/docs-sphinx/user/governingeqns/elasticity-infstrain/dynamic.md
@@ -46,13 +46,13 @@ With the augmented system, we have
 % Displacement-velocity
 \frac{\partial \vec{u}}{\partial t}  = M_u^{-1} \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{v} \, d\Omega, \\
 % Elasticity
-\frac{\partial \vec{v}}{\partial t} = M_v^{-1} \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \left( \vec{f}(t) + \boldsymbol{\nabla} \cdot \boldsymbol{\sigma} (\vec{u}) \right) \, d\Omega, \\
+\frac{\partial \vec{v}}{\partial t} = M_v^{-1} \left(\int_\Omega \vec{\psi}_\mathit{trial}^{v} \cdot \vec{f}(\vec{x},t) + \nabla \vec{\psi}_\mathit{trial}^{v} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega  + \int_{\Gamma_\tau} \vec{\psi}_\mathit{trial}^{v} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma \right), \\
 % Mu
 M_u = \mathit{Lump}\left( \int_\Omega {\psi_\mathit{trial}^{u}}_i \delta_{ij} {\psi_\mathit{basis}^{u}}_j \, d\Omega \right), \\
 % Mv
 M_v = \mathit{Lump}\left( \int_\Omega {\psi_\mathit{trial}^{v}}_i \rho(\vec{x}) \delta_{ij} {\psi_\mathit{basis}^{v}}_j \, d\Omega \right).
 \end{gather}
-%
+
 ## Residual Pointwise Functions
 
 With explicit time stepping the PETSc TS assumes the LHS is $\dot{s}$, so we only need the RHS residual functions:

--- a/docs-sphinx/user/governingeqns/elasticity-infstrain/index.md
+++ b/docs-sphinx/user/governingeqns/elasticity-infstrain/index.md
@@ -1,0 +1,41 @@
+# Elasticity with Infinitesimal Strain and No Faults
+
+We begin with the elasticity equation including the inertial term,
+
+```{math}
+:label: eqn:elasticity:strong:form
+\rho \frac{\partial^2\vec{u}}{\partial t^2} - \vec{f}(\vec{x},t) - \boldsymbol{\nabla} \cdot \boldsymbol{\sigma} (\vec{u}) = \vec{0} \text{ in }\Omega,
+```
+
+```{math}
+:label: eqn:bc:Neumann
+\boldsymbol{\sigma} \cdot \vec{n} = \vec{\tau}(\vec{x},t) \text{ on }\Gamma_\tau,
+```
+
+```{math}
+:label: eqn:bc:Dirichlet
+\vec{u} = \vec{u}_0(\vec{x},t) \text{ on }\Gamma_u,
+```
+
+where $\vec{u}$ is the displacement vector, $\rho$ is the mass density, $\vec{f}$ is the body force vector, $\boldsymbol{\sigma}$ is the Cauchy stress tensor, $\vec{x}$ is the spatial coordinate, and $t$ is time. We specify tractions $\vec{\tau}$ on boundary $\Gamma_\tau$, and displacements $\vec{u}_0$ on boundary $\Gamma_u$.
+Because both $\vec{\tau}$ and $\vec{u}$ are vector quantities, there can be some spatial overlap of boundaries $\Gamma_\tau$ and $\Gamma_u$; however, a degree of freedom at any location cannot be associated with both prescribed displacements (Dirichlet) and traction (Neumann) boundary conditions simultaneously.
+
+```{table} Mathematical notation for elasticity equation with infinitesimal strain.
+:name: tab:notation:elasticity
+
+| **Category**                   |   **Symbol**    | **Description**                                        |
+|:-------------------------------|:---------------:|:-------------------------------------------------------|
+| Unknowns                       |    $\vec{u}$    | Displacement field                                     |
+|                                |    $\vec{v}$    | Velocity field                                         |
+| Derived quantities             |  $\boldsymbol{\sigma}$  | Cauchy stress tensor                                   |
+|                                | $\boldsymbol{\epsilon}$ | Cauchy strain tensor                                   |
+| Common constitutive parameters |     $\rho$      | Density                                                |
+|                                |      $\mu$      | Shear modulus                                          |
+|                                |       $K$       | Bulk modulus                                           |
+| Source terms                   |    $\vec{f}$    | Body force per unit volume, for example $\rho \vec{g}$ |
+```
+
+:::{toctree}
+quasistatic.md
+dynamic.md
+:::

--- a/docs-sphinx/user/governingeqns/elasticity-infstrain/quasistatic.md
+++ b/docs-sphinx/user/governingeqns/elasticity-infstrain/quasistatic.md
@@ -1,0 +1,57 @@
+# Quastistatic
+
+If we neglect the inertial term ($\rho \frac{\partial \vec{v}}{\partial t} \approx \vec{0}$), then time dependence only arises from history-dependent constitutive equations and boundary conditions.
+Our solution vector is the displacement vector and the elasticity equation reduces to
+%
+```{math}
+:label: eqn:elasticity:strong:form:quasistatic
+\begin{gather}
+\vec{f}(\vec{x},t) + \boldsymbol{\nabla} \cdot \boldsymbol{\sigma}(\vec{u}) = \vec{0} \text{ in }\Omega, \\
+%
+\boldsymbol{\sigma} \cdot \vec{n} = \vec{\tau}(\vec{x},t) \text{ on }\Gamma_\tau, \\
+%
+\vec{u} = \vec{u}_0(\vec{x},t) \text{ on }\Gamma_u.
+\end{gather}
+```
+%
+Because we will use implicit time stepping, we place all of the terms in the elasticity equation on the LHS.
+We create the weak form by taking the dot product with the trial function ${\vec{\psi}_\mathit{trial}^{u}}$ and integrating over the domain:
+%
+\begin{equation}
+\int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot \left( \vec{f}(t) + \boldsymbol{\nabla}\cdot \boldsymbol{\sigma} (\vec{u}) \right) \, d\Omega = 0.
+\end{equation}
+%
+Using the divergence theorem and incorporating the Neumann boundary conditions, we have
+%
+\begin{equation}
+\int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega  + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma = 0
+\end{equation}
+%
+## Residual Pointwise Functions
+
+Identifying $F(t,s,\dot{s})$ and $G(t,s)$, we have
+%
+\begin{equation}
+\begin{aligned}
+% Fu
+F^u(t,s,\dot{s}) &=  \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot{\color{blue}\underbrace{\color{black}\vec{f}(\vec{x},t)}_{\color{blue}{\vec{f}^u_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{u}} :{\color{blue} \underbrace{\color{black}-\boldsymbol{\sigma}(\vec{u})}_{\color{blue}{\boldsymbol{f^u_1}}}} \, d\Omega  + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{u}} \cdot {\color{blue}  \underbrace{\color{black}\vec{\tau}(\vec{x},t)}_{\color{blue}{\vec{f}^u_0}}} \, d\Gamma, \\
+% Gu
+G^u(t,s) &= 0
+\end{aligned}
+\end{equation}
+%
+Note that we have multiple $\vec{f}_0$ functions, each associated with a trial function and an integral over a different domain or boundary.
+Each material and boundary condition (except Dirichlet) contribute pointwise functions.
+The integral over the domain $\Omega$ is subdivided into integrals over the materials and the integral over the boundary $\Gamma_\tau$ is subdivided into integrals over the Neumann boundaries.
+Each bulk constitutive model provides a different pointwise function for the stress tensor $\boldsymbol{\sigma}(\vec{u})$.
+With $G=0$ it is clear that we have a formulation that will use implicit time stepping algorithms.
+
+## Jacobian Pointwise Functions
+
+We only have a Jacobian for the LHS:
+%
+\begin{equation}
+\begin{aligned}
+J_F^{uu} &= \frac{\partial F^u}{\partial u} = \int_\Omega \nabla {\vec{\psi}_\mathit{trial}^{u}} : \frac{\partial}{\partial u}(-\boldsymbol{\sigma}) \, d\Omega  = \int_\Omega \nabla {\vec{\psi}_\mathit{trial}^{u}} : -\boldsymbol{C} : \frac{1}{2}(\nabla + \nabla^T){\vec{\psi}_\mathit{basis}^{u}}\, d\Omega  = \int_\Omega {\psi_\mathit{trial}^{u}}_{i,k} \, {\color{blue} \underbrace{\color{black}\left( -C_{ikjl} \right)}_{\color{blue}{J_{f3}^{uu}}}} \, {\psi_\mathit{basis}^{u}}_{j,l}\, d\Omega.
+\end{aligned}
+\end{equation}

--- a/docs-sphinx/user/governingeqns/index.md
+++ b/docs-sphinx/user/governingeqns/index.md
@@ -22,4 +22,5 @@ In all of our derivations, we use the notation described in {ref}`tab:notation`.
 :::{toctree}
 elasticity-derivation.md
 petsc-formulation.md
+elasticity-infstrain/index.md
 :::


### PR DESCRIPTION
Coming back to this after a few weeks focusing on other things, so apologies if its a little disoriented. 
My understanding from the formatting you set in your pull request is that you'd like to use \begin{equation} or \begin{gather} for 'unlabeled' equations, and ```{math} for 'labeled' equations, correct?
The next section (3.4) has the same structure (index - quasistatic - dynamic) but the 'dynamic' section is far longer so I lean toward keeping these sections (3.3 and 3.4) split into different files. Should I consolidate, or keep this as is and structure 3.4 the same way?