### PR TITLE
Elasticity infstrain prescribedslip

### DIFF
--- a/docs-sphinx/quickref.md
+++ b/docs-sphinx/quickref.md
@@ -57,8 +57,6 @@ This is a `seealso` admonition.
 This is a custom `TODO` admonition.
 :::
 
-
-
 ## Lists
 
 ### Itemized lists
@@ -127,7 +125,6 @@ journal.info.problem = 1
 ksp_rtol = 1.0e-3
 ```
 
-
 ## Tables
 
 Please see {numref}`tab:quickref`.
@@ -154,6 +151,15 @@ This is likely a bug.
 
 This is the figure caption.
 :::
+
+## Math
+
+Look at {math:numref}`eqn:one:two`.
+
+```{math}
+:label: eqn:one:two
+F = m a
+```
 
 ## Citations
 

--- a/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/dynamic.md
+++ b/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/dynamic.md
@@ -1,178 +1,117 @@
 # Dynamic
 
-The equation prescribing fault slip is independent of the Lagrange multiplier, so we do not have a system of equations that we can put in the form $\dot{s} = G^*(t,s)$.
+The equation prescribing fault slip is independent of the Lagrange multiplier, so we do not have a system of equations that we can put in
+the form $\dot{s} = G^*(t,s)$.
 Instead, we have a differential-algebraic set of equations (DAEs), which we solve using an implicit-explicit (IMEX) time integration scheme.
 As in the case of dynamic elasticity without faults, we introduce the velocity ($\vec{v}$) as an unknown to turn the elasticity equation into two first order equations.
+Our constraint for prescribed slip is
+\begin{equation}
+  \vec{u}^+ - \vec{u}^- - \vec{d} = \vec{0},
+\end{equation}
+where $\vec{u}$ is the displacement vector and $\vec{d}$ is the slip vector.
+In order to match the order of the time derivative in the elasticity equation, we take the second derivative of the prescribed slip equation with respect to time,
+\begin{equation}
+  \frac{\partial \vec{v}^+}{\partial t} - \frac{\partial \vec{v}^-}{\partial t} - \frac{\partial^2 \vec{d}}{\partial t^2} = \vec{0}.
+\end{equation}
+This means that our differential algebraic equations has a differentiation index of 2.
+
 The strong form for our system of equations is:
-%
 \begin{gather}
-% Solution
-\vec{s}^T = \left( \vec{u} \quad \vec{v} \quad \vec{\lambda} \right)^T \\
-% Displacement-velocity
-\frac{\partial \vec{u}}{\partial t} = \vec{v}, \\
-% Elasticity
-\rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} =
-\vec{f}(\vec{x},t) + \nabla \cdot \boldsymbol{\sigma}(\vec{u}), \\
-% Neumann BC
-\boldsymbol{\sigma} \cdot \vec{n} = \vec{\tau} \text{ on } \Gamma_\tau. \\
-% Dirichlet BC
-\vec{u} = \vec{u}_0 \text{ on } \Gamma_u, \\
-% Presribed slip
-\vec{u}^+(\vec{x},t) - \vec{u}^-(\vec{x},t) - \vec{d}(\vec{x},t) = \vec{0} \text{ on }\Gamma_f,  \\
-\boldsymbol{\sigma} \cdot \vec{n} = -\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^+}, \text{ and}\\
-\boldsymbol{\sigma} \cdot \vec{n} = +\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^-}.
+  % Solution
+  \vec{s}^T = \left( \vec{u} \quad \vec{v} \quad \vec{\lambda} \right)^T \\
+  % Displacement-velocity
+  \frac{\partial \vec{u}}{\partial t} = \vec{v}, \\
+  % Elasticity
+  \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} = \vec{f}(\vec{x},t) + \nabla \cdot \boldsymbol{\sigma}(\vec{u}), \\
+  % Neumann BC
+  \boldsymbol{\sigma} \cdot \vec{n} = \vec{\tau} \text{ on } \Gamma_\tau. \\
+  % Dirichlet BC
+  \vec{u} = \vec{u}_0 \text{ on } \Gamma_u, \\
+  % Presribed slip
+  \frac{\partial \vec{v}^+}{\partial t} - \frac{\partial \vec{v}^-}{\partial t} - \frac{\partial^2 \vec{d}(\vec{x},t)}{\partial t^2} = \vec{0}, \\
+  % Momentum balance on fault interface
+  \int_{\Omega_f} \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} \, d\Omega = \int_{\Gamma_{f^+}} \boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda} \, d\Gamma + \int_{\Gamma_{f^-}} \boldsymbol{\sigma} \cdot \vec{n} - \vec{\lambda} \, d\Gamma.
 \end{gather}
-%
-The differentiation index is 2 because we must take the second time derivative of the prescribed slip equation to match the order of the time derivative in the elasticity equation,
-%
-\begin{gather}
-\frac{\partial \vec{v}^+}{\partial t} - \frac{\partial \vec{v}^-}{\partial t} -
-\frac{\partial^2 \vec{d}(\vec{x},t)}{\partial t^2} = \vec{0}.
-\end{gather}
-%
 We generate the weak form in the usual way,
-%
-\begin{equation}
-% Displacement-velocity
-\int_{\Omega} {\vec{\psi}_\mathit{trial}^{u}} \cdot \frac{\partial \vec{u}}{\partial t} \, d\Omega = \int_{\Omega} {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{v} \, d\Omega, \\
-% Elasticity
-\end{equation}
-\begin{multline}
-\int_{\Omega} {\vec{\psi}_\mathit{trial}^{v}} \cdot \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} \, d\Omega = \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma \\
- + \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) + {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(+\vec{\lambda}(\vec{x},t)\right)\, d\Gamma, \\
-\end{multline}
-% Prescribed slip
-\begin{equation}
-\int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \left(\frac{\partial \vec{v}^+}{\partial t} - \frac{\partial \vec{v}^-}{\partial t} - \frac{\partial^2 \vec{d}(\vec{x},t)}{\partial t^2} \right) \, d\Gamma = 0.
-\end{equation}
-%
+\begin{gather}
+  % Displacement-velocity
+  \int_{\Omega} \vec{\psi}_\mathit{trial}^u \cdot \frac{\partial \vec{u}}{\partial t} \, d\Omega =  \int_{\Omega} \vec{\psi}_\mathit{trial}^u \cdot \vec{v} \, d\Omega, \\
+  % Elasticity
+  \int_{\Omega} \vec{\psi}_\mathit{trial}^v \cdot \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} \, d\Omega  = \int_\Omega \vec{\psi}_\mathit{trial}^v \cdot \vec{f}(\vec{x},t) + \nabla \vec{\psi}_\mathit{trial}^v : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + \int_{\Gamma_\tau} \vec{\psi}_\mathit{trial}^v \cdot \vec{\tau}(\vec{x},t) \, d\Gamma \\
+  \qquad\qquad + \int_{\Gamma_{f}} \vec{\psi}_\mathit{trial}^{v^+} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) + \vec{\psi}_\mathit{trial}^{v^-} \cdot \left(+\vec{\lambda}(\vec{x},t)\right)\, d\Gamma, \\
+  % Prescribed slip
+  \int_{\Gamma_f} \vec{\psi}_\mathit{trial}^\lambda \cdot \left(\frac{\partial \vec{v}^+}{\partial t} - \frac{\partial \vec{v}^-}{\partial t} - \frac{\partial^2 \vec{d}(\vec{x},t)}{\partial t^2} \right) \, d\Gamma = 0. \\
+  \int_{\Omega_f} \vec{\psi}_\mathit{trial}^\lambda \cdot \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} \, d\Omega = \int_{\Gamma_{f^+}} \vec{\psi}_\mathit{trial}^\lambda \cdot \left( \boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda} \right) \, d\Gamma + \int_{\Gamma_{f^-}} \vec{\psi}_\mathit{trial}^\lambda \cdot \left( \boldsymbol{\sigma} \cdot \vec{n} - \vec{\lambda} \right) \, d\Gamma.
+\end{gather}
+
 For compatibility with PETSc TS IMEX implementations, we need $\dot{\vec{s}}$ on the LHS for the explicit part (displacement-velocity and elasticity equations) and we need $\vec{\lambda}$ in the equation for the implicit part (prescribed slip equation).
-We first focus on the explicit part and create a lumped LHS Jacobian matrix, $M$, so that we have
+We first focus on the explicit part and select numerical quadrature that yields a lumped mass matrix, $M$, so that we have
 
 ```{math}
-:label: eqn:displacement:velocity:prescribed:slip:weak:form
-% Displacement-velocity
-\frac{\partial \vec{u}}{\partial t} = M_u^{-1} \int_{\Omega} {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{v} \, d\Omega, \\
-```
-```{math}
-:label: eqn:elasticity:prescribed:slip:dynamic:weak:form
-% Elasticity
-\begin{multline}
-\frac{\partial \vec{v}}{\partial t} = M_v^{-1} \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + M_v^{-1} \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma \\
- + M_{v^+}^{-1} \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) \, d\Gamma + M_{v^-}^{-1} \int_{\Gamma_{f}}{\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(+\vec{\lambda}(\vec{x},t)\right) \, d\Gamma, \\
-\end{multline}
-```
-
+:label: eqn:dynamic:prescribed:slip:weak:form
 \begin{gather}
-% Mu
-M_u = \mathit{Lump}\left( \int_\Omega {\psi_\mathit{trial}^{u}}_i \delta_{ij} {\psi_\mathit{basis}^{u}}_j \, d\Omega \right), \\
-% Mv
-M_v = \mathit{Lump}\left( \int_\Omega {\psi_\mathit{trial}^{v}}_i \rho(\vec{x}) \delta_{ij} {\psi_\mathit{basis}^{v}}_j \, d\Omega \right).
+  % Displacement-velocity
+  \frac{\partial \vec{u}}{\partial t} = M_u^{-1} \int_{\Omega} \vec{\psi}_\mathit{trial}^u \cdot \vec{v} \, d\Omega, \\
+  % Elasticity
+  \frac{\partial \vec{v}}{\partial t} = M_v^{-1} \int_\Omega \vec{\psi}_\mathit{trial}^v \cdot \vec{f}(\vec{x},t) + \nabla \vec{\psi}_\mathit{trial}^v : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + M_v^{-1} \int_{\Gamma_\tau} \vec{\psi}_\mathit{trial}^v \cdot \vec{\tau}(\vec{x},t) \, d\Gamma \\
+  \qquad\qquad+ M_{v^+}^{-1} \int_{\Gamma_{f}} \vec{\psi}_\mathit{trial}^{v^+} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) \, d\Gamma + M_{v^-}^{-1} \int_{\Gamma_{f}}\vec{\psi}_\mathit{trial}^{v^-} \cdot \left(+\vec{\lambda}(\vec{x},t)\right) \, d\Gamma, \\
+  M_u = \mathit{Lump}\left( \int_\Omega \psi_{\mathit{trial}_i}^u \delta_{ij} \psi_{\mathit{basis}_j}^u \, d\Omega \right), \\
+  M_v = \mathit{Lump}\left( \int_\Omega \psi_{\mathit{trial}_i}^v \rho(\vec{x}) \delta_{ij} \psi_{\mathit{basis}_j}^v \, d\Omega \right).
 \end{gather}
-%
-Now, focusing on the implicit part we want to introduce $\vec{\lambda}$ into the prescribed slip equation.
-We solve the elasticity equation for $\frac{\partial \vec{v}}{\partial t}$, create the weak form, and substitute into the prescribed slip equation.
-Solving the elasticity equation for $\frac{\partial \vec{v}}{\partial t}$, we have
-%
-\begin{equation}
-\frac{\partial \vec{v}}{\partial t} = \frac{1}{\rho(x)} \vec{f}(\vec{x},t) + \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u}) \right),
-\end{equation}
-and the corresponding weak form is
-
-```{math}
-:label: eqn:prescribed:slip:DAE:weak:form
-\int_{\Omega} {\vec{\psi}_\mathit{trial}^{v}} \cdot \frac{\partial \vec{v}}{\partial t} \, d\Omega = \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \frac{1}{\rho(x)} \vec{f}(\vec{x},t) + {\vec{\psi}_\mathit{trial}^{v}} \cdot \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega,
 ```
 
-We apply the divergence theorem,
-%
-\begin{equation}
-\int_{\Omega} \nabla \cdot \vec{F} \, d\Omega = \int_\Gamma \vec{F} \cdot \vec{n} \, d\Gamma,
-\end{equation}
-%
-with $\vec{F} = {\vec{\psi}_\mathit{trial}^{v}} \cdot \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u})\right)$ to get
-%
-\begin{equation}
-\int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega = \int_\Gamma {\vec{\psi}_\mathit{trial}^{v}} \cdot \left( \frac{1}{\rho(x)} \boldsymbol{\sigma}(\vec{u}) \cdot \vec{n} \right) \, d\Gamma + \int_\Omega \nabla{\vec{\psi}_\mathit{trial}^{v}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) + {\vec{\psi}_\mathit{trial}^{v}} \cdot \left(-\frac{\nabla \rho(\vec{x})}{\rho^2} \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega.
-\end{equation}
-%
-Restricting the trial function to $v^+$ and $v^-$ while recognizing that there is no overlap between the external Neumann boundary conditions $\Gamma_\tau$ and the fault interfaces $\Gamma_f$, yields
-%
+For the implicit part, we can separate the integration of the weak form for negative and positive sides of the fault interface, which yields
 \begin{gather}
-\int_\Omega {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega = \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\frac{1}{\rho(x)} \vec{\lambda} \right) \, d\Gamma + \int_\Omega \nabla{\vec{\psi}_\mathit{trial}^{v^+}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) + {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \, \left(-\frac{\nabla \rho(\vec{x})}{\rho^2} \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega, \\
-\int_\Omega {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega = \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(+\frac{1}{\rho(x)} \vec{\lambda} \right) \, d\Gamma + \int_\Omega \nabla{\vec{\psi}_\mathit{trial}^{v^-}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) + {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \, \left(-\frac{\nabla \rho(\vec{x})}{\rho^2} \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega.
+  M_{v^+} \frac{\partial \vec{v}^+}{\partial t} = \int_{\Gamma_{f^+}} \vec{\psi}_\mathit{trial}^\lambda \cdot \left( \boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda} \right) \, d\Gamma, \\
+  M_{v^-} \frac{\partial \vec{v}^-}{\partial t} = \int_{\Gamma_{f^-}} \vec{\psi}_\mathit{trial}^\lambda \cdot \left( \boldsymbol{\sigma} \cdot \vec{n} - \vec{\lambda} \right) \, d\Gamma.
 \end{gather}
-%
-Picking ${\vec{\psi}_\mathit{trial}^{v}}={\vec{\psi}_\mathit{trial}^{\lambda}}$ and substituting into equation {math:numref}`eqn:prescribed:slip:DAE:weak:form` gives
-%
-\begin{gather}
-\int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \left( \frac{\partial \vec{v}^+}{\partial t} - \frac{\partial \vec{v}^-}{\partial t} - \frac{\partial^2 \vec{d}(\vec{x},t)}{\partial t^2} \right) \, d\Gamma = \\
-\int_\Omega {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left( \frac{1}{\rho(\vec{x})} \vec{f}(\vec{x}, t) - \frac{\nabla \rho(\vec{x})}{\rho^2(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right) + \nabla {\vec{\psi}_\mathit{trial}^{v^+}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega + \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\frac{1}{\rho(\vec{x})} \vec{\lambda} \right) \, d\Gamma \\
-- \int_\Omega {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left( \frac{1}{\rho(\vec{x})} \vec{f}(\vec{x}, t) -\frac{\nabla \rho(\vec{x})}{\rho^2(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right) + \nabla {\vec{\psi}_\mathit{trial}^{v^-}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega + \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(-\frac{1}{\rho(\vec{x})} \vec{\lambda} \right) \, d\Gamma \\
-- \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \frac{\partial^2 \vec{d}(\vec{x}, t)}{\partial t^2} \, d\Gamma.
-\end{gather}
-%
-We rewrite the integrals over the domain involving the degrees of freedom adjacent to the fault as integrals over the positive and negative sides of the fault.
-These are implemented as integrals over the faces of cells adjacent to the fault; they involve quantities, such as density, that are defined only within the domain cells.
-After collecting and rearranging terms, we have
+Using these equations to substitute in the expressions for the time derivative of the velocity on the negative and positive sides of the fault into the prescribed slip constraint equation yields
 
 ```{math}
 :label: eqn:elasticity:prescribed:slip:dynamic:DAE:weak:form
-\begin{gather}
-\int_{\Gamma_{f^+}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \frac{1}{\rho(\vec{x})} \left(\vec{\lambda} - \vec{f}(\vec{x},t) + \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right) + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : \left(+\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) \, d\Gamma \\
-+ \int_{\Gamma_{f^-}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \frac{1}{\rho(\vec{x})} \left(\vec{\lambda} + \vec{f}(\vec{x},t) - \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right) + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right)  \, d\Gamma \\
-+ \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \frac{\partial^2 \vec{d}(\vec{x}, t)}{\partial t^2} \, d\Gamma = 0.
-\end{gather}
+\begin{equation}
+  M_{v^+}^{-1} \int_{\Gamma_f^+} \vec{\psi}_\mathit{trial}^\lambda \cdot \left(\boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda}\right) \, d\Gamma + M_{v^-}^{-1} \int_{\Gamma_f^-} \vec{\psi}_\mathit{trial}^\lambda \cdot \left( -\boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda} \right) \, d\Gamma - \int_{\Gamma_f} \vec{\psi}_\mathit{trial}^\lambda \cdot \frac{\partial^2 \vec{d}}{\partial t^2} \, d\Gamma = \vec{0}.
+\end{equation}
 ```
 
 ## Residual Pointwise Functions
 
-Combining the explicit parts of the weak form in equations {math:numref}`eqn:displacement:velocity:prescribed:slip:weak:form` and {math:numref}`eqn:elasticity:prescribed:slip:dynamic:weak:form` with the implicit part of the weak form in equation {math:numref}`eqn:elasticity:prescribed:slip:dynamic:DAE:weak:form` and identifying $F(t,s,\dot{s})$ and $G(t,s)$, we have
-%
+Combining the explicit parts of the weak form in equation {math:numref}`eqn:dynamic:prescribed:slip:weak:form` with the implicit part of the weak form in equation {math:numref}`eqn:elasticity:prescribed:slip:dynamic:DAE:weak:form` and identifying $F(t,s,\dot{s})$ and $G(t,s)$, we have
 \begin{gather}
 % Fu
-F^u(t,s,\dot{s}) = \frac{\partial \vec{u}}{\partial t} \\
+  F^u(t,s,\dot{s}) = \frac{\partial \vec{u}}{\partial t} \\
 % Fv
-F^v(t,s,\dot{s}) = \frac{\partial \vec{v}}{\partial t} \\
+  F^v(t,s,\dot{s}) = \frac{\partial \vec{v}}{\partial t} \\
 % Fl
-\end{gather}
-\begin{multline}
-F^\lambda(t,s,\dot{s}) =   \int_{\Gamma_{f^+}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot{\color{blue}\underbrace{\color{black}\frac{1}{\rho(\vec{x})} \left(  \vec{\lambda} - \vec{f}(\vec{x},t) + \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : {\color{blue}\underbrace{\color{black}\left(+\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u})\right)}_{\color{blue}{f^\lambda_1}}} \, d\Gamma \\
-+ \int_{\Gamma_{f^-}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot {\color{blue} \underbrace{\color{black}\frac{1}{\rho(\vec{x})} \left(\vec{\lambda} + \vec{f}(\vec{x},t) - \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : {\color{blue}\underbrace{\color{black}\left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_1}}}  \, d\Gamma \\
-+ \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot {\color{blue}\underbrace{\color{black}\frac{\partial^2 \vec{d}(\vec{x}, t)}{\partial t^2}}_{\color{blue}{f^\lambda_0}}} \, d\Gamma \\
-\end{multline}
+  F^\lambda(t,s,\dot{s}) = {\color{blue}\underbrace{\color{black}M_{v^+}^{-1}}_{\color{blue}{c^+}}} \int_{\Gamma_f^+} \vec{\psi}_\mathit{trial}^\lambda \cdot {\color{blue}\underbrace{\color{black}\left(\boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda}\right)}_{\color{blue}{f^\lambda_0}}} \, d\Gamma + {\color{blue}\underbrace{\color{black}M_{v^-}^{-1}}_{\color{blue}{c^-}}} \int_{\Gamma_f^-} \vec{\psi}_\mathit{trial}^\lambda \cdot {\color{blue}\underbrace{\color{black}\left( -\boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda} \right)}_{\color{blue}{f^\lambda_0}}} \, d\Gamma - \int_{\Gamma_f} \vec{\psi}_\mathit{trial}^\lambda \cdot {\color{blue}\underbrace{\color{black}\frac{\partial^2 \vec{d}}{\partial t^2}}_{\color{blue}{f^\lambda_0}}} \, d\Gamma \\
 % Gu
-\begin{gather}
-G^u(t,s) = \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot{\color{blue}\underbrace{\color{black}\vec{v}}_{\color{blue}{\vec{g}^u_0}}} \, d\Omega, \\
-% Gv
-G^v(t,s) =  \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot{\color{blue}\underbrace{\color{black}\vec{f}(\vec{x},t)}_{\color{blue}{\vec{g}^v_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{v}} : {\color{blue}\underbrace{\color{black}-\boldsymbol{\sigma}(\vec{u})}_{\color{blue}{\boldsymbol{g^v_1}}}} \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot {\color{blue}\underbrace{\color{black}\vec{\tau}(\vec{x},t)}_{\color{blue}{\vec{g}^v_0}}} \, d\Gamma, + \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot {\color{blue}\underbrace{\color{black}\left(-\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{g}^v_0}}} + {\vec{\psi}_\mathit{trial}^{v^-}} \cdot {\color{blue}\underbrace{\color{black}\left(+\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{g}^v_0}}} \, d\Gamma, \\
+  G^u(t,s) = {\color{blue}\underbrace{\color{black}M_{u}^{-1}}_{\color{blue}{c}}} \int_\Omega \vec{\psi}_\mathit{trial}^u \cdot {\color{blue}\underbrace{\color{black}\vec{v}}_{\color{blue}{\vec{g}^u_0}}} \, d\Omega, \\
+ % Gv
+  G^v(t,s) =  {\color{blue}\underbrace{\color{black}M_{v}^{-1}}_{\color{blue}{c}}} \left( \int_\Omega \vec{\psi}_\mathit{trial}^v \cdot {\color{blue}\underbrace{\color{black}\vec{f}(\vec{x},t)}_{\color{blue}{\vec{g}^v_0}}} + \nabla \vec{\psi}_\mathit{trial}^v : {\color{blue}\underbrace{\color{black}-\boldsymbol{\sigma}(\vec{u})}_{\color{blue}{\boldsymbol{g^v_1}}}} \, d\Omega + \int_{\Gamma_\tau} \vec{\psi}_\mathit{trial}^v \cdot {\color{blue}\underbrace{\color{black}\vec{\tau}(\vec{x},t)}_{\color{blue}{\vec{g}^v_0}}} \, d\Gamma, + \int_{\Gamma_{f}} \vec{\psi}_\mathit{trial}^{v^+} \cdot {\color{blue}\underbrace{\color{black}\left(-\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{g}^v_0}}} + \vec{\psi}_\mathit{trial}^{v^-} \cdot {\color{blue}\underbrace{\color{black}\left(+\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{g}^v_0}}} \, d\Gamma \right), \\
 % Gl
-G^l(t,s) = 0
+  G^\lambda(t,s) = 0
 \end{gather}
-%
+
+The integrals for the explicit part are all weighted by the inverse of the lumped mass matrix.
+For the implicit part, only the integrals over the positive and negative sides of the fault are weighted by the inverse of the lumped mass matrix.
+
 ## Jacobian Pointwise Functions
 
-For the explicit part we have pointwise functions for computing the lumped LHS Jacobian.
-These are exactly the same pointwise functions as in the dynamic case without a fault,
-%
-\begin{equation}
-\begin{aligned}
-% J_F uu
-J_F^{uu} &= \frac{\partial F^u}{\partial u} + s_\mathit{tshift} \frac{\partial F^u}{\partial \dot{u}} = \int_\Omega {\psi_\mathit{trial}^{u}}_i{\color{blue}\underbrace{\color{black}s_\mathit{tshift} \delta_{ij}}_{\color{blue}{J^{uu}_{f0}}}} {\psi_\mathit{basis}^{u}}_j  \, d\Omega, \\
-% J_F vv
-J_F^{vv} &= \frac{\partial F^v}{\partial v} + s_\mathit{tshift} \frac{\partial F^v}{\partial \dot{v}} = \int_\Omega {\psi_\mathit{trial}^{v}}_i{\color{blue}  \underbrace{\color{black}\rho(\vec{x}) s_\mathit{tshift} \delta_{ij}}_{\color{blue}{J ^{vv}_{f0}}}} {\psi_\mathit{basis}^{v}}_j \, d\Omega
-\end{aligned}
-\end{equation}
-%
+For the explicit part we have pointwise functions for computing the lumped LHS Jacobian. These are exactly the same pointwise functions as in the dynamic case without a fault,
+\begin{align}
+  % J_F uu
+  J_F^{uu} &= \frac{\partial F^u}{\partial u} + s_\mathit{tshift} \frac{\partial F^u}{\partial \dot{u}} =
+             \int_\Omega \psi_{\mathit{trial}^u_i} {\color{blue}\underbrace{\color{black}s_\mathit{tshift} \delta_{ij}}_{\color{blue}{J^{uu}_{f0}}}} \psi_{\mathit{basis}^u_j}  \, d\Omega, \\
+  % J_F vv
+  J_F^{vv} &= \frac{\partial F^v}{\partial v} + s_\mathit{tshift} \frac{\partial F^v}{\partial \dot{v}} =
+             \int_\Omega \psi_{\mathit{trial}^v_i} {\color{blue}\underbrace{\color{black}\rho(\vec{x}) s_\mathit{tshift} \delta_{ij}}_{\color{blue}{J ^{vv}_{f0}}}} \psi_{\mathit{basis}^v_j} \, d\Omega
+\end{align}
 For the implicit part, we have pointwise functions for the LHS Jacobians associated with the prescribed slip,
-%
-\begin{multline}
-% J_F lu
-J_F^{\lambda u} = \frac{\partial F^\lambda}{\partial u} + s_\mathit{tshift} \frac{\partial F^\lambda}{\partial \dot{u}} = \\
-\int_{\Gamma_{f^+}} {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\frac{\rho_{,j}(\vec{x})}{\rho^2(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{j,l}}_{\color{blue}{J^{\lambda u}_{fX}}}} + {\psi_\mathit{trial}^{\lambda}}_{i,k}{\color{blue}  \underbrace{\color{black}+\frac{1}{\rho(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{k,l}}_{\color{blue}{J^{\lambda u}_{f3}}}} \, d\Gamma \\
-+\int_{\Gamma_{f^-}} {\psi_\mathit{trial}^{\lambda}}_i{\color{blue}\underbrace{\color{black}-\frac{\rho_{,j}(\vec{x})}{\rho^2(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{j,l}}_{\color{blue}{J^{\lambda u}_{fX}}}} + {\psi_\mathit{trial}^{\lambda}}_{i,k} {\color{blue}\underbrace{\color{black}-\frac{1}{\rho(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{k,l}}_{\color{blue}{J^{\lambda u}_{f3}}}} \, d\Gamma \\
-\end{multline}
+\begin{gather}
+  % J_F lu
+  J_F^{\lambda u} = \frac{\partial F^\lambda}{\partial u} + s_\mathit{tshift} \frac{\partial F^\lambda}{\partial \dot{u}} = {\color{blue}\underbrace{\color{black}M_{v^+}^{-1}}_{\color{blue}{c^+}}} \int_{\Gamma_{f^+}} \psi_{\mathit{trial}_i}^\lambda {\color{blue}\underbrace{\color{black} C_{kijl} n_k}_{\color{blue}{J^{\lambda u}_{f1}}}} \psi_{\mathit{basis}_{j,l}}^u \, d\Gamma + {\color{blue}\underbrace{\color{black}M_{v^-}^{-1}}_{\color{blue}{c^-}}} \int_{\Gamma_{f^-}} \psi_{\mathit{trial}_i}^\lambda {\color{blue}\underbrace{\color{black}- C_{kijl} n_k}_{\color{blue}{J^{\lambda u}_{f1}}}} \psi_{\mathit{basis}_{j,l}}^u \, d\Gamma, \\
 % J_F ll
-\begin{equation}
-J_F^{\lambda \lambda} = \frac{\partial F^\lambda}{\partial \lambda} + s_\mathit{tshift} \frac{\partial F^\lambda}{\partial \dot{\lambda}} = \int_{\Gamma_{f^+}} {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\frac{1}{\rho(\vec{x})} \delta_{ij}}_{\color{blue}{J^{\lambda\lambda}_{f0}}}} {\psi_\mathit{basis}^{\lambda}}_j \, d\Gamma + \int_{\Gamma_{f^-}} {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\frac{1}{\rho(\vec{x})} \delta_{ij}}_{\color{blue}{J^{\lambda\lambda}_{f0}}}} {\psi_\mathit{basis}^{\lambda}}_j \, d\Gamma
-\end{equation}
+  J_F^{\lambda \lambda} = \frac{\partial F^\lambda}{\partial \lambda} + s_\mathit{tshift} \frac{\partial F^\lambda}{\partial \dot{\lambda}} = {\color{blue}\underbrace{\color{black}M_{v^+}^{-1}}_{\color{blue}{c^+}}} \int_{\Gamma_{f^+}} \psi_{\mathit{trial}_i}^\lambda {\color{blue}\underbrace{\color{black} \delta_{ij}}_{\color{blue}{J^{\lambda\lambda}_{f0}}}} \psi_{\mathit{basis}_j}^\lambda \, d\Gamma + {\color{blue}\underbrace{\color{black}M_{v^-}^{-1}}_{\color{blue}{c^-}}} \int_{\Gamma_{f^-}} \psi_{\mathit{trial}_i}^\lambda {\color{blue}\underbrace{\color{black} \delta_{ij}}_{\color{blue}{J^{\lambda\lambda}_{f0}}}} \psi_{\mathit{basis}_j}^\lambda \, d\Gamma
+\end{gather}
+
+% End of file

--- a/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/dynamic.md
+++ b/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/dynamic.md
@@ -32,16 +32,20 @@ The differentiation index is 2 because we must take the second time derivative o
 %
 We generate the weak form in the usual way,
 %
-\begin{gather}
+\begin{equation}
 % Displacement-velocity
 \int_{\Omega} {\vec{\psi}_\mathit{trial}^{u}} \cdot \frac{\partial \vec{u}}{\partial t} \, d\Omega = \int_{\Omega} {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{v} \, d\Omega, \\
 % Elasticity
-\int_{\Omega} {\vec{\psi}_\mathit{trial}^{v}} \cdot \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} \, d\Omega = \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma \dots \\
-\dots + \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) + {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(+\vec{\lambda}(\vec{x},t)\right)\, d\Gamma, \\
+\end{equation}
+\begin{multline}
+\int_{\Omega} {\vec{\psi}_\mathit{trial}^{v}} \cdot \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} \, d\Omega = \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma \\
+ + \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) + {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(+\vec{\lambda}(\vec{x},t)\right)\, d\Gamma, \\
+\end{multline}
 % Prescribed slip
+\begin{equation}
 \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \left(\frac{\partial \vec{v}^+}{\partial t} - \frac{\partial \vec{v}^-}{\partial t} - \frac{\partial^2 \vec{d}(\vec{x},t)}{\partial t^2} \right) \, d\Gamma = 0.
-\end{gather}
-
+\end{equation}
+%
 For compatibility with PETSc TS IMEX implementations, we need $\dot{\vec{s}}$ on the LHS for the explicit part (displacement-velocity and elasticity equations) and we need $\vec{\lambda}$ in the equation for the implicit part (prescribed slip equation).
 We first focus on the explicit part and create a lumped LHS Jacobian matrix, $M$, so that we have
 
@@ -53,8 +57,10 @@ We first focus on the explicit part and create a lumped LHS Jacobian matrix, $M$
 ```{math}
 :label: eqn:elasticity:prescribed:slip:dynamic:weak:form
 % Elasticity
-\frac{\partial \vec{v}}{\partial t} = M_v^{-1} \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + M_v^{-1} \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma \dots \\
-\dots + M_{v^+}^{-1} \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) \, d\Gamma + M_{v^-}^{-1} \int_{\Gamma_{f}}{\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(+\vec{\lambda}(\vec{x},t)\right) \, d\Gamma, \\
+\begin{multline}
+\frac{\partial \vec{v}}{\partial t} = M_v^{-1} \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + M_v^{-1} \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma \\
+ + M_{v^+}^{-1} \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) \, d\Gamma + M_{v^-}^{-1} \int_{\Gamma_{f}}{\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(+\vec{\lambda}(\vec{x},t)\right) \, d\Gamma, \\
+\end{multline}
 ```
 
 \begin{gather}
@@ -119,7 +125,7 @@ After collecting and rearranging terms, we have
 \end{gather}
 ```
 
-### Residual Pointwise Functions
+## Residual Pointwise Functions
 
 Combining the explicit parts of the weak form in equations {math:numref}`eqn:displacement:velocity:prescribed:slip:weak:form` and {math:numref}`eqn:elasticity:prescribed:slip:dynamic:weak:form` with the implicit part of the weak form in equation {math:numref}`eqn:elasticity:prescribed:slip:dynamic:DAE:weak:form` and identifying $F(t,s,\dot{s})$ and $G(t,s)$, we have
 %
@@ -129,10 +135,14 @@ F^u(t,s,\dot{s}) = \frac{\partial \vec{u}}{\partial t} \\
 % Fv
 F^v(t,s,\dot{s}) = \frac{\partial \vec{v}}{\partial t} \\
 % Fl
-F^\lambda(t,s,\dot{s}) =   \int_{\Gamma_{f^+}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot{\color{blue}\underbrace{\color{black}\frac{1}{\rho(\vec{x})} \left(  \vec{\lambda} - \vec{f}(\vec{x},t) + \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : {\color{blue}\underbrace{\color{black}\left(+\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u})\right)}_{\color{blue}{f^\lambda_1}}} \, d\Gamma \dots \\
-\dots + \int_{\Gamma_{f^-}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot {\color{blue} \underbrace{\color{black}\frac{1}{\rho(\vec{x})} \left(\vec{\lambda} + \vec{f}(\vec{x},t) - \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : {\color{blue}\underbrace{\color{black}\left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_1}}}  \, d\Gamma \dots \\
-\dots + \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot {\color{blue}\underbrace{\color{black}\frac{\partial^2 \vec{d}(\vec{x}, t)}{\partial t^2}}_{\color{blue}{f^\lambda_0}}} \, d\Gamma \\
+\end{gather}
+\begin{multline}
+F^\lambda(t,s,\dot{s}) =   \int_{\Gamma_{f^+}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot{\color{blue}\underbrace{\color{black}\frac{1}{\rho(\vec{x})} \left(  \vec{\lambda} - \vec{f}(\vec{x},t) + \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : {\color{blue}\underbrace{\color{black}\left(+\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u})\right)}_{\color{blue}{f^\lambda_1}}} \, d\Gamma \\
++ \int_{\Gamma_{f^-}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot {\color{blue} \underbrace{\color{black}\frac{1}{\rho(\vec{x})} \left(\vec{\lambda} + \vec{f}(\vec{x},t) - \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : {\color{blue}\underbrace{\color{black}\left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_1}}}  \, d\Gamma \\
++ \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot {\color{blue}\underbrace{\color{black}\frac{\partial^2 \vec{d}(\vec{x}, t)}{\partial t^2}}_{\color{blue}{f^\lambda_0}}} \, d\Gamma \\
+\end{multline}
 % Gu
+\begin{gather}
 G^u(t,s) = \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot{\color{blue}\underbrace{\color{black}\vec{v}}_{\color{blue}{\vec{g}^u_0}}} \, d\Omega, \\
 % Gv
 G^v(t,s) =  \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot{\color{blue}\underbrace{\color{black}\vec{f}(\vec{x},t)}_{\color{blue}{\vec{g}^v_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{v}} : {\color{blue}\underbrace{\color{black}-\boldsymbol{\sigma}(\vec{u})}_{\color{blue}{\boldsymbol{g^v_1}}}} \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot {\color{blue}\underbrace{\color{black}\vec{\tau}(\vec{x},t)}_{\color{blue}{\vec{g}^v_0}}} \, d\Gamma, + \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot {\color{blue}\underbrace{\color{black}\left(-\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{g}^v_0}}} + {\vec{\psi}_\mathit{trial}^{v^-}} \cdot {\color{blue}\underbrace{\color{black}\left(+\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{g}^v_0}}} \, d\Gamma, \\
@@ -140,7 +150,7 @@ G^v(t,s) =  \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot{\color{blue}\under
 G^l(t,s) = 0
 \end{gather}
 %
-### Jacobian Pointwise Functions
+## Jacobian Pointwise Functions
 
 For the explicit part we have pointwise functions for computing the lumped LHS Jacobian.
 These are exactly the same pointwise functions as in the dynamic case without a fault,
@@ -156,11 +166,13 @@ J_F^{vv} &= \frac{\partial F^v}{\partial v} + s_\mathit{tshift} \frac{\partial F
 %
 For the implicit part, we have pointwise functions for the LHS Jacobians associated with the prescribed slip,
 %
-\begin{gather}
+\begin{multline}
 % J_F lu
-J_F^{\lambda u} = \frac{\partial F^\lambda}{\partial u} + s_\mathit{tshift} \frac{\partial F^\lambda}{\partial \dot{u}} = \dots \\
-\dots \int_{\Gamma_{f^+}} {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\frac{\rho_{,j}(\vec{x})}{\rho^2(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{j,l}}_{\color{blue}{J^{\lambda u}_{fX}}}} + {\psi_\mathit{trial}^{\lambda}}_{i,k}{\color{blue}  \underbrace{\color{black}+\frac{1}{\rho(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{k,l}}_{\color{blue}{J^{\lambda u}_{f3}}}} \, d\Gamma \dots \\
-\dots +\int_{\Gamma_{f^-}} {\psi_\mathit{trial}^{\lambda}}_i{\color{blue}\underbrace{\color{black}-\frac{\rho_{,j}(\vec{x})}{\rho^2(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{j,l}}_{\color{blue}{J^{\lambda u}_{fX}}}} + {\psi_\mathit{trial}^{\lambda}}_{i,k} {\color{blue}\underbrace{\color{black}-\frac{1}{\rho(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{k,l}}_{\color{blue}{J^{\lambda u}_{f3}}}} \, d\Gamma \\
+J_F^{\lambda u} = \frac{\partial F^\lambda}{\partial u} + s_\mathit{tshift} \frac{\partial F^\lambda}{\partial \dot{u}} = \\
+\int_{\Gamma_{f^+}} {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\frac{\rho_{,j}(\vec{x})}{\rho^2(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{j,l}}_{\color{blue}{J^{\lambda u}_{fX}}}} + {\psi_\mathit{trial}^{\lambda}}_{i,k}{\color{blue}  \underbrace{\color{black}+\frac{1}{\rho(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{k,l}}_{\color{blue}{J^{\lambda u}_{f3}}}} \, d\Gamma \\
++\int_{\Gamma_{f^-}} {\psi_\mathit{trial}^{\lambda}}_i{\color{blue}\underbrace{\color{black}-\frac{\rho_{,j}(\vec{x})}{\rho^2(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{j,l}}_{\color{blue}{J^{\lambda u}_{fX}}}} + {\psi_\mathit{trial}^{\lambda}}_{i,k} {\color{blue}\underbrace{\color{black}-\frac{1}{\rho(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{k,l}}_{\color{blue}{J^{\lambda u}_{f3}}}} \, d\Gamma \\
+\end{multline}
 % J_F ll
+\begin{equation}
 J_F^{\lambda \lambda} = \frac{\partial F^\lambda}{\partial \lambda} + s_\mathit{tshift} \frac{\partial F^\lambda}{\partial \dot{\lambda}} = \int_{\Gamma_{f^+}} {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\frac{1}{\rho(\vec{x})} \delta_{ij}}_{\color{blue}{J^{\lambda\lambda}_{f0}}}} {\psi_\mathit{basis}^{\lambda}}_j \, d\Gamma + \int_{\Gamma_{f^-}} {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\frac{1}{\rho(\vec{x})} \delta_{ij}}_{\color{blue}{J^{\lambda\lambda}_{f0}}}} {\psi_\mathit{basis}^{\lambda}}_j \, d\Gamma
-\end{gather}
+\end{equation}

--- a/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/dynamic.md
+++ b/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/dynamic.md
@@ -1,0 +1,166 @@
+# Dynamic
+
+The equation prescribing fault slip is independent of the Lagrange multiplier, so we do not have a system of equations that we can put in the form $\dot{s} = G^*(t,s)$.
+Instead, we have a differential-algebraic set of equations (DAEs), which we solve using an implicit-explicit (IMEX) time integration scheme.
+As in the case of dynamic elasticity without faults, we introduce the velocity ($\vec{v}$) as an unknown to turn the elasticity equation into two first order equations.
+The strong form for our system of equations is:
+%
+\begin{gather}
+% Solution
+\vec{s}^T = \left( \vec{u} \quad \vec{v} \quad \vec{\lambda} \right)^T \\
+% Displacement-velocity
+\frac{\partial \vec{u}}{\partial t} = \vec{v}, \\
+% Elasticity
+\rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} =
+\vec{f}(\vec{x},t) + \nabla \cdot \boldsymbol{\sigma}(\vec{u}), \\
+% Neumann BC
+\boldsymbol{\sigma} \cdot \vec{n} = \vec{\tau} \text{ on } \Gamma_\tau. \\
+% Dirichlet BC
+\vec{u} = \vec{u}_0 \text{ on } \Gamma_u, \\
+% Presribed slip
+\vec{u}^+(\vec{x},t) - \vec{u}^-(\vec{x},t) - \vec{d}(\vec{x},t) = \vec{0} \text{ on }\Gamma_f,  \\
+\boldsymbol{\sigma} \cdot \vec{n} = -\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^+}, \text{ and}\\
+\boldsymbol{\sigma} \cdot \vec{n} = +\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^-}.
+\end{gather}
+%
+The differentiation index is 2 because we must take the second time derivative of the prescribed slip equation to match the order of the time derivative in the elasticity equation,
+%
+\begin{gather}
+\frac{\partial \vec{v}^+}{\partial t} - \frac{\partial \vec{v}^-}{\partial t} -
+\frac{\partial^2 \vec{d}(\vec{x},t)}{\partial t^2} = \vec{0}.
+\end{gather}
+%
+We generate the weak form in the usual way,
+%
+\begin{gather}
+% Displacement-velocity
+\int_{\Omega} {\vec{\psi}_\mathit{trial}^{u}} \cdot \frac{\partial \vec{u}}{\partial t} \, d\Omega = \int_{\Omega} {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{v} \, d\Omega, \\
+% Elasticity
+\int_{\Omega} {\vec{\psi}_\mathit{trial}^{v}} \cdot \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} \, d\Omega = \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma \dots \\
+\dots + \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) + {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(+\vec{\lambda}(\vec{x},t)\right)\, d\Gamma, \\
+% Prescribed slip
+\int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \left(\frac{\partial \vec{v}^+}{\partial t} - \frac{\partial \vec{v}^-}{\partial t} - \frac{\partial^2 \vec{d}(\vec{x},t)}{\partial t^2} \right) \, d\Gamma = 0.
+\end{gather}
+
+For compatibility with PETSc TS IMEX implementations, we need $\dot{\vec{s}}$ on the LHS for the explicit part (displacement-velocity and elasticity equations) and we need $\vec{\lambda}$ in the equation for the implicit part (prescribed slip equation).
+We first focus on the explicit part and create a lumped LHS Jacobian matrix, $M$, so that we have
+
+```{math}
+:label: eqn:displacement:velocity:prescribed:slip:weak:form
+% Displacement-velocity
+\frac{\partial \vec{u}}{\partial t} = M_u^{-1} \int_{\Omega} {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{v} \, d\Omega, \\
+```
+```{math}
+:label: eqn:elasticity:prescribed:slip:dynamic:weak:form
+% Elasticity
+\frac{\partial \vec{v}}{\partial t} = M_v^{-1} \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + M_v^{-1} \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma \dots \\
+\dots + M_{v^+}^{-1} \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) \, d\Gamma + M_{v^-}^{-1} \int_{\Gamma_{f}}{\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(+\vec{\lambda}(\vec{x},t)\right) \, d\Gamma, \\
+```
+
+\begin{gather}
+% Mu
+M_u = \mathit{Lump}\left( \int_\Omega {\psi_\mathit{trial}^{u}}_i \delta_{ij} {\psi_\mathit{basis}^{u}}_j \, d\Omega \right), \\
+% Mv
+M_v = \mathit{Lump}\left( \int_\Omega {\psi_\mathit{trial}^{v}}_i \rho(\vec{x}) \delta_{ij} {\psi_\mathit{basis}^{v}}_j \, d\Omega \right).
+\end{gather}
+%
+Now, focusing on the implicit part we want to introduce $\vec{\lambda}$ into the prescribed slip equation.
+We solve the elasticity equation for $\frac{\partial \vec{v}}{\partial t}$, create the weak form, and substitute into the prescribed slip equation.
+Solving the elasticity equation for $\frac{\partial \vec{v}}{\partial t}$, we have
+%
+\begin{equation}
+\frac{\partial \vec{v}}{\partial t} = \frac{1}{\rho(x)} \vec{f}(\vec{x},t) + \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u}) \right),
+\end{equation}
+and the corresponding weak form is
+
+```{math}
+:label: eqn:prescribed:slip:DAE:weak:form
+\int_{\Omega} {\vec{\psi}_\mathit{trial}^{v}} \cdot \frac{\partial \vec{v}}{\partial t} \, d\Omega = \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \frac{1}{\rho(x)} \vec{f}(\vec{x},t) + {\vec{\psi}_\mathit{trial}^{v}} \cdot \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega,
+```
+
+We apply the divergence theorem,
+%
+\begin{equation}
+\int_{\Omega} \nabla \cdot \vec{F} \, d\Omega = \int_\Gamma \vec{F} \cdot \vec{n} \, d\Gamma,
+\end{equation}
+%
+with $\vec{F} = {\vec{\psi}_\mathit{trial}^{v}} \cdot \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u})\right)$ to get
+%
+\begin{equation}
+\int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega = \int_\Gamma {\vec{\psi}_\mathit{trial}^{v}} \cdot \left( \frac{1}{\rho(x)} \boldsymbol{\sigma}(\vec{u}) \cdot \vec{n} \right) \, d\Gamma + \int_\Omega \nabla{\vec{\psi}_\mathit{trial}^{v}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) + {\vec{\psi}_\mathit{trial}^{v}} \cdot \left(-\frac{\nabla \rho(\vec{x})}{\rho^2} \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega.
+\end{equation}
+%
+Restricting the trial function to $v^+$ and $v^-$ while recognizing that there is no overlap between the external Neumann boundary conditions $\Gamma_\tau$ and the fault interfaces $\Gamma_f$, yields
+%
+\begin{gather}
+\int_\Omega {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega = \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\frac{1}{\rho(x)} \vec{\lambda} \right) \, d\Gamma + \int_\Omega \nabla{\vec{\psi}_\mathit{trial}^{v^+}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) + {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \, \left(-\frac{\nabla \rho(\vec{x})}{\rho^2} \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega, \\
+\int_\Omega {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \frac{1}{\rho(x)} \left(\nabla \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega = \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(+\frac{1}{\rho(x)} \vec{\lambda} \right) \, d\Gamma + \int_\Omega \nabla{\vec{\psi}_\mathit{trial}^{v^-}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) + {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \, \left(-\frac{\nabla \rho(\vec{x})}{\rho^2} \cdot \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega.
+\end{gather}
+%
+Picking ${\vec{\psi}_\mathit{trial}^{v}}={\vec{\psi}_\mathit{trial}^{\lambda}}$ and substituting into equation {math:numref}`eqn:prescribed:slip:DAE:weak:form` gives
+%
+\begin{gather}
+\int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \left( \frac{\partial \vec{v}^+}{\partial t} - \frac{\partial \vec{v}^-}{\partial t} - \frac{\partial^2 \vec{d}(\vec{x},t)}{\partial t^2} \right) \, d\Gamma = \\
+\int_\Omega {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left( \frac{1}{\rho(\vec{x})} \vec{f}(\vec{x}, t) - \frac{\nabla \rho(\vec{x})}{\rho^2(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right) + \nabla {\vec{\psi}_\mathit{trial}^{v^+}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega + \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot \left(-\frac{1}{\rho(\vec{x})} \vec{\lambda} \right) \, d\Gamma \\
+- \int_\Omega {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left( \frac{1}{\rho(\vec{x})} \vec{f}(\vec{x}, t) -\frac{\nabla \rho(\vec{x})}{\rho^2(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right) + \nabla {\vec{\psi}_\mathit{trial}^{v^-}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) \, d\Omega + \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{v^-}} \cdot \left(-\frac{1}{\rho(\vec{x})} \vec{\lambda} \right) \, d\Gamma \\
+- \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \frac{\partial^2 \vec{d}(\vec{x}, t)}{\partial t^2} \, d\Gamma.
+\end{gather}
+%
+We rewrite the integrals over the domain involving the degrees of freedom adjacent to the fault as integrals over the positive and negative sides of the fault.
+These are implemented as integrals over the faces of cells adjacent to the fault; they involve quantities, such as density, that are defined only within the domain cells.
+After collecting and rearranging terms, we have
+
+```{math}
+:label: eqn:elasticity:prescribed:slip:dynamic:DAE:weak:form
+\begin{gather}
+\int_{\Gamma_{f^+}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \frac{1}{\rho(\vec{x})} \left(\vec{\lambda} - \vec{f}(\vec{x},t) + \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right) + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : \left(+\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right) \, d\Gamma \\
++ \int_{\Gamma_{f^-}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \frac{1}{\rho(\vec{x})} \left(\vec{\lambda} + \vec{f}(\vec{x},t) - \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right) + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : \left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right)  \, d\Gamma \\
++ \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \frac{\partial^2 \vec{d}(\vec{x}, t)}{\partial t^2} \, d\Gamma = 0.
+\end{gather}
+```
+
+### Residual Pointwise Functions
+
+Combining the explicit parts of the weak form in equations {math:numref}`eqn:displacement:velocity:prescribed:slip:weak:form` and {math:numref}`eqn:elasticity:prescribed:slip:dynamic:weak:form` with the implicit part of the weak form in equation {math:numref}`eqn:elasticity:prescribed:slip:dynamic:DAE:weak:form` and identifying $F(t,s,\dot{s})$ and $G(t,s)$, we have
+%
+\begin{gather}
+% Fu
+F^u(t,s,\dot{s}) = \frac{\partial \vec{u}}{\partial t} \\
+% Fv
+F^v(t,s,\dot{s}) = \frac{\partial \vec{v}}{\partial t} \\
+% Fl
+F^\lambda(t,s,\dot{s}) =   \int_{\Gamma_{f^+}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot{\color{blue}\underbrace{\color{black}\frac{1}{\rho(\vec{x})} \left(  \vec{\lambda} - \vec{f}(\vec{x},t) + \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : {\color{blue}\underbrace{\color{black}\left(+\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u})\right)}_{\color{blue}{f^\lambda_1}}} \, d\Gamma \dots \\
+\dots + \int_{\Gamma_{f^-}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot {\color{blue} \underbrace{\color{black}\frac{1}{\rho(\vec{x})} \left(\vec{\lambda} + \vec{f}(\vec{x},t) - \frac{\nabla\rho(\vec{x})}{\rho(\vec{x})} \cdot \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{\lambda}} : {\color{blue}\underbrace{\color{black}\left(-\frac{1}{\rho(\vec{x})} \boldsymbol{\sigma}(\vec{u}) \right)}_{\color{blue}{f^\lambda_1}}}  \, d\Gamma \dots \\
+\dots + \int_{\Gamma_f} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot {\color{blue}\underbrace{\color{black}\frac{\partial^2 \vec{d}(\vec{x}, t)}{\partial t^2}}_{\color{blue}{f^\lambda_0}}} \, d\Gamma \\
+% Gu
+G^u(t,s) = \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot{\color{blue}\underbrace{\color{black}\vec{v}}_{\color{blue}{\vec{g}^u_0}}} \, d\Omega, \\
+% Gv
+G^v(t,s) =  \int_\Omega {\vec{\psi}_\mathit{trial}^{v}} \cdot{\color{blue}\underbrace{\color{black}\vec{f}(\vec{x},t)}_{\color{blue}{\vec{g}^v_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{v}} : {\color{blue}\underbrace{\color{black}-\boldsymbol{\sigma}(\vec{u})}_{\color{blue}{\boldsymbol{g^v_1}}}} \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{v}} \cdot {\color{blue}\underbrace{\color{black}\vec{\tau}(\vec{x},t)}_{\color{blue}{\vec{g}^v_0}}} \, d\Gamma, + \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{v^+}} \cdot {\color{blue}\underbrace{\color{black}\left(-\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{g}^v_0}}} + {\vec{\psi}_\mathit{trial}^{v^-}} \cdot {\color{blue}\underbrace{\color{black}\left(+\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{g}^v_0}}} \, d\Gamma, \\
+% Gl
+G^l(t,s) = 0
+\end{gather}
+%
+### Jacobian Pointwise Functions
+
+For the explicit part we have pointwise functions for computing the lumped LHS Jacobian.
+These are exactly the same pointwise functions as in the dynamic case without a fault,
+%
+\begin{equation}
+\begin{aligned}
+% J_F uu
+J_F^{uu} &= \frac{\partial F^u}{\partial u} + s_\mathit{tshift} \frac{\partial F^u}{\partial \dot{u}} = \int_\Omega {\psi_\mathit{trial}^{u}}_i{\color{blue}\underbrace{\color{black}s_\mathit{tshift} \delta_{ij}}_{\color{blue}{J^{uu}_{f0}}}} {\psi_\mathit{basis}^{u}}_j  \, d\Omega, \\
+% J_F vv
+J_F^{vv} &= \frac{\partial F^v}{\partial v} + s_\mathit{tshift} \frac{\partial F^v}{\partial \dot{v}} = \int_\Omega {\psi_\mathit{trial}^{v}}_i{\color{blue}  \underbrace{\color{black}\rho(\vec{x}) s_\mathit{tshift} \delta_{ij}}_{\color{blue}{J ^{vv}_{f0}}}} {\psi_\mathit{basis}^{v}}_j \, d\Omega
+\end{aligned}
+\end{equation}
+%
+For the implicit part, we have pointwise functions for the LHS Jacobians associated with the prescribed slip,
+%
+\begin{gather}
+% J_F lu
+J_F^{\lambda u} = \frac{\partial F^\lambda}{\partial u} + s_\mathit{tshift} \frac{\partial F^\lambda}{\partial \dot{u}} = \dots \\
+\dots \int_{\Gamma_{f^+}} {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\frac{\rho_{,j}(\vec{x})}{\rho^2(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{j,l}}_{\color{blue}{J^{\lambda u}_{fX}}}} + {\psi_\mathit{trial}^{\lambda}}_{i,k}{\color{blue}  \underbrace{\color{black}+\frac{1}{\rho(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{k,l}}_{\color{blue}{J^{\lambda u}_{f3}}}} \, d\Gamma \dots \\
+\dots +\int_{\Gamma_{f^-}} {\psi_\mathit{trial}^{\lambda}}_i{\color{blue}\underbrace{\color{black}-\frac{\rho_{,j}(\vec{x})}{\rho^2(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{j,l}}_{\color{blue}{J^{\lambda u}_{fX}}}} + {\psi_\mathit{trial}^{\lambda}}_{i,k} {\color{blue}\underbrace{\color{black}-\frac{1}{\rho(\vec{x})} C_{ikjl} {\psi_\mathit{basis}^{u}}_{k,l}}_{\color{blue}{J^{\lambda u}_{f3}}}} \, d\Gamma \\
+% J_F ll
+J_F^{\lambda \lambda} = \frac{\partial F^\lambda}{\partial \lambda} + s_\mathit{tshift} \frac{\partial F^\lambda}{\partial \dot{\lambda}} = \int_{\Gamma_{f^+}} {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\frac{1}{\rho(\vec{x})} \delta_{ij}}_{\color{blue}{J^{\lambda\lambda}_{f0}}}} {\psi_\mathit{basis}^{\lambda}}_j \, d\Gamma + \int_{\Gamma_{f^-}} {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\frac{1}{\rho(\vec{x})} \delta_{ij}}_{\color{blue}{J^{\lambda\lambda}_{f0}}}} {\psi_\mathit{basis}^{\lambda}}_j \, d\Gamma
+\end{gather}

--- a/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/index.md
+++ b/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/index.md
@@ -1,39 +1,49 @@
 # Elasticity with Infinitesimal Strain and Prescribed Slip on Faults
 
 For each fault, which is an internal interface, we add a boundary condition to the elasticity equation prescribing the jump in the displacement field across the fault,
-
+%
 ```{math}
-:label: eqn:bc:prescribed_slip
+:label: eqn:bc:prescribed:slip
 \begin{gather}
-\vec{u}^+(\vec{x},t) - \vec{u}^-(\vec{x},t) - \vec{d}(\vec{x},t) = \vec{0} \text{ on }\Gamma_f,
+  \vec{u}^+ - \vec{u}^- - \vec{d}(\vec{x},t) = \vec{0} \text{ on }\Gamma_f,
 \end{gather}
 ```
+%
 where $\vec{u}^+$ is the displacement vector on the "positive" side of the fault, $\vec{u}^-$ is the displacement vector on the "negative" side of the fault, $\vec{d}$ is the slip vector on the fault, and $\vec{n}$ is the fault normal which points from the negative side of the fault to the positive side of the fault.
-Note that as an alternative to prescribing the jump in displacement across the fault, we can also prescribe the jump in velocity or acceleration across the fault in terms of slip rate or slip acceleration, respectively.
+We enforce the jump in displacements across the fault using a Lagrange multiplier corresponding to equal and opposite tractions on the two sides of the fault.
 
-Using a domain decomposition approach for constraining the fault slip yields additional Neumann-like boundary conditions on the fault surface,
-%
+We apply conservation of momemtum,
+\begin{equation}
+  \int_\Omega \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} \, d\Omega = \int_\Omega \vec{f}(\vec{x},t) \, d\Omega + \int_\Gamma \vec{\tau}(\vec{x},t) \, d\Gamma,
+\end{equation}
+to a fault interface $\Omega_f$ with boundaries $\Gamma_{f^+}$ and $\Gamma_{f^-}$.
+For a fault interface, the body force is zero, $\vec{f}(\vec{x},t) = \vec{0}$.
+The tractions on the positive and negative fault faces are
 \begin{gather}
-\boldsymbol{\sigma} \cdot \vec{n} = -\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^+}, \\
-\boldsymbol{\sigma} \cdot \vec{n} = +\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^-},
+  \tau^+(\vec{x},t) = \boldsymbol{\sigma}^+ \cdot \vec{n} + \vec{\lambda} \\
+  \tau^-(\vec{x},t) = \boldsymbol{\sigma}^- \cdot \vec{n} - \vec{\lambda},
 \end{gather}
-%
-where $\vec{\lambda}$ is the vector of Lagrange multipliers corresponding to the tractions applied to the fault surface to generate the prescribed slip.
+
+where $\vec{\lambda}$ is the Lagrange multiplier that corresponds to the fault traction generating the prescribed slip and $\boldsymbol{\sigma}^+$ and $\boldsymbol{\sigma}^-$ are the stresses in the domain at the positive and negative sides of the fault.
+Thus, for a fault interface, we have
+\begin{equation}
+  \int_{\Omega_f} \rho(\vec{x}) \frac{\partial \vec{v}}{\partial t} \, d\Omega = \int_{\Gamma_{f^+}} \boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda} \, d\Gamma + \int_{\Gamma_{f^-}} \boldsymbol{\sigma} \cdot \vec{n} - \vec{\lambda} \, d\Gamma.
+\end{equation}
 
 ```{table} Mathematical notation for elasticity equation with infinitesimal strain and prescribed slip on faults.
 :name: tab:notation:elasticity:prescribed:slip
-| **Category**                   |   **Symbol**    | **Description**                                                                                   |
-|:-------------------------------|:---------------:|:--------------------------------------------------------------------------------------------------|
-| Unknowns                       |    $\vec{u}$    | Displacement field                                                                                |
-|                                |    $\vec{v}$    | Velocity field                                                                                    |
-|                                | $\vec{\lambda}$ | Lagrange multiplier field                                                                         |
-| Derived quantities             |  $\boldsymbol{\sigma}$  | Cauchy stress tensor                                                                              |
-|                                | $\boldsymbol{\epsilon}$ | Cauchy strain tensor                                                                              |
-| Common constitutive parameters |     $\rho$      | Density                                                                                           |
-|                                |      $\mu$      | Shear modulus                                                                                     |
-|                                |       $K$       | Bulk modulus                                                                                      |
-| Source terms                   |    $\vec{f}$    | Body force per unit volume, for example $\rho \vec{g}$                                            |
-|                                |    $\vec{d}$    | Slip vector field on the fault corresponding to a jump in the displacement field across the fault |
+| Category | Symbol | Description |
+|:-------------|:----------:| :-------------------------|
+| Unknowns |    $\vec{u}$    | Displacement field       |
+|          |    $\vec{v}$    | Velocity field           |
+|          | $\vec{\lambda}$ | Lagrange multiplier field |
+| Derived quantities |  $\boldsymbol{\sigma}$  | Cauchy stress tensor |
+|                    | $\boldsymbol{\epsilon}$ | Cauchy strain tensor |
+| Common constitutive parameters | $\rho$  | Density        |
+|                                | $\mu$   | Shear modulus  |
+|                                | $K$     | Bulk modulus   |
+| Source terms  | $\vec{f}$ | Body force per unit volume, for example $\rho \vec{g}$ |
+|               | $\vec{d}$ | Slip vector field on the fault corresponding to a jump in the displacement field across the fault |
 ```
 
 :::{toctree}

--- a/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/index.md
+++ b/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/index.md
@@ -1,0 +1,42 @@
+# Elasticity with Infinitesimal Strain and Prescribed Slip on Faults
+
+For each fault, which is an internal interface, we add a boundary condition to the elasticity equation prescribing the jump in the displacement field across the fault,
+
+```{math}
+:label: eqn:bc:prescribed_slip
+\begin{gather}
+\vec{u}^+(\vec{x},t) - \vec{u}^-(\vec{x},t) - \vec{d}(\vec{x},t) = \vec{0} \text{ on }\Gamma_f,
+\end{gather}
+```
+where $\vec{u}^+$ is the displacement vector on the "positive" side of the fault, $\vec{u}^-$ is the displacement vector on the "negative" side of the fault, $\vec{d}$ is the slip vector on the fault, and $\vec{n}$ is the fault normal which points from the negative side of the fault to the positive side of the fault.
+Note that as an alternative to prescribing the jump in displacement across the fault, we can also prescribe the jump in velocity or acceleration across the fault in terms of slip rate or slip acceleration, respectively.
+
+Using a domain decomposition approach for constraining the fault slip yields additional Neumann-like boundary conditions on the fault surface,
+%
+\begin{gather}
+\boldsymbol{\sigma} \cdot \vec{n} = -\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^+}, \\
+\boldsymbol{\sigma} \cdot \vec{n} = +\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^-},
+\end{gather}
+%
+where $\vec{\lambda}$ is the vector of Lagrange multipliers corresponding to the tractions applied to the fault surface to generate the prescribed slip.
+
+```{table} Mathematical notation for elasticity equation with infinitesimal strain and prescribed slip on faults.
+:name: tab:notation:elasticity:prescribed:slip
+| **Category**                   |   **Symbol**    | **Description**                                                                                   |
+|:-------------------------------|:---------------:|:--------------------------------------------------------------------------------------------------|
+| Unknowns                       |    $\vec{u}$    | Displacement field                                                                                |
+|                                |    $\vec{v}$    | Velocity field                                                                                    |
+|                                | $\vec{\lambda}$ | Lagrange multiplier field                                                                         |
+| Derived quantities             |  $\boldsymbol{\sigma}$  | Cauchy stress tensor                                                                              |
+|                                | $\boldsymbol{\epsilon}$ | Cauchy strain tensor                                                                              |
+| Common constitutive parameters |     $\rho$      | Density                                                                                           |
+|                                |      $\mu$      | Shear modulus                                                                                     |
+|                                |       $K$       | Bulk modulus                                                                                      |
+| Source terms                   |    $\vec{f}$    | Body force per unit volume, for example $\rho \vec{g}$                                            |
+|                                |    $\vec{d}$    | Slip vector field on the fault corresponding to a jump in the displacement field across the fault |
+```
+
+:::{toctree}
+quasistatic.md
+dynamic.md
+:::

--- a/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/quasistatic.md
+++ b/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/quasistatic.md
@@ -1,0 +1,79 @@
+# Quasistatic
+
+As in the case of elasticity without faults, we first consider the quasistatic case in which we neglect the inertial term ($\rho \frac{\partial \vec{v}}{\partial t} \approx \vec{0}$).
+We place all of the terms in the elasticity equation on the LHS, consistent with implicit time stepping.
+Our solution vector consists of both displacements and Lagrange multipliers, and the strong form for the system of equations is
+%
+\begin{gather}
+% Solution
+\vec{s}^T = \left( \vec{u} \quad \vec{\lambda} \right)^T \\
+% Elasticity
+\vec{f}(\vec{x},t) + \boldsymbol{\nabla} \cdot \boldsymbol{\sigma}(\vec{u}) = \vec{0} \text{ in }\Omega, \\
+% Neumann
+\boldsymbol{\sigma} \cdot \vec{n} = \vec{\tau}(\vec{x},t) \text{ on }\Gamma_\tau, \\
+% Dirichlet
+\vec{u} = \vec{u}_0(\vec{x},t) \text{ on }\Gamma_u, \\
+% Prescribed slip
+\vec{u}^+(\vec{x},t) - \vec{u}^-(\vec{x},t) - \vec{d}(\vec{x},t) = \vec{0} \text{ on }\Gamma_f,  \\
+\boldsymbol{\sigma} \cdot \vec{n} = -\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^+}, \text{ and}\\
+\boldsymbol{\sigma} \cdot \vec{n} = +\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^-}.
+\end{gather}
+
+We create the weak form by taking the dot product with the trial function ${\vec{\psi}_\mathit{trial}^{u}}$ or ${\vec{\psi}_\mathit{trial}^{\lambda}}$ and integrating over the domain.
+After using the divergence theorem and incorporating the Neumann boundary and fault interface conditions, we have
+%
+\begin{gather}
+% Elasticity
+\int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma, + \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{u^+}} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) + {\vec{\psi}_\mathit{trial}^{u^-}} \cdot \left(+\vec{\lambda}(\vec{x},t)\right)\, d\Gamma = 0 \\
+% Prescribed slip
+\int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \left(-\vec{u}^+(\vec{x},t) + \vec{u}^-(\vec{x},t) + \vec{d}(\vec{x},t) \right) \, d\Gamma = 0.
+\end{gather}
+%
+We have chosen the signs in the last equation so that the Jacobian will be symmetric with respect to the Lagrange multiplier.
+We solve the system of equations using implicit time stepping, making use of residuals functions and Jacobians for the LHS.
+
+## Residual Pointwise Functions
+
+Identifying $F(t,s,\dot{s})$ and $G(t,s)$, we have
+%
+\begin{equation}
+\begin{aligned}
+% Fu
+F^u(t,s,\dot{s}) &= \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot{\color{blue}\underbrace{\color{black}\vec{f}(\vec{x},t)}_{\color{blue}{\vec{f}^u_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{u}} : {\color{blue}\underbrace{\color{black}-\boldsymbol{\sigma}(\vec{u})}_{\color{blue}{\boldsymbol{f^u_1}}}} \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{u}} \cdot{\color{blue}\underbrace{\color{black}\vec{\tau}(\vec{x},t)}_{\color{blue}{\vec{f}^u_0}}} \, d\Gamma + \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{u^+}} \cdot{\color{blue}\underbrace{\color{black}\left(-\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{f}^u_0}}} + {\vec{\psi}_\mathit{trial}^{u^-}} \cdot{\color{blue}\underbrace{\color{black}\left(+\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{f}^u_0}}}\, d\Gamma \\
+% Fl
+F^\lambda(t,s,\dot{s}) &= \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot{\color{blue}\underbrace{\color{black}\left(-\vec{u}^+(\vec{x},t) + \vec{u}^-(\vec{x},t) + \vec{d}(\vec{x},t) \right)}_{\color{blue}{\vec{f}^\lambda_0}}} \, d\Gamma, \\
+% Gu
+G^u(t,s) &= 0 \\
+% Gl
+G^\lambda(t,s) &= 0
+\end{aligned}
+\end{equation}
+%
+Compared to the quasistatic elasticity case without a fault, we have simply added additional pointwise functions associated with the fault.
+Our fault implementation does not change the formulation for the materials or external Dirichlet or Neumann boundary conditions.
+
+## Jacobian Pointwise Functions
+
+The LHS Jacobians are:
+%
+\begin{equation}
+\begin{aligned}
+% J_F uu
+J_F^{uu} &= \frac{\partial F^u}{\partial u} + s_\mathit{tshift} \frac{\partial F^u}{\partial \dot{u}} = \int_\Omega \nabla {\vec{\psi}_\mathit{trial}^{u}} : -\boldsymbol{C} : \frac{1}{2}(\nabla + \nabla^T){\vec{\psi}_\mathit{basis}^{u}} \, d\Omega = \int_\Omega {\psi_\mathit{trial}^{u}}_{i,k} \,{\color{blue}\underbrace{\color{black}\left( -C_{ikjl} \right)}_{\color{blue}{J_{f3}^{uu}}}} \, {\psi_\mathit{basis}^{u}}_{j,l}\, d\Omega \\
+% J_F ul
+J_F^{u\lambda} &= \frac{\partial F^u}{\partial \lambda} + s_\mathit{tshift} \frac{\partial F^u}{\partial \dot{\lambda}} = \int_{\Gamma_{f}} {\psi_\mathit{trial}^{u^+}}_i {\color{blue}\underbrace{\color{black}\left(-\delta_{ij}\right)}_{\color{blue}{J^{u\lambda}_{f0}}}} {\psi_\mathit{basis}^{\lambda}}_j + {\psi_\mathit{trial}^{u^-}}_i {\color{blue}\underbrace{\color{black}\left(+\delta_{ij}\right)}_{\color{blue}{J^{u\lambda}_{f0}}}} {\psi_\mathit{basis}^{\lambda}}_j\, d\Gamma, \\
+% J_F lu
+J_F^{\lambda u} &= \frac{\partial F^\lambda}{\partial u} + s_\mathit{tshift} \frac{\partial F^\lambda}{\partial \dot{u}} = \int_{\Gamma_{f}} {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\left(-\delta_{ij}\right)}_{\color{blue}{J^{\lambda u}_{f0}}}} {\psi_\mathit{basis}^{u^+}}_j  + {\psi_\mathit{trial}^{\lambda}}_i {\color{blue}\underbrace{\color{black}\left(+\delta_{ij}\right)}_{\color{blue}{J^{\lambda u}_{f0}}}} {\psi_\mathit{basis}^{u^-}}_j \, d\Gamma, \\
+% J_F ll
+J_F^{\lambda \lambda} &= \boldsymbol{0}
+\end{aligned}
+\end{equation}
+%
+This LHS Jacobian has the structure
+%
+\begin{equation}
+J_F = \left( \begin{array} {cc} J_F^{uu} & J_F^{u\lambda} \\ J_F^{\lambda u} & 0 \end{array} \right) = \left( \begin{array} {cc} J_F^{uu} & C^T \\ C & 0 \end{array} \right),
+\end{equation}  
+%
+where $C$ contains entries of $\pm 1$ for degrees of freedom on the two sides of the fault.
+The Schur complement of $J$ with respect to $J_F^{uu}$ is $-C\left(J_F^{uu}\right)^{-1}C^T$.

--- a/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/quasistatic.md
+++ b/docs-sphinx/user/governingeqns/elasticity-infstrain-prescribedslip/quasistatic.md
@@ -2,33 +2,44 @@
 
 As in the case of elasticity without faults, we first consider the quasistatic case in which we neglect the inertial term ($\rho \frac{\partial \vec{v}}{\partial t} \approx \vec{0}$).
 We place all of the terms in the elasticity equation on the LHS, consistent with implicit time stepping.
-Our solution vector consists of both displacements and Lagrange multipliers, and the strong form for the system of equations is
-%
+Our equation of the conservation of momentum on the fault interface reduces to
+\begin{equation}
+  \int_{\Gamma_{f^+}} \boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda} \, d\Gamma + \int_{\Gamma_{f^-}} \boldsymbol{\sigma} \cdot \vec{n} - \vec{\lambda} \, d\Gamma = 0.
+\end{equation}
+We enforce this equation on each portion of the fault interface along with our prescribed slip constraint, which leads to
 \begin{gather}
-% Solution
-\vec{s}^T = \left( \vec{u} \quad \vec{\lambda} \right)^T \\
-% Elasticity
-\vec{f}(\vec{x},t) + \boldsymbol{\nabla} \cdot \boldsymbol{\sigma}(\vec{u}) = \vec{0} \text{ in }\Omega, \\
-% Neumann
-\boldsymbol{\sigma} \cdot \vec{n} = \vec{\tau}(\vec{x},t) \text{ on }\Gamma_\tau, \\
-% Dirichlet
-\vec{u} = \vec{u}_0(\vec{x},t) \text{ on }\Gamma_u, \\
-% Prescribed slip
-\vec{u}^+(\vec{x},t) - \vec{u}^-(\vec{x},t) - \vec{d}(\vec{x},t) = \vec{0} \text{ on }\Gamma_f,  \\
-\boldsymbol{\sigma} \cdot \vec{n} = -\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^+}, \text{ and}\\
-\boldsymbol{\sigma} \cdot \vec{n} = +\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^-}.
+  \boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda} = \vec{0} \text{ on } \Gamma_{f^+}, \\
+  \boldsymbol{\sigma} \cdot \vec{n} - \vec{\lambda} = \vec{0}\text{ on } \Gamma_{f^-}, \\
+  \vec{u}^+ - \vec{u}^- - \vec{d}(\vec{x},t) = \vec{0},  
 \end{gather}
 
-We create the weak form by taking the dot product with the trial function ${\vec{\psi}_\mathit{trial}^{u}}$ or ${\vec{\psi}_\mathit{trial}^{\lambda}}$ and integrating over the domain.
-After using the divergence theorem and incorporating the Neumann boundary and fault interface conditions, we have
-%
+Our solution vector consists of both displacements and Lagrange multipliers, and the strong form for the system of equations is
 \begin{gather}
-% Elasticity
-\int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{f}(\vec{x},t) + \nabla {\vec{\psi}_\mathit{trial}^{v}} : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{u}} \cdot \vec{\tau}(\vec{x},t) \, d\Gamma, + \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{u^+}} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) + {\vec{\psi}_\mathit{trial}^{u^-}} \cdot \left(+\vec{\lambda}(\vec{x},t)\right)\, d\Gamma = 0 \\
-% Prescribed slip
-\int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot \left(-\vec{u}^+(\vec{x},t) + \vec{u}^-(\vec{x},t) + \vec{d}(\vec{x},t) \right) \, d\Gamma = 0.
+  % Solution
+  \vec{s}^T = \left( \vec{u} \quad \vec{\lambda} \right)^T \\
+  % Elasticity
+  \vec{f}(\vec{x},t) + \boldsymbol{\nabla} \cdot \boldsymbol{\sigma}(\vec{u}) = \vec{0} \text{ in }\Omega, \\
+  % Neumann
+  \boldsymbol{\sigma} \cdot \vec{n} = \vec{\tau}(\vec{x},t) \text{ on }\Gamma_\tau, \\
+  % Dirichlet
+  \vec{u} = \vec{u}_0(\vec{x},t) \text{ on }\Gamma_u, \\
+  % Prescribed slip
+  \vec{u}^+ - \vec{u}^- - \vec{d}(\vec{x},t) = \vec{0} \text{ on }\Gamma_f,  \\
+  \boldsymbol{\sigma} \cdot \vec{n} = -\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^+}, \text{ and}\\
+  \boldsymbol{\sigma} \cdot \vec{n} = +\vec{\lambda}(\vec{x},t) \text{ on }\Gamma_{f^-}.
 \end{gather}
-%
+We create the weak form by taking the dot product with the trial function $\vec{\psi}_\mathit{trial}^u$ or $\vec{\psi}_\mathit{trial}^\lambda$ and integrating over the domain.
+After using the divergence theorem and incorporating the Neumann boundary and fault interface conditions, we have
+\begin{gather}
+  % Elasticity
+  \int_\Omega \vec{\psi}_\mathit{trial}^u \cdot \vec{f}(\vec{x},t) + \nabla \vec{\psi}_\mathit{trial}^u : -\boldsymbol{\sigma}(\vec{u}) \, d\Omega
+  + \int_{\Gamma_\tau} \vec{\psi}_\mathit{trial}^u \cdot \vec{\tau}(\vec{x},t) \, d\Gamma,
+  + \int_{\Gamma_{f}} \vec{\psi}_\mathit{trial}^{u^+} \cdot \left(-\vec{\lambda}(\vec{x},t)\right)
+  + \vec{\psi}_\mathit{trial}^{u^-} \cdot \left(+\vec{\lambda}(\vec{x},t)\right)\, d\Gamma = 0\\
+  % Prescribed slip
+  \int_{\Gamma_{f}} \vec{\psi}_\mathit{trial}^\lambda \cdot \left(
+    -\vec{u}^+ + \vec{u}^- + \vec{d}(\vec{x},t) \right) \, d\Gamma = 0.
+\end{gather}
 We have chosen the signs in the last equation so that the Jacobian will be symmetric with respect to the Lagrange multiplier.
 We solve the system of equations using implicit time stepping, making use of residuals functions and Jacobians for the LHS.
 
@@ -41,7 +52,7 @@ Identifying $F(t,s,\dot{s})$ and $G(t,s)$, we have
 % Fu
 F^u(t,s,\dot{s}) &= \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot{\color{blue}\underbrace{\color{black}\vec{f}(\vec{x},t)}_{\color{blue}{\vec{f}^u_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{u}} : {\color{blue}\underbrace{\color{black}-\boldsymbol{\sigma}(\vec{u})}_{\color{blue}{\boldsymbol{f^u_1}}}} \, d\Omega + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{u}} \cdot{\color{blue}\underbrace{\color{black}\vec{\tau}(\vec{x},t)}_{\color{blue}{\vec{f}^u_0}}} \, d\Gamma + \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{u^+}} \cdot{\color{blue}\underbrace{\color{black}\left(-\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{f}^u_0}}} + {\vec{\psi}_\mathit{trial}^{u^-}} \cdot{\color{blue}\underbrace{\color{black}\left(+\vec{\lambda}(\vec{x},t)\right)}_{\color{blue}{\vec{f}^u_0}}}\, d\Gamma \\
 % Fl
-F^\lambda(t,s,\dot{s}) &= \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot{\color{blue}\underbrace{\color{black}\left(-\vec{u}^+(\vec{x},t) + \vec{u}^-(\vec{x},t) + \vec{d}(\vec{x},t) \right)}_{\color{blue}{\vec{f}^\lambda_0}}} \, d\Gamma, \\
+F^\lambda(t,s,\dot{s}) &= \int_{\Gamma_{f}} {\vec{\psi}_\mathit{trial}^{\lambda}} \cdot{\color{blue}\underbrace{\color{black}\left(-\vec{u}^+ + \vec{u}^- + \vec{d}(\vec{x},t) \right)}_{\color{blue}{\vec{f}^\lambda_0}}} \, d\Gamma, \\
 % Gu
 G^u(t,s) &= 0 \\
 % Gl

--- a/docs-sphinx/user/governingeqns/index.md
+++ b/docs-sphinx/user/governingeqns/index.md
@@ -23,4 +23,5 @@ In all of our derivations, we use the notation described in {ref}`tab:notation`.
 elasticity-derivation.md
 petsc-formulation.md
 elasticity-infstrain/index.md
+elasticity-infstrain-prescribedslip/index.md
 :::


### PR DESCRIPTION
Seems like the environment "multlined" isn't recognized. I've used \dots in specific cases to clarify equations which continue onto another line. Is there a different way you'd like this handled?