### PR TITLE
Clean up use of `label` and `description`. Add use of `label_value`.

### DIFF
--- a/docs/intro/development-plan.md
+++ b/docs/intro/development-plan.md
@@ -16,6 +16,34 @@ List of new features currently available in the `main` branch.
 * Output of subfields with user-defined basis order
 * Simulation metadata with command line utility for searching metadata
 * Convert to Python 3
+* Automatically assign label value for fault cohesive cells (`id` setting is obsolete).
+* Use `description` for descriptive labels and `label` and `label_value` for tagging entities. PyLith's use of`label` and `label_value` now corresponds to PETSc labels and label values.
+
+### SpatialData settings
+
+```{code-block} cfg
+db = spatialdata.spatialdb.UniformDB
+
+# Old
+db.label = Slip spatial database
+
+# New
+db.description = Slip spatial database
+```
+
+### Material settings
+
+```{code-block} cfg
+material = pylith.materials.Elasticity
+
+# Old
+material.label = Elastic material
+material.id = 2
+
+# New
+material.description = Elastic material
+material.label_value = 2
+```
 
 ## Version 3.0.0
 

--- a/examples/barwaves-2d/pylithapp.cfg
+++ b/examples/barwaves-2d/pylithapp.cfg
@@ -88,9 +88,9 @@ materials = [elastic]
 # (isotropic, linearly elastic).
 
 [pylithapp.problem.materials.elastic]
-# id must match the values in the mesh material-ids.
-label = Elastic material
-id = 1
+# label_value must match the block values in the Cubit Exoxus file.
+description = Elastic material
+label_value = 1
 
 # We will use uniform material properties, so we use the UniformDB
 # spatial database.

--- a/examples/barwaves-2d/step04_swave_prescribedslip.cfg
+++ b/examples/barwaves-2d/step04_swave_prescribedslip.cfg
@@ -74,9 +74,6 @@ interfaces = [fault]
 # The label corresponds to the nodeset we created in CUBIT/Trelis for the fault.
 label = fault
 
-# For the fault, we need to specify an id associated with the cohesive cells that is
-# different from any of the ids for the materials.
-id = 10
 observers.observer.data_fields = [slip_rate]
 
 

--- a/examples/box-2d/pylithapp.cfg
+++ b/examples/box-2d/pylithapp.cfg
@@ -65,9 +65,9 @@ materials = [elastic]
 # (isotropic, linearly elastic).
 
 [pylithapp.problem.materials.elastic]
-# id must match the values in the mesh material-ids.
-label = Elastic material
-id = 0
+# label_value must match the values in the mesh material-ids.
+description = Elastic material
+label_value = 0
 
 # We will use uniform material properties, so we use the UniformDB
 # spatial database.

--- a/examples/box-3d/pylithapp.cfg
+++ b/examples/box-3d/pylithapp.cfg
@@ -63,9 +63,9 @@ label = boundary_zpos
 materials = [elastic]
 
 [pylithapp.problem.materials.elastic]
-# id must match the values in the mesh material-ids.
-label = Elastic material
-id = 1
+# label_value must match the block values in the Exodus file.
+description = Elastic material
+label_value = 1
 
 # We will use the default material (elasticity) and rheology
 # (isotropic, linearly elastic).

--- a/examples/reverse-2d/pylithapp.cfg
+++ b/examples/reverse-2d/pylithapp.cfg
@@ -73,8 +73,9 @@ materials = [slab, plate, wedge]
 # examples.
 
 [pylithapp.problem.materials.slab]
-label = Material below main fault
-id = 1
+description = Material below main fault
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Elastic properties for material below main fault
 db_auxiliary_field.iohandler.filename = mat_elastic.spatialdb
@@ -89,8 +90,9 @@ derived_subfields.cauchy_stress.basis_order = 1
 
 
 [pylithapp.problem.materials.plate]
-label = Material below main fault
-id = 2
+description = Material below main fault
+label_value = 2
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Elastic properties for material above main fault and splay
 db_auxiliary_field.iohandler.filename = mat_elastic.spatialdb
@@ -105,8 +107,9 @@ derived_subfields.cauchy_stress.basis_order = 1
 
 
 [pylithapp.problem.materials.wedge]
-label = Material between main fault and splay
-id = 3
+description = Material between main fault and splay
+label_value = 3
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Elastic properties for material above main fault and splay
 db_auxiliary_field.iohandler.filename = mat_elastic.spatialdb

--- a/examples/reverse-2d/step05_onefault.cfg
+++ b/examples/reverse-2d/step05_onefault.cfg
@@ -65,7 +65,6 @@ lagrange_fault.basis_order = 1
 interfaces = [fault]
 
 [pylithapp.problem.interfaces.fault]
-id = 10
 label = fault
 edge = fault_edge
 observers.observer.data_fields = [slip]

--- a/examples/reverse-2d/step06_twofaults_elastic.cfg
+++ b/examples/reverse-2d/step06_twofaults_elastic.cfg
@@ -65,7 +65,6 @@ lagrange_fault.basis_order = 1
 interfaces = [fault, splay]
 
 [pylithapp.problem.interfaces.fault]
-id = 10
 label = fault
 edge = fault_edge
 
@@ -78,7 +77,6 @@ db_auxiliary_field.values = [initiation_time, final_slip_left_lateral, final_sli
 db_auxiliary_field.data = [0.0*s, -2.0*m, 0.0*m]
 
 [pylithapp.problem.interfaces.splay]
-id = 11
 label = splay
 edge = splay_edge
 

--- a/examples/reverse-2d/step07_twofaults_maxwell.cfg
+++ b/examples/reverse-2d/step07_twofaults_maxwell.cfg
@@ -92,7 +92,6 @@ bulk_rheology.auxiliary_subfields.maxwell_time.basis_order = 0
 interfaces = [fault, splay]
 
 [pylithapp.problem.interfaces.fault]
-id = 10
 label = fault
 edge = fault_edge
 
@@ -105,7 +104,6 @@ db_auxiliary_field.values = [initiation_time, final_slip_left_lateral, final_sli
 db_auxiliary_field.data = [0.0*s, -2.0*m, 0.0*m]
 
 [pylithapp.problem.interfaces.splay]
-id = 11
 label = splay
 edge = splay_edge
 

--- a/examples/reverse-2d/step08_twofaults_powerlaw.cfg
+++ b/examples/reverse-2d/step08_twofaults_powerlaw.cfg
@@ -94,7 +94,6 @@ bulk_rheology.auxiliary_subfields.power_law_exponent.basis_order = 0
 interfaces = [fault, splay]
 
 [pylithapp.problem.interfaces.fault]
-id = 10
 label = fault
 edge = fault_edge
 
@@ -107,7 +106,6 @@ db_auxiliary_field.values = [initiation_time, final_slip_left_lateral, final_sli
 db_auxiliary_field.data = [0.0*s, -2.0*m, 0.0*m]
 
 [pylithapp.problem.interfaces.splay]
-id = 11
 label = splay
 edge = splay_edge
 

--- a/examples/strikeslip-2d/pylithapp.cfg
+++ b/examples/strikeslip-2d/pylithapp.cfg
@@ -86,9 +86,9 @@ materials = [elastic_xneg, elastic_xpos]
 # (isotropic, linearly elastic).
 
 [pylithapp.problem.materials.elastic_xneg]
-label = Material to on the -x side of the fault
-# id must match the values in the mesh material-ids.
-id = 1
+# label_value must match the block values in the Cubit Exodus file.
+description = Material to on the -x side of the fault
+label_value = 1
 
 # The properties are uniform. We could use a UniformDB, but for illustrative
 # purposes, we use a SimpleDB with a single data point (data-dim == 0) to specify uniform values.
@@ -106,8 +106,8 @@ derived_subfields.cauchy_stress.basis_order = 1
 
 
 [pylithapp.problem.materials.elastic_xpos]
-label = Material to on the +x side of the fault
-id = 2
+description = Material to on the +x side of the fault
+label_value = 2
 
 db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.description = Elastic properties xpos
@@ -132,9 +132,6 @@ interfaces = [fault]
 # The label corresponds to the nodeset we created in CUBIT/Trelis for the fault.
 label = fault
 
-# For the fault, we need to specify an id associated with the cohesive cells that is
-# different from any of the ids for the materials.
-id = 10
 observers.observer.data_fields = [slip]
 
 # ----------------------------------------------------------------------

--- a/examples/subduction-2d/pylithapp.cfg
+++ b/examples/subduction-2d/pylithapp.cfg
@@ -90,8 +90,8 @@ ocean_mantle.bulk_rheology = pylith.materials.IsotropicLinearElasticity
 
 # Continental crust -----------------------------
 [pylithapp.problem.materials.continent_crust]
-label = Continental crust
-id = 1
+description = Continental crust
+label_value = 1
 
 # The properties are uniform. We could use a UniformDB, but for
 # illustrative purposes, we use a SimpleDB with a single data point
@@ -111,8 +111,8 @@ derived_subfields.cauchy_stress.basis_order = 1
 
 # Continental mantle --------------------
 [pylithapp.problem.materials.continent_mantle]
-label = Continental mantle
-id = 2
+description = Continental mantle
+label_value = 2
 
 db_auxiliary_field.description = Continental mantle properties
 db_auxiliary_field.iohandler.filename = mat_conmantle.spatialdb
@@ -129,8 +129,8 @@ derived_subfields.cauchy_stress.basis_order = 1
 
 # Oceanic crust --------------------
 [pylithapp.problem.materials.ocean_crust]
-label = Oceanic crust
-id = 3
+description = Oceanic crust
+label_value = 3
 
 db_auxiliary_field.description = Oceanic crust properties
 db_auxiliary_field.iohandler.filename = mat_oceancrust.spatialdb
@@ -147,8 +147,8 @@ derived_subfields.cauchy_stress.basis_order = 1
 
 # Oceanic mantle --------------------
 [pylithapp.problem.materials.ocean_mantle]
-label = Oceanic mantle
-id = 4
+description = Oceanic mantle
+label_value = 4
 
 db_auxiliary_field.description = Oceanic mantle properties
 db_auxiliary_field.iohandler.filename = mat_oceanmantle.spatialdb

--- a/examples/subduction-2d/step02_interseismic.cfg
+++ b/examples/subduction-2d/step02_interseismic.cfg
@@ -48,10 +48,8 @@ interfaces.fault_slabbot = pylith.faults.FaultCohesiveKin
 # Slab top --------------------
 [pylithapp.problem.interfaces.fault_slabtop]
 # The label corresponds to the nodeset we created in CUBIT/Trelis for
-# the fault.  The id must be different than any other materials or
-# faults.
+# the fault.
 label = fault_slabtop
-id = 100
 
 observers.observer.data_fields = [slip]
 
@@ -71,10 +69,8 @@ db_auxiliary_field.query_type = linear
 # Slab bottom --------------------
 [pylithapp.problem.interfaces.fault_slabbot]
 # The label corresponds to the nodeset we created in CUBIT/Trelis for
-# the fault.  The id must be different than any other materials or
-# faults.
+# the fault.
 label = fault_slabbot
-id = 101
 
 observers.observer.data_fields = [slip]
 

--- a/examples/subduction-2d/step03_eqcycle.cfg
+++ b/examples/subduction-2d/step03_eqcycle.cfg
@@ -48,10 +48,8 @@ interfaces.fault_slabbot = pylith.faults.FaultCohesiveKin
 # Slab top --------------------
 [pylithapp.problem.interfaces.fault_slabtop]
 # The label corresponds to the nodeset we created in CUBIT/Trelis for
-# the fault.  The id must be different than any other materials or
-# faults.
+# the fault.
 label = fault_slabtop
-id = 100
 
 observers.observer.data_fields = [slip]
 
@@ -86,10 +84,8 @@ db_auxiliary_field.query_type = linear
 # Slab bottom --------------------
 [pylithapp.problem.interfaces.fault_slabbot]
 # The label corresponds to the nodeset we created in CUBIT/Trelis for
-# the fault.  The id must be different than any other materials or
-# faults.
+# the fault.
 label = fault_slabbot
-id = 101
 
 observers.observer.data_fields = [slip]
 

--- a/examples/subduction-2d/step05_eqcycleslipweakening.cfg
+++ b/examples/subduction-2d/step05_eqcycleslipweakening.cfg
@@ -92,7 +92,6 @@ fault_slabbot = pylith.faults.FaultCohesiveKin
 # Slab top --------------------
 [pylithapp.timedependent.interfaces.fault_slabtop]
 # The label corresponds to the name of the nodeset in CUBIT.
-id = 100
 label = fault_slabtop
 
 # We must define the quadrature information for fault cells.
@@ -128,7 +127,6 @@ vertex_data_fields = [slip, slip_rate, traction]
 [pylithapp.timedependent.interfaces.fault_slabbot]
 # The label corresponds to the name of the nodeset in CUBIT.
 label = fault_slabbot
-id = 101
 
 # We must define the quadrature information for fault cells.
 # The fault cells are 1D (line).

--- a/examples/subduction-2d/step06_eqcycleratestate.cfg
+++ b/examples/subduction-2d/step06_eqcycleratestate.cfg
@@ -93,7 +93,6 @@ fault_slabbot = pylith.faults.FaultCohesiveKin
 [pylithapp.timedependent.interfaces.fault_slabtop]
 # The label corresponds to the name of the nodeset in CUBIT.
 label = fault_slabtop
-id = 100
 
 # We must define the quadrature information for fault cells.
 # The fault cells are 1D (line).
@@ -137,7 +136,6 @@ vertex_data_fields = [slip, slip_rate, traction, state_variable]
 [pylithapp.timedependent.interfaces.fault_slabbot]
 # The label corresponds to the name of the nodeset in CUBIT.
 label = fault_slabbot
-id = 101
 
 # We must define the quadrature information for fault cells.
 # The fault cells are 1D (line).

--- a/examples/subduction-3d/pylithapp.cfg
+++ b/examples/subduction-3d/pylithapp.cfg
@@ -100,20 +100,20 @@ trigger.num_skip = 1
 materials = [slab, wedge, crust, mantle]
 
 [pylithapp.problem.materials.slab]
-label = Subducting slab
-id = 1
+description = Subducting slab
+label_value = 1
 
 [pylithapp.problem.materials.wedge]
-label = Accretionary wedge
-id = 2
+description = Accretionary wedge
+label_value = 2
 
 [pylithapp.problem.materials.mantle]
-label = Mantle
-id = 3
+description = Mantle
+label_value = 3
 
 [pylithapp.problem.materials.crust]
-label = Continental crust
-id = 4
+description = Continental crust
+label_value = 4
 
 # ----------------------------------------------------------------------
 # boundary conditions

--- a/examples/subduction-3d/step02_coseismic.cfg
+++ b/examples/subduction-3d/step02_coseismic.cfg
@@ -73,7 +73,6 @@ interfaces = [slab_top]
 slab_top = pylith.faults.FaultCohesiveKin ; Default
 
 [pylithapp.problem.interfaces.slab_top]
-id = 100
 label = fault_slabtop_patch ; Nodeset for the entire fault surface
 edge = fault_slabtop_patch_edge ; Nodeset for the buried edges
 

--- a/examples/subduction-3d/step03_interseismic.cfg
+++ b/examples/subduction-3d/step03_interseismic.cfg
@@ -74,7 +74,6 @@ slab_top = pylith.faults.FaultCohesiveKin
 
 # Slab bottom ----------------------------------------------------------
 [pylithapp.problem.interfaces.slab_bottom]
-id = 100 ; Must be different from ids used for materials
 label = fault_slabbot ; Nodeset for the entire fault surface
 edge = fault_slabbot_edge ; Nodeset for the buried edges
 # Some portions of the bottom of the slab are perfectly horizontal, so
@@ -99,7 +98,6 @@ db_auxiliary_field.data = [+2.0*cm/year, -4.0*cm/year, 0.0*cm/year, 0.0*year]
 
 # Slab top -------------------------------------------------------------
 [pylithapp.problem.interfaces.slab_top]
-id = 101 ; Must be different from ids used for materials
 label = fault_slabtop ; Nodeset for the entire fault surface
 edge = fault_slabtop_edge ; Nodeset for the buried edges
 

--- a/examples/subduction-3d/step04_eqcycle.cfg
+++ b/examples/subduction-3d/step04_eqcycle.cfg
@@ -101,7 +101,6 @@ db_auxiliary_field.data = [+2.0*cm/year, -4.0*cm/year, 0.0*cm/year, 0.0*year]
 
 # Slab top -------------------------------------------------------------
 [pylithapp.problem.interfaces.slab_top]
-id = 101 ; Must be different from ids used for materials
 label = fault_slabtop ; Nodeset for the entire fault surface
 edge = fault_slabtop_edge ; Nodeset for the buried edges
 
@@ -137,7 +136,6 @@ db_auxiliary_field.query_type = linear
 
 # Splay ----------------------------------------------------------------
 [pylithapp.problem.interfaces.splay]
-id = 102 ; Must be different from ids used for materials
 label = fault_splay ; Nodeset for the entire fault surface
 edge = fault_splay_edge ; Nodeset for the buried edges
 

--- a/examples/troubleshooting-2d/.fix02-pylithapp.cfg
+++ b/examples/troubleshooting-2d/.fix02-pylithapp.cfg
@@ -60,9 +60,9 @@ materials = [elastic]
 # (isotropic, linearly elastic).
 
 [pylithapp.problem.materials.elastic]
-# id must match the values in the mesh material-ids.
-label = Elastic material
-id = 0
+# label_value must match the values in the mesh material-ids.
+description = Elastic material
+label_value = 0
 
 # We will use uniform material properties, so we use the UniformDB
 # spatial database.

--- a/examples/troubleshooting-2d/.fix04-pylithapp.cfg
+++ b/examples/troubleshooting-2d/.fix04-pylithapp.cfg
@@ -60,9 +60,9 @@ materials = [elastic]
 # (isotropic, linearly elastic).
 
 [pylithapp.problem.materials.elastic]
-# id must match the values in the mesh material-ids.
-label = Elastic material
-id = 1
+# label_alue must match the values in the mesh material-ids.
+description = Elastic material
+label_value = 1
 
 # We will use uniform material properties, so we use the UniformDB
 # spatial database.

--- a/examples/troubleshooting-2d/pylithapp.cfg
+++ b/examples/troubleshooting-2d/pylithapp.cfg
@@ -60,9 +60,9 @@ materials = [elastic]
 # (isotropic, linearly elastic).
 
 [pylithapp.problem.materials.elastic]
-# id must match the values in the mesh material-ids.
-label = Elastic material
-id = 0
+# label_value must match the values in the mesh material-ids.
+description = Elastic material
+label_value = 0
 
 # We will use uniform material properties, so we use the UniformDB
 # spatial database.

--- a/libsrc/pylith/bc/AbsorbingDampers.cc
+++ b/libsrc/pylith/bc/AbsorbingDampers.cc
@@ -70,8 +70,7 @@ public:
 // ---------------------------------------------------------------------------------------------------------------------
 // Default constructor.
 pylith::bc::AbsorbingDampers::AbsorbingDampers(void) :
-    _auxiliaryFactory(new pylith::bc::AbsorbingDampersAuxiliaryFactory),
-    _boundaryLabel("") {
+    _auxiliaryFactory(new pylith::bc::AbsorbingDampersAuxiliaryFactory) {
     PyreComponent::setName(_AbsorbingDampers::pyreComponent);
 
     _subfieldName = "velocity";
@@ -127,9 +126,9 @@ pylith::bc::AbsorbingDampers::createIntegrator(const pylith::topology::Field& so
     PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
 
     pylith::feassemble::IntegratorBoundary* integrator = new pylith::feassemble::IntegratorBoundary(this);assert(integrator);
-    integrator->setMarkerLabel(getMarkerLabel());
     integrator->setSubfieldName(getSubfieldName());
-    integrator->setLabelName(getMarkerLabel());
+    integrator->setLabelName(getLabelName());
+    integrator->setLabelValue(getLabelValue());
 
     _AbsorbingDampers::setKernelsResidual(integrator, *this, solution);
 

--- a/libsrc/pylith/bc/AbsorbingDampers.hh
+++ b/libsrc/pylith/bc/AbsorbingDampers.hh
@@ -104,7 +104,6 @@ private:
     pylith::bc::AbsorbingDampersAuxiliaryFactory* _auxiliaryFactory; ///< Factory for auxiliary subfields.
     PylithReal _refDir1[3]; ///< First choice reference direction used to compute boundary tangential directions.
     PylithReal _refDir2[3]; ///< Second choice reference direction used to compute boundary tangential directions.
-    std::string _boundaryLabel; ///< Label to identify boundary condition points in mesh.
 
     // NOT IMPLEMENTED /////////////////////////////////////////////////////////////////////////////////////////////////
 private:

--- a/libsrc/pylith/bc/BoundaryCondition.hh
+++ b/libsrc/pylith/bc/BoundaryCondition.hh
@@ -46,18 +46,6 @@ public:
     virtual
     void deallocate(void);
 
-    /** Set label marking boundary associated with boundary condition surface.
-     *
-     * @param[in] value Label of surface (from mesh generator).
-     */
-    void setMarkerLabel(const char* value);
-
-    /** Get label marking boundary associated with boundary condition surface.
-     *
-     * @returns Label of surface (from mesh generator).
-     */
-    const char* getMarkerLabel(void) const;
-
     /** Set name of solution subfield associated with boundary condition.
      *
      * @param[in] value Name of solution subfield.
@@ -69,6 +57,30 @@ public:
      * @preturn Name of solution subfield.
      */
     const char* getSubfieldName(void) const;
+
+    /** Set name of label marking boundary associated with boundary condition surface.
+     *
+     * @param[in] value Name of label for surface (from mesh generator).
+     */
+    void setLabelName(const char* value);
+
+    /** Get name of label marking boundary associated with boundary condition surface.
+     *
+     * @returns Name of label for surface (from mesh generator).
+     */
+    const char* getLabelName(void) const;
+
+    /** Set value of label marking boundary associated with boundary condition surface.
+     *
+     * @param[in] value Value of label for surface (from mesh generator).
+     */
+    void setLabelValue(const int value);
+
+    /** Get value of label marking boundary associated with boundary condition surface.
+     *
+     * @returns Value of label for surface (from mesh generator).
+     */
+    int getLabelValue(void) const;
 
     /** Set first choice for reference direction to discriminate among tangential directions in 3-D.
      *
@@ -94,8 +106,9 @@ protected:
 
     PylithReal _refDir1[3]; ///< First choice reference direction used to compute boundary tangential directions.
     PylithReal _refDir2[3]; ///< Second choice reference direction used to compute boundary tangential directions.
-    std::string _boundaryLabel; ///< Label to identify boundary condition points in mesh.
     std::string _subfieldName; ///< Name of solution subfield for boundary condition.
+    std::string _labelName; ///< Name of label to identify boundary condition points in mesh.
+    int _labelValue; ///< Value of label to identify boundary condition points in mesh.
 
     // NOT IMPLEMENTED /////////////////////////////////////////////////////////////////////////////////////////////////
 private:

--- a/libsrc/pylith/bc/DirichletTimeDependent.cc
+++ b/libsrc/pylith/bc/DirichletTimeDependent.cc
@@ -246,9 +246,10 @@ pylith::bc::DirichletTimeDependent::createConstraints(const pylith::topology::Fi
     std::vector<pylith::feassemble::Constraint*> constraintArray;
     pylith::feassemble::ConstraintSpatialDB* constraint = new pylith::feassemble::ConstraintSpatialDB(this);assert(constraint);
 
-    constraint->setMarkerLabel(getMarkerLabel());
-    constraint->setConstrainedDOF(&_constrainedDOF[0], _constrainedDOF.size());
     constraint->setSubfieldName(_subfieldName.c_str());
+    constraint->setLabelName(getLabelName());
+    constraint->setLabelValue(getLabelValue());
+    constraint->setConstrainedDOF(&_constrainedDOF[0], _constrainedDOF.size());
 
     _DirichletTimeDependent::setKernelConstraint(constraint, *this, solution);
 

--- a/libsrc/pylith/bc/DirichletUserFn.cc
+++ b/libsrc/pylith/bc/DirichletUserFn.cc
@@ -173,9 +173,10 @@ pylith::bc::DirichletUserFn::createConstraints(const pylith::topology::Field& so
 
     std::vector<pylith::feassemble::Constraint*> constraintArray;
     pylith::feassemble::ConstraintUserFn* constraint = new pylith::feassemble::ConstraintUserFn(this);assert(constraint);
-    constraint->setMarkerLabel(getMarkerLabel());
-    constraint->setConstrainedDOF(&_constrainedDOF[0], _constrainedDOF.size());
     constraint->setSubfieldName(_subfieldName.c_str());
+    constraint->setLabelName(getLabelName());
+    constraint->setLabelValue(getLabelValue());
+    constraint->setConstrainedDOF(&_constrainedDOF[0], _constrainedDOF.size());
     constraint->setUserFn(_fn);
     constraint->setUserFnDot(_fnDot);
 

--- a/libsrc/pylith/bc/NeumannTimeDependent.cc
+++ b/libsrc/pylith/bc/NeumannTimeDependent.cc
@@ -192,7 +192,7 @@ pylith::bc::NeumannTimeDependent::setScaleName(const char* value) {
         _scaleName = value;
     } else {
         std::ostringstream msg;
-        msg << "Unknown name of scale ("<<value<<") for Neumann boundary condition '" << _boundaryLabel << "'.";
+        msg << "Unknown name of scale ("<<value<<") for Neumann boundary condition '" << _labelName << "'.";
         throw std::runtime_error(msg.str());
     } // if
 } // setScaleName
@@ -206,9 +206,9 @@ pylith::bc::NeumannTimeDependent::createIntegrator(const pylith::topology::Field
     PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
 
     pylith::feassemble::IntegratorBoundary* integrator = new pylith::feassemble::IntegratorBoundary(this);assert(integrator);
-    integrator->setMarkerLabel(getMarkerLabel());
     integrator->setSubfieldName(getSubfieldName());
-    integrator->setLabelName(getMarkerLabel());
+    integrator->setLabelName(getLabelName());
+    integrator->setLabelValue(getLabelValue());
 
     _NeumannTimeDependent::setKernelsResidual(integrator, *this, solution, _formulation);
 
@@ -254,7 +254,7 @@ pylith::bc::NeumannTimeDependent::createAuxiliaryField(const pylith::topology::F
         description.scale = _normalizer->getDensityScale();
     } else {
         std::ostringstream msg;
-        msg << "Unknown name of scale ("<<_scaleName<<") for Neumann boundary condition for '" << _boundaryLabel << "'.";
+        msg << "Unknown name of scale ("<<_scaleName<<") for Neumann boundary condition for '" << _labelName << "'.";
         PYLITH_COMPONENT_ERROR(msg.str());
         throw std::logic_error(msg.str());
     } // if/else

--- a/libsrc/pylith/bc/NeumannUserFn.cc
+++ b/libsrc/pylith/bc/NeumannUserFn.cc
@@ -121,9 +121,9 @@ pylith::bc::NeumannUserFn::createIntegrator(const pylith::topology::Field& solut
     PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
 
     pylith::feassemble::IntegratorBoundary* integrator = new pylith::feassemble::IntegratorBoundary(this);assert(integrator);
-    integrator->setMarkerLabel(getMarkerLabel());
     integrator->setSubfieldName(getSubfieldName());
-    integrator->setLabelName(getMarkerLabel());
+    integrator->setLabelName(getLabelName());
+    integrator->setLabelValue(getLabelValue());
 
     _NeumannUserFn::setKernelsResidual(integrator, *this, solution, _formulation);
 

--- a/libsrc/pylith/faults/FaultCohesive.hh
+++ b/libsrc/pylith/faults/FaultCohesive.hh
@@ -47,41 +47,77 @@ public:
     virtual
     void deallocate(void);
 
-    /** Set identifier for fault cohesive cells.
+    /** Set name of label identifying cohesive cells.
      *
-     * @param[in] value Fault identifier
+     * @param[in] value Name of label.
      */
-    void setInterfaceId(const int value);
+    void setCohesiveLabelName(const char* value);
 
-    /** Get identifier for fault cohesive cells.
+    /** Get name of label identifying cohesive cells.
      *
-     * @returns Fault identifier
+     * @returns Name of label.
      */
-    int getInterfaceId(void) const;
+    const char* getCohesiveLabelName(void) const;
 
-    /** Set label marking surface of interface.
+    /** Set value of label identifying cohesive cells.
      *
-     * @param[in] value Label of surface (from mesh generator).
+     * @param[in] value Value of label.
      */
-    void setSurfaceMarkerLabel(const char* value);
+    void setCohesiveLabelValue(const int value);
 
-    /** Get label marking surface of interface.
+    /** Get value of label identifying cohesive cells.
      *
-     * @returns Label of surface (from mesh generator).
+     * @returns Value of label.
      */
-    const char* getSurfaceMarkerLabel(void) const;
+    int getCohesiveLabelValue(void) const;
 
-    /** Set label marking buried edges of interface surface.
+    /** Set name of label marking surface of interface.
      *
-     * @param[in] value Label of buried surface edge (from mesh generator).
+     * @param[in] value Name of label of surface (from mesh generator).
      */
-    void setBuriedEdgesMarkerLabel(const char* value);
+    void setSurfaceLabelName(const char* value);
 
-    /** Get label marking buried edges of interface surface.
+    /** Get name of label marking surface of interface.
      *
-     * @returns Label of buried surface edge (from mesh generator).
+     * @returns Name of label of surface (from mesh generator).
      */
-    const char* getBuriedEdgesMarkerLabel(void) const;
+    const char* getSurfaceLabelName(void) const;
+
+    /** Set value of label marking surface of interface.
+     *
+     * @param[in] value Value of label of surface (from mesh generator).
+     */
+    void setSurfaceLabelValue(const int value);
+
+    /** Get value of label marking surface of interface.
+     *
+     * @returns Value of label of surface (from mesh generator).
+     */
+    int getSurfaceLabelValue(void) const;
+
+    /** Set name of label marking buried edges of interface surface.
+     *
+     * @param[in] value Name of label of buried surface edge (from mesh generator).
+     */
+    void setBuriedEdgesLabelName(const char* value);
+
+    /** Get name of label marking buried edges of interface surface.
+     *
+     * @returns Name of label of buried surface edge (from mesh generator).
+     */
+    const char* getBuriedEdgesLabelName(void) const;
+
+    /** Set value of label marking buried edges of interface surface.
+     *
+     * @param[in] value Value of label of buried surface edge (from mesh generator).
+     */
+    void setBuriedEdgesLabelValue(const int value);
+
+    /** Get value of label marking buried edges of interface surface.
+     *
+     * @returns Value of label of buried surface edge (from mesh generator).
+     */
+    int getBuriedEdgesLabelValue(void) const;
 
     /** Set first choice for reference direction to discriminate among tangential directions in 3-D.
      *
@@ -128,9 +164,12 @@ protected:
     // PRIVATE MEMBERS ////////////////////////////////////////////////////////////////////////////
 private:
 
-    int _interfaceId; ///< Identifier for cohesive cells.
-    std::string _interfaceLabel; ///< Label identifying vertices associated with fault.
-    std::string _buriedEdgesLabel; ///< Label identifying vertices along buried edges of fault.
+    std::string _cohesiveLabelName; ///< Name of label for cohesive cells.
+    std::string _surfaceLabelName; ///< Name of label identifying points associated with fault.
+    std::string _buriedEdgesLabelName; ///< Name of label identifying buried edges of fault.
+    int _cohesiveLabelValue; ///< Value of label for cohesive cells.
+    int _surfaceLabelValue; ///< Value of label identifying points associated with fault.
+    int _buriedEdgesLabelValue; ///< Value of label identifying buried edges of fault.
 
     // NOT IMPLEMENTED ////////////////////////////////////////////////////////////////////////////
 private:

--- a/libsrc/pylith/faults/FaultCohesiveKin.cc
+++ b/libsrc/pylith/faults/FaultCohesiveKin.cc
@@ -220,12 +220,12 @@ pylith::faults::FaultCohesiveKin::createConstraints(const pylith::topology::Fiel
     PetscInt n;
     std::ostringstream labelstream;
     labelstream << getBuriedEdgesMarkerLabel() << "_cohesive";
-    std::string labelname = labelstream.str();
+    std::string buriedLabelName = labelstream.str();
     PetscErrorCode err;
 
-    err = DMCreateLabel(dm, labelname.c_str());PYLITH_CHECK_ERROR(err);
+    err = DMCreateLabel(dm, buriedLabelName.c_str());PYLITH_CHECK_ERROR(err);
     err = DMGetLabel(dm, getBuriedEdgesMarkerLabel(), &buriedLabel);PYLITH_CHECK_ERROR(err);
-    err = DMGetLabel(dm, labelname.c_str(), &buriedCohesiveLabel);PYLITH_CHECK_ERROR(err);
+    err = DMGetLabel(dm, buriedLabelName.c_str(), &buriedCohesiveLabel);PYLITH_CHECK_ERROR(err);
     err = DMLabelGetStratumIS(buriedLabel, 1, &pointIS);PYLITH_CHECK_ERROR(err);
     err = ISGetLocalSize(pointIS, &n);PYLITH_CHECK_ERROR(err);
     err = ISGetIndices(pointIS, &points);PYLITH_CHECK_ERROR(err);
@@ -257,7 +257,7 @@ pylith::faults::FaultCohesiveKin::createConstraints(const pylith::topology::Fiel
 
     std::vector<pylith::feassemble::Constraint*> constraintArray;
     pylith::feassemble::ConstraintSimple *constraint = new pylith::feassemble::ConstraintSimple(this);assert(constraint);
-    constraint->setMarkerLabel(labelname.c_str());
+    constraint->setLabelName(buriedLabelName.c_str());
     err = PetscObjectViewFromOptions((PetscObject) buriedLabel, NULL, "-buried_edge_label_view");
     err = PetscObjectViewFromOptions((PetscObject) buriedCohesiveLabel, NULL, "-buried_cohesive_edge_label_view");
     constraint->setConstrainedDOF(&constrainedDOF[0], constrainedDOF.size());

--- a/libsrc/pylith/faults/FaultCohesiveKin.cc
+++ b/libsrc/pylith/faults/FaultCohesiveKin.cc
@@ -177,8 +177,9 @@ pylith::faults::FaultCohesiveKin::createIntegrator(const pylith::topology::Field
     PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
 
     pylith::feassemble::IntegratorInterface* integrator = new pylith::feassemble::IntegratorInterface(this);assert(integrator);
-    integrator->setLabelValue(getInterfaceId());
-    integrator->setSurfaceMarkerLabel(getSurfaceMarkerLabel());
+    integrator->setLabelName(getCohesiveLabelName());
+    integrator->setLabelValue(getCohesiveLabelValue());
+    integrator->setSurfaceLabelName(getSurfaceLabelName());
 
     pylith::feassemble::InterfacePatches* patches =
         pylith::feassemble::InterfacePatches::createMaterialPairs(this, solution.getDM());
@@ -198,7 +199,7 @@ pylith::faults::FaultCohesiveKin::createConstraints(const pylith::topology::Fiel
     PYLITH_METHOD_BEGIN;
     PYLITH_COMPONENT_DEBUG("createConstraints(solution="<<solution.getLabel()<<")");
 
-    if (0 == strlen(getBuriedEdgesMarkerLabel())) {
+    if (0 == strlen(getBuriedEdgesLabelName())) {
         std::vector<pylith::feassemble::Constraint*> constraintArray;
         PYLITH_METHOD_RETURN(constraintArray);
     } // if
@@ -219,14 +220,14 @@ pylith::faults::FaultCohesiveKin::createConstraints(const pylith::topology::Fiel
     const PetscInt *points = NULL;
     PetscInt n;
     std::ostringstream labelstream;
-    labelstream << getBuriedEdgesMarkerLabel() << "_cohesive";
+    labelstream << getBuriedEdgesLabelName() << "_cohesive";
     std::string buriedLabelName = labelstream.str();
     PetscErrorCode err;
 
     err = DMCreateLabel(dm, buriedLabelName.c_str());PYLITH_CHECK_ERROR(err);
-    err = DMGetLabel(dm, getBuriedEdgesMarkerLabel(), &buriedLabel);PYLITH_CHECK_ERROR(err);
+    err = DMGetLabel(dm, getBuriedEdgesLabelName(), &buriedLabel);PYLITH_CHECK_ERROR(err);
     err = DMGetLabel(dm, buriedLabelName.c_str(), &buriedCohesiveLabel);PYLITH_CHECK_ERROR(err);
-    err = DMLabelGetStratumIS(buriedLabel, 1, &pointIS);PYLITH_CHECK_ERROR(err);
+    err = DMLabelGetStratumIS(buriedLabel, getBuriedEdgesLabelValue(), &pointIS);PYLITH_CHECK_ERROR(err);
     err = ISGetLocalSize(pointIS, &n);PYLITH_CHECK_ERROR(err);
     err = ISGetIndices(pointIS, &points);PYLITH_CHECK_ERROR(err);
     for (int p = 0; p < n; ++p) {
@@ -249,7 +250,10 @@ pylith::faults::FaultCohesiveKin::createConstraints(const pylith::topology::Fiel
                 for (int c = 0; c < coneSize; ++c) {
                     PetscInt val;
                     err = DMLabelGetValue(buriedLabel, cone[c], &val);PYLITH_CHECK_ERROR(err);
-                    if (val >= 0) {err = DMLabelSetValue(buriedCohesiveLabel, spoint, 1);PYLITH_CHECK_ERROR(err);break;}
+                    if (val >= 0) {
+                        err = DMLabelSetValue(buriedCohesiveLabel, spoint, 1);PYLITH_CHECK_ERROR(err);
+                        break;
+                    } // if
                 } // for
             } // if
         } // for

--- a/libsrc/pylith/faults/TopologyOps.cc
+++ b/libsrc/pylith/faults/TopologyOps.cc
@@ -185,7 +185,7 @@ pylith::faults::TopologyOps::create(pylith::topology::Mesh* mesh,
     err = DMPlexLabelCohesiveComplete(dm, label, faultBdLabel, PETSC_FALSE, faultMesh.getDM());PYLITH_CHECK_ERROR(err);
     err = DMPlexConstructCohesiveCells(dm, label, NULL, &sdm);PYLITH_CHECK_ERROR(err);
 
-    const char* interfaceLabelName = pylith::topology::Mesh::getCellsLabelName();
+    const char* interfaceLabelName = pylith::topology::Mesh::cells_label_name;
     err = DMGetLabel(sdm, interfaceLabelName, &mlabel);PYLITH_CHECK_ERROR(err);
     if (mlabel) {
         err = DMPlexGetHeightStratum(sdm, 0, &cStart, &cEnd);PYLITH_CHECK_ERROR(err);

--- a/libsrc/pylith/feassemble/Constraint.hh
+++ b/libsrc/pylith/feassemble/Constraint.hh
@@ -52,6 +52,42 @@ public:
     virtual
     void deallocate(void);
 
+    /** Set name of constrained solution subfield.
+     *
+     * @param[in] value Name of solution subfield.
+     */
+    void setSubfieldName(const char* value);
+
+    /** Get name of constrained solution subfield.
+     *
+     * @preturn Name of solution subfield.
+     */
+    const char* getSubfieldName(void) const;
+
+    /** Set name of label marking boundary associated with constraint.
+     *
+     * @param[in] value Name of label for surface (from mesh generator).
+     */
+    void setLabelName(const char* value);
+
+    /** Get name of label marking boundary associated with constraint.
+     *
+     * @returns Name of label for surface (from mesh generator).
+     */
+    const char* getLabelName(void) const;
+
+    /** Set value of label marking boundary associated with constraint.
+     *
+     * @param[in] value Value of label for surface (from mesh generator).
+     */
+    void setLabelValue(const int value);
+
+    /** Get value of label marking boundary associated with constraint.
+     *
+     * @returns Value of label for surface (from mesh generator).
+     */
+    int getLabelValue(void) const;
+
     /** Set indices of constrained degrees of freedom at each location.
      *
      * Example: [0, 1] to apply forces to x and y degrees of freedom in
@@ -68,30 +104,6 @@ public:
      * @returns Array of indices for constrained degrees of freedom.
      */
     const pylith::int_array& getConstrainedDOF(void) const;
-
-    /** Set label marking constrained degrees of freedom.
-     *
-     * @param[in] value Label of constrained degrees of freedom (from mesh generator).
-     */
-    void setMarkerLabel(const char* value);
-
-    /** Get label marking constrained degrees of freedom.
-     *
-     * @returns Label of constrained degrees of freedom (from mesh generator).
-     */
-    const char* getMarkerLabel(void) const;
-
-    /** Set name of constrained solution subfield.
-     *
-     * @param[in] value Name of solution subfield.
-     */
-    void setSubfieldName(const char* value);
-
-    /** Get name of constrained solution subfield.
-     *
-     * @preturn Name of solution subfield.
-     */
-    const char* getSubfieldName(void) const;
 
     /** Get mesh associated with constrained boundary.
      *
@@ -136,9 +148,11 @@ public:
     // PROTECTED MEMBERS ///////////////////////////////////////////////////////////////////////////////////////////////
 protected:
 
-    int_array _constrainedDOF; ///< List of constrained degrees of freedom at each location.
-    std::string _constraintLabel; ///< Label marking constrained degrees of freedom.
     std::string _subfieldName; ///< Name of solution subfield that is constrained.
+    std::string _labelName; ///< Name of label associated with integration domain.
+    int _labelValue; ///< Value of label associated with integration domain.
+
+    int_array _constrainedDOF; ///< List of constrained degrees of freedom at each location.
     pylith::topology::Mesh* _boundaryMesh; ///< Boundary mesh.
     PylithReal _tSolution; ///< Time used for current solution.
 

--- a/libsrc/pylith/feassemble/ConstraintSpatialDB.cc
+++ b/libsrc/pylith/feassemble/ConstraintSpatialDB.cc
@@ -84,11 +84,10 @@ pylith::feassemble::ConstraintSpatialDB::initialize(const pylith::topology::Fiel
     PetscErrorCode err = DMGetDS(dmSoln, &prob);PYLITH_CHECK_ERROR(err);assert(prob);
 
     void* context = NULL;
-    const int labelId = 1;
     const PylithInt numConstrained = _constrainedDOF.size();
     const PetscInt i_field = solution.getSubfieldInfo(_subfieldName.c_str()).index;
-    err = DMGetLabel(dmSoln, _constraintLabel.c_str(), &label);PYLITH_CHECK_ERROR(err);
-    err = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL_BD_FIELD, _constraintLabel.c_str(), label, 1, &labelId, i_field,
+    err = DMGetLabel(dmSoln, _labelName.c_str(), &label);PYLITH_CHECK_ERROR(err);
+    err = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL_BD_FIELD, _labelName.c_str(), label, 1, &_labelValue, i_field,
                              numConstrained, &_constrainedDOF[0], (void (*)()) _kernelConstraint, NULL, context, NULL);PYLITH_CHECK_ERROR(err);
 
     PYLITH_METHOD_END;
@@ -143,7 +142,7 @@ pylith::feassemble::ConstraintSpatialDB::setSolution(pylith::problems::Integrati
     err = DMSetAuxiliaryVec(dmSoln, dmLabel, labelValue, part, _auxiliaryField->getLocalVector());PYLITH_CHECK_ERROR(err);
 
     // Get label for constraint.
-    err = DMGetLabel(dmSoln, _constraintLabel.c_str(), &dmLabel);PYLITH_CHECK_ERROR(err);
+    err = DMGetLabel(dmSoln, _labelName.c_str(), &dmLabel);PYLITH_CHECK_ERROR(err);
 
     void* context = NULL;
     const int labelId = 1;

--- a/libsrc/pylith/feassemble/IntegratorBoundary.cc
+++ b/libsrc/pylith/feassemble/IntegratorBoundary.cc
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 //
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 //
 // Brad T. Aagaard, U.S. Geological Survey
 // Charles A. Williams, GNS Science
@@ -13,8 +13,7 @@
 //
 // See LICENSE.md for license information.
 //
-// ---------------------------------------------------------------------------------------------------------------------
-//
+// ------------------------------------------------------------------------------------------------
 
 #include <portinfo>
 
@@ -37,7 +36,7 @@
 #include <cassert> // USES assert()
 #include <stdexcept> // USES std::runtime_error
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Local "private" functions.
 namespace pylith {
     namespace feassemble {
@@ -51,7 +50,7 @@ public:
     } // feassemble
 } // pylith
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Default constructor.
 pylith::feassemble::IntegratorBoundary::IntegratorBoundary(pylith::problems::Physics* const physics) :
     Integrator(physics),
@@ -62,14 +61,14 @@ pylith::feassemble::IntegratorBoundary::IntegratorBoundary(pylith::problems::Phy
 } // constructor
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Destructor.
 pylith::feassemble::IntegratorBoundary::~IntegratorBoundary(void) {
     deallocate();
 } // destructor
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Deallocate PETSc and local data structures.
 void
 pylith::feassemble::IntegratorBoundary::deallocate(void) {
@@ -83,29 +82,7 @@ pylith::feassemble::IntegratorBoundary::deallocate(void) {
 } // deallocate
 
 
-// ---------------------------------------------------------------------------------------------------------------------
-// Set label marking boundary associated with boundary condition surface.
-void
-pylith::feassemble::IntegratorBoundary::setMarkerLabel(const char* value) {
-    PYLITH_JOURNAL_DEBUG("setMarkerLabel(value="<<value<<")");
-
-    if (strlen(value) == 0) {
-        throw std::runtime_error("Empty string given for boundary condition integrator label.");
-    } // if
-
-    _boundarySurfaceLabel = value;
-} // setMarkerLabel
-
-
-// ---------------------------------------------------------------------------------------------------------------------
-// Get label marking boundary associated with boundary condition surface.
-const char*
-pylith::feassemble::IntegratorBoundary::getMarkerLabel(void) const {
-    return _boundarySurfaceLabel.c_str();
-} // getMarkerLabel
-
-
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Set name of solution subfield associated with boundary condition.
 void
 pylith::feassemble::IntegratorBoundary::setSubfieldName(const char* value) {
@@ -121,7 +98,7 @@ pylith::feassemble::IntegratorBoundary::setSubfieldName(const char* value) {
 } // setSubfieldName
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Get name of solution subfield associated with boundary condition.
 const char*
 pylith::feassemble::IntegratorBoundary::getSubfieldName(void) const {
@@ -129,7 +106,7 @@ pylith::feassemble::IntegratorBoundary::getSubfieldName(void) const {
 } // getSubfieldName
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Get mesh associated with integration domain.
 const pylith::topology::Mesh&
 pylith::feassemble::IntegratorBoundary::getPhysicsDomainMesh(void) const {
@@ -138,7 +115,7 @@ pylith::feassemble::IntegratorBoundary::getPhysicsDomainMesh(void) const {
 } // domainMesh
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 void
 pylith::feassemble::IntegratorBoundary::setKernelsResidual(const std::vector<ResidualKernels>& kernels,
                                                            const pylith::topology::Field& solution) {
@@ -174,7 +151,7 @@ pylith::feassemble::IntegratorBoundary::setKernelsResidual(const std::vector<Res
 } // setKernelsResidual
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Initialize integration domain, auxiliary field, and derived field. Update observers.
 void
 pylith::feassemble::IntegratorBoundary::initialize(const pylith::topology::Field& solution) {
@@ -182,7 +159,7 @@ pylith::feassemble::IntegratorBoundary::initialize(const pylith::topology::Field
     PYLITH_JOURNAL_DEBUG("intialize(solution="<<solution.getLabel()<<")");
 
     delete _boundaryMesh;
-    _boundaryMesh = pylith::topology::MeshOps::createLowerDimMesh(solution.getMesh(), _boundarySurfaceLabel.c_str());
+    _boundaryMesh = pylith::topology::MeshOps::createLowerDimMesh(solution.getMesh(), _labelName.c_str(), _labelValue);
     assert(_boundaryMesh);
     pylith::topology::CoordsVisitor::optimizeClosure(_boundaryMesh->getDM());
 
@@ -206,7 +183,7 @@ pylith::feassemble::IntegratorBoundary::initialize(const pylith::topology::Field
 } // initialize
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Update auxiliary field values to current time.
 void
 pylith::feassemble::IntegratorBoundary::updateState(const double t) {
@@ -231,7 +208,7 @@ pylith::feassemble::IntegratorBoundary::updateState(const double t) {
 } // updateState
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Compute RHS residual for G(t,s).
 void
 pylith::feassemble::IntegratorBoundary::computeRHSResidual(pylith::topology::Field* residual,
@@ -266,7 +243,7 @@ pylith::feassemble::IntegratorBoundary::computeRHSResidual(pylith::topology::Fie
 } // computeRHSResidual
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Compute LHS residual for F(t,s,\dot{s}).
 void
 pylith::feassemble::IntegratorBoundary::computeLHSResidual(pylith::topology::Field* residual,
@@ -302,7 +279,7 @@ pylith::feassemble::IntegratorBoundary::computeLHSResidual(pylith::topology::Fie
 } // computeLHSResidual
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Compute LHS Jacobian for F(t,s,\dot{s}).
 void
 pylith::feassemble::IntegratorBoundary::computeLHSJacobian(PetscMat jacobianMat,
@@ -318,7 +295,7 @@ pylith::feassemble::IntegratorBoundary::computeLHSJacobian(PetscMat jacobianMat,
 } // computeLHSJacobian
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Compute LHS Jacobian for F(t,s,\dot{s}).
 void
 pylith::feassemble::IntegratorBoundary::computeLHSJacobianLumpedInv(pylith::topology::Field* jacobianInv,

--- a/libsrc/pylith/feassemble/IntegratorBoundary.hh
+++ b/libsrc/pylith/feassemble/IntegratorBoundary.hh
@@ -76,18 +76,6 @@ public:
     virtual
     void deallocate(void);
 
-    /** Set label marking boundary associated with boundary condition surface.
-     *
-     * @param[in] value Label of surface (from mesh generator).
-     */
-    void setMarkerLabel(const char* value);
-
-    /** Get label marking boundary associated with boundary condition surface.
-     *
-     * @returns Label of surface (from mesh generator).
-     */
-    const char* getMarkerLabel(void) const;
-
     /** Set name of solution subfield associated with boundary condition.
      *
      * @param[in] value Name of solution subfield.

--- a/libsrc/pylith/feassemble/IntegratorDomain.cc
+++ b/libsrc/pylith/feassemble/IntegratorDomain.cc
@@ -75,7 +75,6 @@ pylith::feassemble::IntegratorDomain::IntegratorDomain(pylith::problems::Physics
     _materialMesh(NULL),
     _updateState(NULL) {
     GenericComponent::setName("integratordomain");
-    _labelName = pylith::topology::Mesh::getCellsLabelName();
 } // constructor
 
 

--- a/libsrc/pylith/feassemble/IntegratorInterface.cc
+++ b/libsrc/pylith/feassemble/IntegratorInterface.cc
@@ -107,11 +107,11 @@ public:
 pylith::feassemble::IntegratorInterface::IntegratorInterface(pylith::problems::Physics* const physics) :
     Integrator(physics),
     _interfaceMesh(NULL),
-    _interfaceSurfaceLabel(""),
+    _surfaceLabelName(""),
     _integrationPatches(NULL) {
     GenericComponent::setName(_IntegratorInterface::genericComponent);
     _labelValue = 100;
-    _labelName = pylith::topology::Mesh::getCellsLabelName();
+    _labelName = pylith::topology::Mesh::cells_label_name;
 } // constructor
 
 
@@ -140,23 +140,23 @@ pylith::feassemble::IntegratorInterface::deallocate(void) {
 // ------------------------------------------------------------------------------------------------
 // Set label marking boundary associated with boundary condition surface.
 void
-pylith::feassemble::IntegratorInterface::setSurfaceMarkerLabel(const char* value) {
-    PYLITH_JOURNAL_DEBUG("setSurfaceMarkerLabel(value="<<value<<")");
+pylith::feassemble::IntegratorInterface::setSurfaceLabelName(const char* value) {
+    PYLITH_JOURNAL_DEBUG("setSurfaceLabelName(value="<<value<<")");
 
     if (strlen(value) == 0) {
         throw std::runtime_error("Empty string given for boundary condition label.");
     } // if
 
-    _interfaceSurfaceLabel = value;
-} // setSurfaceMarkerLabel
+    _surfaceLabelName = value;
+} // setSurfaceLabelName
 
 
 // ------------------------------------------------------------------------------------------------
 // Get label marking boundary associated with boundary condition surface.
 const char*
-pylith::feassemble::IntegratorInterface::getSurfaceMarkerLabel(void) const {
-    return _interfaceSurfaceLabel.c_str();
-} // getSurfaceMarkerLabel
+pylith::feassemble::IntegratorInterface::getSurfaceLabelName(void) const {
+    return _surfaceLabelName.c_str();
+} // getSurfaceLabelName
 
 
 // ------------------------------------------------------------------------------------------------
@@ -309,7 +309,7 @@ pylith::feassemble::IntegratorInterface::initialize(const pylith::topology::Fiel
     const bool isSubmesh = true;
     delete _interfaceMesh;_interfaceMesh = new pylith::topology::Mesh(isSubmesh);assert(_interfaceMesh);
     pylith::faults::TopologyOps::createFaultParallel(_interfaceMesh, solution.getMesh(), _labelValue, _labelName.c_str(),
-                                                     _interfaceSurfaceLabel.c_str());
+                                                     _surfaceLabelName.c_str());
     pylith::topology::MeshOps::checkTopology(*_interfaceMesh);
     pylith::topology::CoordsVisitor::optimizeClosure(_interfaceMesh->getDM());
 

--- a/libsrc/pylith/feassemble/IntegratorInterface.hh
+++ b/libsrc/pylith/feassemble/IntegratorInterface.hh
@@ -131,17 +131,17 @@ public:
     virtual
     void deallocate(void);
 
-    /** Set label marking interior interface surface.
+    /** Set name of label marking interior interface surface.
      *
-     * @param[in] value Label of surface (from mesh generator).
+     * @param[in] value Name of label of surface (from mesh generator).
      */
-    void setSurfaceMarkerLabel(const char* value);
+    void setSurfaceLabelName(const char* value);
 
-    /** Get label marking interior interface surface.
+    /** Get name of label marking interior interface surface.
      *
-     * @returns Label of surface (from mesh generator).
+     * @returns Name of label of surface (from mesh generator).
      */
-    const char* getSurfaceMarkerLabel(void) const;
+    const char* getSurfaceLabelName(void) const;
 
     /** Get mesh associated with integrator domain.
      *
@@ -221,7 +221,7 @@ public:
 private:
 
     pylith::topology::Mesh* _interfaceMesh; ///< Boundary mesh.
-    std::string _interfaceSurfaceLabel; ///< Name of label identifying interface surface.
+    std::string _surfaceLabelName; ///< Name of label identifying interface surface.
 
     pylith::feassemble::InterfacePatches* _integrationPatches; ///< Face patches.
 

--- a/libsrc/pylith/feassemble/InterfacePatches.cc
+++ b/libsrc/pylith/feassemble/InterfacePatches.cc
@@ -56,7 +56,7 @@ namespace pylith {
 // ------------------------------------------------------------------------------------------------
 // Default constructor.
 pylith::feassemble::InterfacePatches::InterfacePatches(void) :
-    _labelName(pylith::topology::Mesh::getCellsLabelName()) {}
+    _labelName(pylith::topology::Mesh::cells_label_name) {}
 
 
 // ------------------------------------------------------------------------------------------------
@@ -88,8 +88,8 @@ pylith::feassemble::InterfacePatches::createMaterialPairs(const pylith::faults::
     PYLITH_METHOD_BEGIN;
 
     assert(fault);
-    const char* const cellsLabelName = pylith::topology::Mesh::getCellsLabelName();
-    const std::string& patchLabelName = fault->getSurfaceMarkerLabel() + std::string("-integration-patches");
+    const char* const cellsLabelName = pylith::topology::Mesh::cells_label_name;
+    const std::string& patchLabelName = fault->getSurfaceLabelName() + std::string("-integration-patches");
     InterfacePatches* patches = new InterfacePatches();assert(patches);
     patches->_labelName = patchLabelName;
 
@@ -101,7 +101,7 @@ pylith::feassemble::InterfacePatches::createMaterialPairs(const pylith::faults::
     PetscIS cohesiveCellsIS = NULL;
     PylithInt numCohesiveCells = 0;
     const PylithInt* cohesiveCells = NULL;
-    err = DMGetStratumIS(dmSoln, cellsLabelName, fault->getInterfaceId(), &cohesiveCellsIS);PYLITH_CHECK_ERROR(err);
+    err = DMGetStratumIS(dmSoln, cellsLabelName, fault->getCohesiveLabelValue(), &cohesiveCellsIS);PYLITH_CHECK_ERROR(err);
     err = ISGetSize(cohesiveCellsIS, &numCohesiveCells);PYLITH_CHECK_ERROR(err);assert(numCohesiveCells > 0);
     err = ISGetIndices(cohesiveCellsIS, &cohesiveCells);PYLITH_CHECK_ERROR(err);assert(cohesiveCells);
 
@@ -123,7 +123,7 @@ pylith::feassemble::InterfacePatches::createMaterialPairs(const pylith::faults::
             pythia::journal::debug_t debug("interfacepatches");
             // debug.activate();
             debug << pythia::journal::at(__HERE__)
-                  << "Creating integration patch on fault '" << fault->getSurfaceMarkerLabel()
+                  << "Creating integration patch on fault '" << fault->getSurfaceLabelName()
                   << "' for material pair ("<< matPair.first << "," << matPair.second<< ") "
                   << "using label '" << patchLabelName << "' with value " << patchLabelValue << "."
                   << pythia::journal::endl;

--- a/libsrc/pylith/materials/Elasticity.cc
+++ b/libsrc/pylith/materials/Elasticity.cc
@@ -40,13 +40,13 @@
 
 #include <typeinfo> // USES typeid()
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 typedef pylith::feassemble::IntegratorDomain::ResidualKernels ResidualKernels;
 typedef pylith::feassemble::IntegratorDomain::JacobianKernels JacobianKernels;
 typedef pylith::feassemble::IntegratorDomain::ProjectKernels ProjectKernels;
 typedef pylith::feassemble::Integrator::EquationPart EquationPart;
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Default constructor.
 pylith::materials::Elasticity::Elasticity(void) :
     _useBodyForce(false),
@@ -56,14 +56,14 @@ pylith::materials::Elasticity::Elasticity(void) :
 } // constructor
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Destructor.
 pylith::materials::Elasticity::~Elasticity(void) {
     deallocate();
 } // destructor
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Deallocate PETSc and local data structures.
 void
 pylith::materials::Elasticity::deallocate(void) {
@@ -74,7 +74,7 @@ pylith::materials::Elasticity::deallocate(void) {
 } // deallocate
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Include body force?
 void
 pylith::materials::Elasticity::useBodyForce(const bool value) {
@@ -84,7 +84,7 @@ pylith::materials::Elasticity::useBodyForce(const bool value) {
 } // useBodyForce
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Include body force?
 bool
 pylith::materials::Elasticity::useBodyForce(void) const {
@@ -92,7 +92,7 @@ pylith::materials::Elasticity::useBodyForce(void) const {
 } // useBodyForce
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Set bulk rheology.
 void
 pylith::materials::Elasticity::setBulkRheology(pylith::materials::RheologyElasticity* const rheology) {
@@ -100,7 +100,7 @@ pylith::materials::Elasticity::setBulkRheology(pylith::materials::RheologyElasti
 } // setBulkRheology
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Get bulk rheology.
 pylith::materials::RheologyElasticity*
 pylith::materials::Elasticity::getBulkRheology(void) const {
@@ -108,7 +108,7 @@ pylith::materials::Elasticity::getBulkRheology(void) const {
 } // getBulkRheology
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Verify configuration is acceptable.
 void
 pylith::materials::Elasticity::verifyConfiguration(const pylith::topology::Field& solution) const {
@@ -138,7 +138,7 @@ pylith::materials::Elasticity::verifyConfiguration(const pylith::topology::Field
 } // verifyConfiguration
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Create integrator and set kernels.
 pylith::feassemble::Integrator*
 pylith::materials::Elasticity::createIntegrator(const pylith::topology::Field& solution) {
@@ -146,8 +146,8 @@ pylith::materials::Elasticity::createIntegrator(const pylith::topology::Field& s
     PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
 
     pylith::feassemble::IntegratorDomain* integrator = new pylith::feassemble::IntegratorDomain(this);assert(integrator);
-    integrator->setLabelName(pylith::topology::Mesh::getCellsLabelName());
-    integrator->setLabelValue(getMaterialId());
+    integrator->setLabelName(getLabelName());
+    integrator->setLabelValue(getLabelValue());
 
     _setKernelsResidual(integrator, solution);
     _setKernelsJacobian(integrator, solution);
@@ -158,7 +158,7 @@ pylith::materials::Elasticity::createIntegrator(const pylith::topology::Field& s
 } // createIntegrator
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Create auxiliary field.
 pylith::topology::Field*
 pylith::materials::Elasticity::createAuxiliaryField(const pylith::topology::Field& solution,
@@ -205,7 +205,7 @@ pylith::materials::Elasticity::createAuxiliaryField(const pylith::topology::Fiel
 } // createAuxiliaryField
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Create derived field.
 pylith::topology::Field*
 pylith::materials::Elasticity::createDerivedField(const pylith::topology::Field& solution,
@@ -235,7 +235,7 @@ pylith::materials::Elasticity::createDerivedField(const pylith::topology::Field&
 } // createDerivedField
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Get auxiliary factory associated with physics.
 pylith::feassemble::AuxiliaryFactory*
 pylith::materials::Elasticity::_getAuxiliaryFactory(void) {
@@ -244,7 +244,7 @@ pylith::materials::Elasticity::_getAuxiliaryFactory(void) {
 } // _getAuxiliaryFactory
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Update kernel constants.
 void
 pylith::materials::Elasticity::_updateKernelConstants(const PylithReal dt) {
@@ -253,7 +253,7 @@ pylith::materials::Elasticity::_updateKernelConstants(const PylithReal dt) {
 } // _updateKernelConstants
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Get derived factory associated with physics.
 pylith::topology::FieldFactory*
 pylith::materials::Elasticity::_getDerivedFactory(void) {
@@ -261,7 +261,7 @@ pylith::materials::Elasticity::_getDerivedFactory(void) {
 } // _getDerivedFactory
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Set kernels for residual.
 void
 pylith::materials::Elasticity::_setKernelsResidual(pylith::feassemble::IntegratorDomain* integrator,
@@ -335,7 +335,7 @@ pylith::materials::Elasticity::_setKernelsResidual(pylith::feassemble::Integrato
 } // _setKernelsResidual
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Set kernels for Jacobian.
 void
 pylith::materials::Elasticity::_setKernelsJacobian(pylith::feassemble::IntegratorDomain* integrator,
@@ -404,7 +404,7 @@ pylith::materials::Elasticity::_setKernelsJacobian(pylith::feassemble::Integrato
 } // _setKernelsJacobian
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Set kernels for computing updated state variables in auxiliary field.
 void
 pylith::materials::Elasticity::_setKernelsUpdateStateVars(pylith::feassemble::IntegratorDomain* integrator,
@@ -424,7 +424,7 @@ pylith::materials::Elasticity::_setKernelsUpdateStateVars(pylith::feassemble::In
 } // _setKernelsUpdateStateVars
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Set kernels for computing derived field.
 void
 pylith::materials::Elasticity::_setKernelsDerivedField(pylith::feassemble::IntegratorDomain* integrator,

--- a/libsrc/pylith/materials/IncompressibleElasticity.cc
+++ b/libsrc/pylith/materials/IncompressibleElasticity.cc
@@ -138,8 +138,8 @@ pylith::materials::IncompressibleElasticity::createIntegrator(const pylith::topo
     PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
 
     pylith::feassemble::IntegratorDomain* integrator = new pylith::feassemble::IntegratorDomain(this);assert(integrator);
-    integrator->setLabelName(pylith::topology::Mesh::getCellsLabelName());
-    integrator->setLabelValue(getMaterialId());
+    integrator->setLabelName(getLabelName());
+    integrator->setLabelValue(getLabelValue());
 
     _setKernelsResidual(integrator, solution);
     _setKernelsJacobian(integrator, solution);

--- a/libsrc/pylith/materials/Material.cc
+++ b/libsrc/pylith/materials/Material.cc
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 //
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 //
 // Brad T. Aagaard, U.S. Geological Survey
 // Charles A. Williams, GNS Science
@@ -13,8 +13,7 @@
 //
 // See LICENSE.md for license information.
 //
-// ---------------------------------------------------------------------------------------------------------------------
-//
+// ------------------------------------------------------------------------------------------------
 
 #include <portinfo>
 
@@ -26,22 +25,23 @@
 #include <cassert> // USES assert()
 #include <stdexcept> // USES std::runtime_error
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Default constructor.
 pylith::materials::Material::Material(void) :
     _gravityField(NULL),
-    _materialId(0),
-    _descriptiveLabel("") {}
+    _description(""),
+    _labelName("material-id"),
+    _labelValue(1) {}
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Destructor.
 pylith::materials::Material::~Material(void) {
     deallocate();
 } // destructor
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Deallocate PETSc and local data structures.
 void
 pylith::materials::Material::deallocate(void) {
@@ -55,43 +55,63 @@ pylith::materials::Material::deallocate(void) {
 } // deallocate
 
 
-// ---------------------------------------------------------------------------------------------------------------------
-// Set value of label material-id used to identify material cells.
-void
-pylith::materials::Material::setMaterialId(const int value) {
-    PYLITH_COMPONENT_DEBUG("setMaterialId(value="<<value<<")");
-
-    _materialId = value;
-} // setMaterialId
-
-
-// ---------------------------------------------------------------------------------------------------------------------
-// Get value of label material-id used to identify material cells.
-int
-pylith::materials::Material::getMaterialId(void) const {
-    return _materialId;
-} // getMaterialId
-
-
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Set descriptive label of material.
 void
-pylith::materials::Material::setDescriptiveLabel(const char* value) {
-    PYLITH_COMPONENT_DEBUG("setDescriptiveLabel(value="<<value<<")");
+pylith::materials::Material::setDescription(const char* value) {
+    PYLITH_COMPONENT_DEBUG("setDescription(value="<<value<<")");
 
-    _descriptiveLabel = value;
-} // setDescriptiveLabel
+    _description = value;
+} // setDescription
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Get label of material.
 const char*
-pylith::materials::Material::getDescriptiveLabel(void) const {
-    return _descriptiveLabel.c_str();
-} // getDescriptiveLabel
+pylith::materials::Material::getDescription(void) const {
+    return _description.c_str();
+} // getDescription
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
+// Set name of label marking material.
+void
+pylith::materials::Material::setLabelName(const char* value) {
+    PYLITH_COMPONENT_DEBUG("setLabelName(value="<<value<<")");
+
+    if (strlen(value) == 0) {
+        throw std::runtime_error("Empty string given for material label.");
+    } // if
+
+    _labelName = value;
+} // setLabelName
+
+
+// ------------------------------------------------------------------------------------------------
+// Get name of label marking material.
+const char*
+pylith::materials::Material::getLabelName(void) const {
+    return _labelName.c_str();
+} // getLabelName
+
+
+// ------------------------------------------------------------------------------------------------
+// Set value of label marking material.
+void
+pylith::materials::Material::setLabelValue(const int value) {
+    _labelValue = value;
+} // setLabelValue
+
+
+// ------------------------------------------------------------------------------------------------
+// Get value of label marking material.
+int
+pylith::materials::Material::getLabelValue(void) const {
+    return _labelValue;
+} // getLabelValue
+
+
+// ------------------------------------------------------------------------------------------------
 // Set gravity field.
 void
 pylith::materials::Material::setGravityField(spatialdata::spatialdb::GravityField* const g) {
@@ -99,7 +119,7 @@ pylith::materials::Material::setGravityField(spatialdata::spatialdb::GravityFiel
 } // setGravityField
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Create constraint and set kernels.
 std::vector<pylith::feassemble::Constraint*>
 pylith::materials::Material::createConstraints(const pylith::topology::Field& solution) {
@@ -109,5 +129,6 @@ pylith::materials::Material::createConstraints(const pylith::topology::Field& so
 
     PYLITH_METHOD_RETURN(constraintArray);
 } // createConstraints
+
 
 // End of file

--- a/libsrc/pylith/materials/Material.hh
+++ b/libsrc/pylith/materials/Material.hh
@@ -65,29 +65,41 @@ public:
     virtual
     void deallocate(void);
 
-    /** Set value of label material-id used to identify material cells.
-     *
-     * @param value Material identifier
-     */
-    void setMaterialId(const int value);
-
-    /** Get value of label material-id used to identify material cells.
-     *
-     * @returns Material identifier
-     */
-    int getMaterialId(void) const;
-
     /** Set descriptive label for material.
      *
      * @param value Label of material.
      */
-    void setDescriptiveLabel(const char* value);
+    void setDescription(const char* value);
 
     /** Get descruptive label of material.
      *
      * @returns Label of material
      */
-    const char* getDescriptiveLabel(void) const;
+    const char* getDescription(void) const;
+
+    /** Set name of label marking material.
+     *
+     * @param[in] value Name of label for material (from mesh generator).
+     */
+    void setLabelName(const char* value);
+
+    /** Get name of label marking material.
+     *
+     * @returns Name of label for material (from mesh generator).
+     */
+    const char* getLabelName(void) const;
+
+    /** Set value of label marking material.
+     *
+     * @param[in] value Value of label for material (from mesh generator).
+     */
+    void setLabelValue(const int value);
+
+    /** Get value of label marking material.
+     *
+     * @returns Value of label for material (from mesh generator).
+     */
+    int getLabelValue(void) const;
 
     /** Set gravity field.
      *
@@ -111,8 +123,9 @@ protected:
     // PRIVATE MEMBERS /////////////////////////////////////////////////////////////////////////////////////////////////
 private:
 
-    int _materialId; ///< Value of material-id label in mesh.
-    std::string _descriptiveLabel; ///< Descriptive label for material.
+    std::string _description; ///< Descriptive label for material.
+    std::string _labelName; ///< Name of label in mesh for material.
+    int _labelValue; ///< Value of label in mesh for material.
 
     // NOT IMPLEMENTED /////////////////////////////////////////////////////////////////////////////////////////////////
 private:

--- a/libsrc/pylith/materials/Poroelasticity.cc
+++ b/libsrc/pylith/materials/Poroelasticity.cc
@@ -187,8 +187,8 @@ pylith::materials::Poroelasticity::createIntegrator(const pylith::topology::Fiel
     PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
 
     pylith::feassemble::IntegratorDomain* integrator = new pylith::feassemble::IntegratorDomain(this);assert(integrator);
-    integrator->setLabelName("material-id");
-    integrator->setLabelValue(getMaterialId());
+    integrator->setLabelName(getLabelName());
+    integrator->setLabelValue(getLabelValue());
 
     _setKernelsResidual(integrator, solution);
     _setKernelsJacobian(integrator, solution);

--- a/libsrc/pylith/meshio/MeshIO.cc
+++ b/libsrc/pylith/meshio/MeshIO.cc
@@ -235,7 +235,7 @@ pylith::meshio::MeshIO::_getCells(int_array* cells,
 // ----------------------------------------------------------------------
 // Tag cells in mesh with material identifiers.
 void
-pylith::meshio::MeshIO::_setMaterials(const int_array& materialIds) { // _setMaterials
+pylith::meshio::MeshIO::_setMaterials(const int_array& materialIds) {
     PYLITH_METHOD_BEGIN;
 
     assert(_mesh);
@@ -253,7 +253,7 @@ pylith::meshio::MeshIO::_setMaterials(const int_array& materialIds) { // _setMat
             throw std::runtime_error(msg.str());
         } // if
         PetscErrorCode err = 0;
-        const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
+        const char* const labelName = pylith::topology::Mesh::cells_label_name;
         for (PetscInt c = cStart; c < cEnd; ++c) {
             err = DMSetLabelValue(dmMesh, labelName, c, materialIds[c-cStart]);PYLITH_CHECK_ERROR(err);
         } // for
@@ -280,7 +280,7 @@ pylith::meshio::MeshIO::_getMaterials(int_array* materialIds) const {
     materialIds->resize(cellsStratum.size());
     PetscErrorCode err = 0;
     PetscInt matId = 0;
-    const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
+    const char* const labelName = pylith::topology::Mesh::cells_label_name;
     for (PetscInt c = cStart, index = 0; c < cEnd; ++c) {
         err = DMGetLabelValue(dmMesh, labelName, c, &matId);PYLITH_CHECK_ERROR(err);
         (*materialIds)[index++] = matId;
@@ -379,7 +379,7 @@ pylith::meshio::MeshIO::_getGroupNames(string_vector* names) const { // _getGrou
     const PetscInt numGroups = numLabels - 3; // Remove depth, celltype, and material labels.
     names->resize(numGroups);
 
-    const std::string& materialLabelName = pylith::topology::Mesh::getCellsLabelName();
+    const std::string& materialLabelName = pylith::topology::Mesh::cells_label_name;
     for (int iGroup = 0, iLabel = 0; iLabel < numLabels; ++iLabel) {
         const char* labelName = NULL;
         err = DMGetLabelName(dmMesh, iLabel, &labelName);PYLITH_CHECK_ERROR(err);

--- a/libsrc/pylith/meshio/OutputSolnBoundary.hh
+++ b/libsrc/pylith/meshio/OutputSolnBoundary.hh
@@ -48,11 +48,17 @@ public:
     /// Deallocate PETSc and local data structures.
     void deallocate(void);
 
-    /** Set label identifier for subdomain.
+    /** Set name of label identifier for subdomain.
      *
-     * @param[in] value Label of subdomain.
+     * @param[in] value Name of label for subdomain.
      */
-    void setLabel(const char* value);
+    void setLabelName(const char* value);
+
+    /** Set value of label identifier for subdomain.
+     *
+     * @param[in] value Value of label for subdomain.
+     */
+    void setLabelValue(const int value);
 
     /** Verify configuration.
      *
@@ -76,8 +82,9 @@ protected:
     // PRIVATE MEMBERS /////////////////////////////////////////////////////////////////////////////////////////////////
 private:
 
-    std::string _label; ///< Label of subdomain.
     pylith::topology::Mesh* _boundaryMesh; ///< Mesh of subdomain.
+    std::string _labelName; ///< Name of label for subdomain.
+    int _labelValue; ///< Value of label for subdomain.
 
     // NOT IMPLEMENTED /////////////////////////////////////////////////////////////////////////////////////////////////
 private:

--- a/libsrc/pylith/problems/InitialConditionPatch.cc
+++ b/libsrc/pylith/problems/InitialConditionPatch.cc
@@ -31,23 +31,24 @@
 #include "pylith/utils/journals.hh" // USES PYLITH_COMPONENT_*
 #include <cassert> // USES assert()
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Constructor
 pylith::problems::InitialConditionPatch::InitialConditionPatch(void) :
-    _patchId(0),
+    _labelName(pylith::topology::Mesh::cells_label_name),
+    _labelValue(1),
     _db(NULL) {
     PyreComponent::setName("initialconditionpatch");
 } // constructor
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Destructor
 pylith::problems::InitialConditionPatch::~InitialConditionPatch(void) {
     deallocate();
 } // destructor
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Deallocate PETSc and local data structures.
 void
 pylith::problems::InitialConditionPatch::deallocate(void) {
@@ -59,28 +60,45 @@ pylith::problems::InitialConditionPatch::deallocate(void) {
 } // deallocate
 
 
-// ---------------------------------------------------------------------------------------------------------------------
-// Set material id associated with patch.
+// ------------------------------------------------------------------------------------------------
+// Set name of label marking initial condition patch.
 void
-pylith::problems::InitialConditionPatch::setMaterialId(const int value) {
-    PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("setMaterialId(value="<<value<<")");
+pylith::problems::InitialConditionPatch::setLabelName(const char* value) {
+    PYLITH_COMPONENT_DEBUG("setLabelName(value="<<value<<")");
 
-    _patchId = value;
+    if (strlen(value) == 0) {
+        throw std::runtime_error("Empty string given for label of initial condition patch.");
+    } // if
 
-    PYLITH_METHOD_END;
-} // setMaterialId
+    _labelName = value;
+} // setLabelName
 
 
-// ---------------------------------------------------------------------------------------------------------------------
-// Get material id associated with patch.
+// ------------------------------------------------------------------------------------------------
+// Get name of label marking initial condition patch.
+const char*
+pylith::problems::InitialConditionPatch::getLabelName(void) const {
+    return _labelName.c_str();
+} // getLabelName
+
+
+// ------------------------------------------------------------------------------------------------
+// Set value of label marking initial condition patch.
+void
+pylith::problems::InitialConditionPatch::setLabelValue(const int value) {
+    _labelValue = value;
+} // setLabelValue
+
+
+// ------------------------------------------------------------------------------------------------
+// Get value of label marking initial condition patch.
 int
-pylith::problems::InitialConditionPatch::getMaterialId(void) const {
-    return _patchId;
-} // getMaterialId
+pylith::problems::InitialConditionPatch::getLabelValue(void) const {
+    return _labelValue;
+} // getLabelValue
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Set spatial database holding initial conditions.
 void
 pylith::problems::InitialConditionPatch::setDB(spatialdata::spatialdb::SpatialDB* db) {
@@ -93,7 +111,7 @@ pylith::problems::InitialConditionPatch::setDB(spatialdata::spatialdb::SpatialDB
 } // setDB
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Verify configuration is acceptable.
 void
 pylith::problems::InitialConditionPatch::verifyConfiguration(const pylith::topology::Field& solution) const {
@@ -104,22 +122,21 @@ pylith::problems::InitialConditionPatch::verifyConfiguration(const pylith::topol
 
     const PetscDM dmSoln = solution.getDM();
     PetscBool hasLabel = PETSC_FALSE;
-    const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
-    PetscErrorCode err = DMHasLabel(dmSoln, labelName, &hasLabel);PYLITH_CHECK_ERROR(err);
+    PetscErrorCode err = DMHasLabel(dmSoln, _labelName.c_str(), &hasLabel);PYLITH_CHECK_ERROR(err);
     if (!hasLabel) {
         std::ostringstream msg;
-        msg << "Could not find label '" << labelName << "' for setting patch for initial condition '"
+        msg << "Could not find label '" << _labelName << "' for setting patch for initial condition '"
             << PyreComponent::getIdentifier() << "'.";
         throw std::runtime_error(msg.str());
     } // if
 
     PetscDMLabel dmLabel = NULL;
-    err = DMGetLabel(solution.getDM(), labelName, &dmLabel);PYLITH_CHECK_ERROR(err);
+    err = DMGetLabel(solution.getDM(), _labelName.c_str(), &dmLabel);PYLITH_CHECK_ERROR(err);
     PetscBool hasValue = PETSC_FALSE;
-    err = DMLabelHasValue(dmLabel, _patchId, &hasValue);PYLITH_CHECK_ERROR(err);
+    err = DMLabelHasValue(dmLabel, _labelValue, &hasValue);PYLITH_CHECK_ERROR(err);
     if (!hasValue) {
         std::ostringstream msg;
-        msg << "Label '" << labelName << "' missing value '" << _patchId << "' for initial condition '"
+        msg << "Label '" << _labelName << "' missing value '" << _labelValue << "' for initial condition '"
             << PyreComponent::getIdentifier() << "'.";
         throw std::runtime_error(msg.str());
     } // if
@@ -130,7 +147,7 @@ pylith::problems::InitialConditionPatch::verifyConfiguration(const pylith::topol
 } // verifyConfiguration
 
 
-// ---------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Set solver type.
 void
 pylith::problems::InitialConditionPatch::setValues(pylith::topology::Field* solution,
@@ -151,8 +168,7 @@ pylith::problems::InitialConditionPatch::setValues(pylith::topology::Field* solu
     } // for
 
     fieldQuery.openDB(_db, normalizer.getLengthScale());
-    const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
-    fieldQuery.queryDBLabel(labelName, _patchId);
+    fieldQuery.queryDBLabel(_labelName.c_str(), _labelValue);
     fieldQuery.closeDB(_db);
 
     pythia::journal::debug_t debug(PyreComponent::getName());

--- a/libsrc/pylith/problems/InitialConditionPatch.hh
+++ b/libsrc/pylith/problems/InitialConditionPatch.hh
@@ -43,17 +43,29 @@ public:
     /// Deallocate PETSc and local data structures.
     void deallocate(void);
 
-    /** Set material id associated with patch.
+    /** Set name of label marking material.
      *
-     * @param[in] value Material id associated with patch.
+     * @param[in] value Name of label for material (from mesh generator).
      */
-    void setMaterialId(const int value);
+    void setLabelName(const char* value);
 
-    /** Get material id associated with patch.
+    /** Get name of label marking material.
      *
-     * @returns Material id associated with patch.
+     * @returns Name of label for material (from mesh generator).
      */
-    int getMaterialId(void) const;
+    const char* getLabelName(void) const;
+
+    /** Set value of label marking material.
+     *
+     * @param[in] value Value of label for material (from mesh generator).
+     */
+    void setLabelValue(const int value);
+
+    /** Get value of label marking material.
+     *
+     * @returns Value of label for material (from mesh generator).
+     */
+    int getLabelValue(void) const;
 
     /** Verify configuration is acceptable.
      *
@@ -79,7 +91,8 @@ public:
     // //////////////////////////////////////////////////////////////////////////////////////////////////
 private:
 
-    PylithInt _patchId; ///< Material id associated with patch.
+    std::string _labelName; ///< Name of label associated with patch.
+    int _labelValue; ///< Value of label associated with patch.
     spatialdata::spatialdb::SpatialDB* _db; ///< Spatial database with values for initial condition.
 
     // NOT IMPLEMENTED /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/libsrc/pylith/problems/Problem.cc
+++ b/libsrc/pylith/problems/Problem.cc
@@ -332,7 +332,7 @@ pylith::problems::Problem::verifyConfiguration(void) const {
         _bc[i]->verifyConfiguration(*solution);
     } // for
 
-    _checkMaterialIds();
+    _checkMaterialLabels();
 
     assert(_observers);
     _observers->verifyObservers(*solution);
@@ -392,31 +392,31 @@ pylith::problems::Problem::initialize(void) {
 // ---------------------------------------------------------------------------------------------------------------------
 // Check material and interface ids.
 void
-pylith::problems::Problem::_checkMaterialIds(void) const {
+pylith::problems::Problem::_checkMaterialLabels(void) const {
     PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("Problem::_checkMaterialIds()");
+    PYLITH_COMPONENT_DEBUG("Problem::_checkMaterialLabels()");
 
     const size_t numMaterials = _materials.size();
     const size_t numInterfaces = _interfaces.size();
 
-    pylith::int_array materialIds(numMaterials + numInterfaces);
+    pylith::int_array labelValues(numMaterials + numInterfaces);
     size_t count = 0;
     for (size_t i = 0; i < numMaterials; ++i) {
         assert(_materials[i]);
-        materialIds[count++] = _materials[i]->getMaterialId();
+        labelValues[count++] = _materials[i]->getLabelValue();
     } // for
     for (size_t i = 0; i < numInterfaces; ++i) {
         assert(_interfaces[i]);
-        materialIds[count++] = _interfaces[i]->getInterfaceId();
+        labelValues[count++] = _interfaces[i]->getCohesiveLabelValue();
     } // for
 
     assert(_integrationData);
     const pylith::topology::Field* solution = _integrationData->getField("solution");
     assert(solution);
-    pylith::topology::MeshOps::checkMaterialIds(solution->getMesh(), materialIds);
+    pylith::topology::MeshOps::checkMaterialLabels(solution->getMesh(), labelValues);
 
     PYLITH_METHOD_END;
-} // _checkMaterialIds
+} // _checkMaterialLabels
 
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/libsrc/pylith/problems/Problem.hh
+++ b/libsrc/pylith/problems/Problem.hh
@@ -194,8 +194,8 @@ protected:
     // PRIVATE METHODS /////////////////////////////////////////////////////////////////////////////////////////////////
 private:
 
-    /// Check material and interface ids.
-    void _checkMaterialIds(void) const;
+    /// Check material and interface label values.
+    void _checkMaterialLabels(void) const;
 
     /// Create array of integrators from materials, interfaces, and boundary conditions.
     void _createIntegrators(void);

--- a/libsrc/pylith/topology/Mesh.cc
+++ b/libsrc/pylith/topology/Mesh.cc
@@ -33,6 +33,9 @@
 #include <cassert> // USES assert()
 
 // ------------------------------------------------------------------------------------------------
+const char* pylith::topology::Mesh::cells_label_name = "material-id";
+
+// ------------------------------------------------------------------------------------------------
 // Default constructor
 pylith::topology::Mesh::Mesh(void) :
     _coordSys(NULL),
@@ -216,14 +219,6 @@ pylith::topology::Mesh::view(const char* viewOption) const {
 
     PYLITH_METHOD_END;
 } // view
-
-
-// ------------------------------------------------------------------------------------------------
-// Get name of label for all mesh cells, including hybrid cells.
-const char* const
-pylith::topology::Mesh::getCellsLabelName(void) {
-    return "material-id";
-} // getCellsLabelName
 
 
 // End of file

--- a/libsrc/pylith/topology/Mesh.hh
+++ b/libsrc/pylith/topology/Mesh.hh
@@ -40,6 +40,11 @@
 class pylith::topology::Mesh { // Mesh
     friend class TestMesh; // unit testing
 
+    // PUBLIC MEMBERS ///////////////////////////////////////////////////////
+public:
+
+    static const char* cells_label_name; ///< Name of label covering all cells.
+
     // PUBLIC METHODS ///////////////////////////////////////////////////////
 public:
 
@@ -122,13 +127,6 @@ public:
      *   VTK vtk:refined.vtk:ascii_vtk
      */
     void view(const char* viewOption="::ascii_info_detail") const;
-
-    /** Get name of label for all mesh cells, including hybrid cells.
-     *
-     * @returns Name of label.
-     */
-    static
-    const char* const getCellsLabelName(void);
 
     // PRIVATE MEMBERS //////////////////////////////////////////////////////
 private:

--- a/libsrc/pylith/topology/MeshOps.cc
+++ b/libsrc/pylith/topology/MeshOps.cc
@@ -383,17 +383,17 @@ pylith::topology::MeshOps::getNumCorners(const pylith::topology::Mesh& mesh) {
 
 // ---------------------------------------------------------------------------------------------------------------------
 void
-pylith::topology::MeshOps::checkMaterialIds(const pylith::topology::Mesh& mesh,
-                                            pylith::int_array& materialIds) {
+pylith::topology::MeshOps::checkMaterialLabels(const pylith::topology::Mesh& mesh,
+                                               pylith::int_array& labelValues) {
     PYLITH_METHOD_BEGIN;
 
     PetscErrorCode err;
 
     // Create map with indices for each material
-    const size_t numIds = materialIds.size();
+    const size_t numIds = labelValues.size();
     std::map<int, int> materialIndex;
     for (size_t i = 0; i < numIds; ++i) {
-        materialIndex[materialIds[i]] = i;
+        materialIndex[labelValues[i]] = i;
     } // for
 
     int_array matCellCounts(numIds);
@@ -405,11 +405,11 @@ pylith::topology::MeshOps::checkMaterialIds(const pylith::topology::Mesh& mesh,
     const PetscInt cEnd = cellsStratum.end();
 
     PetscDMLabel materialsLabel = NULL;
-    const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
+    const char* const labelName = pylith::topology::Mesh::cells_label_name;
     err = DMGetLabel(dmMesh, labelName, &materialsLabel);PYLITH_CHECK_ERROR(err);assert(materialsLabel);
 
-    int *matBegin = &materialIds[0];
-    int *matEnd = &materialIds[0] + materialIds.size();
+    int *matBegin = &labelValues[0];
+    int *matEnd = &labelValues[0] + labelValues.size();
     std::sort(matBegin, matEnd);
 
     for (PetscInt c = cStart; c < cEnd; ++c) {
@@ -440,7 +440,7 @@ pylith::topology::MeshOps::checkMaterialIds(const pylith::topology::Mesh& mesh,
     err = MPI_Allreduce(&matCellCounts[0], &matCellCountsAll[0],
                         matCellCounts.size(), MPI_INT, MPI_SUM, mesh.getComm());PYLITH_CHECK_ERROR(err);
     for (size_t i = 0; i < numIds; ++i) {
-        const int matId = materialIds[i];
+        const int matId = labelValues[i];
         const size_t matIndex = materialIndex[matId];
         assert(0 <= matIndex && matIndex < numIds);
         if (matCellCountsAll[matIndex] <= 0) {

--- a/libsrc/pylith/topology/MeshOps.hh
+++ b/libsrc/pylith/topology/MeshOps.hh
@@ -42,7 +42,7 @@ public:
     /** Create subdomain mesh using label.
      *
      * @param[in] mesh Mesh for domain.
-     * @param[in] label Name of label marking subdomain.
+     * @param[in] labelName Name of label marking subdomain.
      * @param[in] labelValue Value of label marking subdomain.
      * @param[in] descriptiveLabel Descriptive label for subdomain.
      *
@@ -50,20 +50,22 @@ public:
      */
     static
     pylith::topology::Mesh* createSubdomainMesh(const pylith::topology::Mesh& mesh,
-                                                const char* label,
+                                                const char* labelName,
                                                 const int labelValue,
                                                 const char* descriptiveLabel);
 
     /** Create lower dimension mesh using label.
      *
      * @param[in] mesh Mesh for domain.
-     * @param[in] label Label for vertices marking lower dimension domain.
+     * @param[in] labelName Name of label marking subdomain.
+     * @param[in] labelValue Value of label marking subdomain.
      *
      * @returns Lower dimension mesh.
      */
     static
     pylith::topology::Mesh* createLowerDimMesh(const pylith::topology::Mesh& mesh,
-                                               const char* label);
+                                               const char* labelName,
+                                               const int labelValue);
 
     /** Create 0-dimension mesh from points.
      *

--- a/libsrc/pylith/topology/MeshOps.hh
+++ b/libsrc/pylith/topology/MeshOps.hh
@@ -140,15 +140,15 @@ public:
     static
     PylithInt getNumCorners(const pylith::topology::Mesh& mesh);
 
-    /** Check to make sure material id of every cell matches the id of
+    /** Check to make sure material label value for every cell matches the label value of
      *  one of the materials.
      *
      * @param[in] mesh Finite-element mesh.
-     * @param[in] materialIds Array of ids for all materials and interior interfaces.
+     * @param[in] labelValues Array of label values for all materials and interior interfaces.
      */
     static
-    void checkMaterialIds(const Mesh& mesh,
-                          pylith::int_array& materialIds);
+    void checkMaterialLabels(const Mesh& mesh,
+                             pylith::int_array& labelValues);
 
     // NOT IMPLEMENTED /////////////////////////////////////////////////////////////////////////////////////////////////
 private:

--- a/libsrc/pylith/topology/RefineUniform.cc
+++ b/libsrc/pylith/topology/RefineUniform.cc
@@ -89,8 +89,8 @@ pylith::topology::RefineUniform::refine(Mesh* const newMesh,
 
     newMesh->setDM(dmNew);
 
-    // Remove all non-cells from material id label
-    const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
+    // Remove all non-cells from cells label
+    const char* const labelName = pylith::topology::Mesh::cells_label_name;
     PetscDMLabel matidLabel = NULL;
     PetscIS valuesIS = NULL;
     const PetscInt *values = NULL;

--- a/libsrc/pylith/topology/ReverseCuthillMcKee.cc
+++ b/libsrc/pylith/topology/ReverseCuthillMcKee.cc
@@ -32,7 +32,7 @@ pylith::topology::ReverseCuthillMcKee::reorder(topology::Mesh* mesh) {
 
     PetscDMLabel dmLabel = NULL;
     PetscDM dmOrig = mesh->getDM();
-    const char* const labelName = pylith::topology::Mesh::getCellsLabelName();
+    const char* const labelName = pylith::topology::Mesh::cells_label_name;
     err = DMGetLabel(dmOrig, labelName, &dmLabel);PYLITH_CHECK_ERROR(err);
 
     PetscIS permutation = NULL;
@@ -66,7 +66,7 @@ pylith::topology::ReverseCuthillMcKee::reorder(topology::Mesh* mesh) {
                 err = ISDestroy(&valuesIS);PYLITH_CHECK_ERROR(err);
 
                 std::ostringstream msg;
-                msg << "Cells for label material-id " << values[iValue] << " are not consecutive (" << points[iPoint] << " and " << points[iPoint-1] << ").";
+                msg << "Cells for label '" << labelName << "' with value " << values[iValue] << " are not consecutive (" << points[iPoint] << " and " << points[iPoint-1] << ").";
                 throw std::runtime_error(msg.str());
             } // if
         } // for

--- a/modulesrc/bc/BoundaryCondition.i
+++ b/modulesrc/bc/BoundaryCondition.i
@@ -23,7 +23,7 @@
 
 namespace pylith {
     namespace bc {
-        class BoundaryCondition : public pylith::problems::Physics {
+        class BoundaryCondition: public pylith::problems::Physics {
             // PUBLIC METHODS //////////////////////////////////////////////////////////////////////////////////////////
 public:
 
@@ -37,18 +37,6 @@ public:
             virtual
             void deallocate(void);
 
-            /** Set label marking boundary associated with boundary condition surface.
-             *
-             * @param[in] value Label of surface (from mesh generator).
-             */
-            void setMarkerLabel(const char* value);
-
-            /** Get label marking boundary associated with boundary condition surface.
-             *
-             * @returns Label of surface (from mesh generator).
-             */
-            const char* getMarkerLabel(void) const;
-
             /** Set name of solution subfield associated with boundary condition.
              *
              * @param[in] value Name of solution subfield.
@@ -60,6 +48,30 @@ public:
              * @preturn Name of solution subfield.
              */
             const char* getSubfieldName(void) const;
+
+            /** Set name of label marking boundary associated with boundary condition surface.
+             *
+             * @param[in] value Name of label for surface (from mesh generator).
+             */
+            void setLabelName(const char* value);
+
+            /** Get name of label marking boundary associated with boundary condition surface.
+             *
+             * @returns Name of label for surface (from mesh generator).
+             */
+            const char* getLabelName(void) const;
+
+            /** Set value of label marking boundary associated with boundary condition surface.
+             *
+             * @param[in] value Value of label for surface (from mesh generator).
+             */
+            void setLabelValue(const int value);
+
+            /** Get value of label marking boundary associated with boundary condition surface.
+             *
+             * @returns Value of label for surface (from mesh generator).
+             */
+            int getLabelValue(void) const;
 
             /** Set first choice for reference direction to discriminate among tangential directions in 3-D.
              *

--- a/modulesrc/faults/FaultCohesive.i
+++ b/modulesrc/faults/FaultCohesive.i
@@ -23,7 +23,7 @@
 
 namespace pylith {
     namespace faults {
-        class FaultCohesive : public pylith::problems::Physics {
+        class FaultCohesive: public pylith::problems::Physics {
             // PUBLIC METHODS //////////////////////////////////////////////////////////////////////////////////////////
 public:
 
@@ -37,41 +37,77 @@ public:
             virtual
             void deallocate(void);
 
+            /** Set name of label identifying cohesive cells.
+             *
+             * @param[in] value Name of label.
+             */
+            void setCohesiveLabelName(const char* value);
+
+            /** Get name of label identifying cohesive cells.
+             *
+             * @returns Name of label.
+             */
+            const char* getCohesiveLabelName(void) const;
+
             /** Set identifier for fault cohesive cells.
              *
              * @param[in] value Fault identifier
              */
-            void setInterfaceId(const int value);
+            void setCohesiveLabelValue(const int value);
 
             /** Get identifier for fault cohesive cells.
              *
              * @returns Fault identifier
              */
-            int getInterfaceId(void) const;
+            int getCohesiveLabelValue(void) const;
 
             /** Set label marking surface of interface.
              *
              * @param[in] value Label of surface (from mesh generator).
              */
-            void setSurfaceMarkerLabel(const char* value);
+            void setSurfaceLabelName(const char* value);
 
             /** Get label marking surface of interface.
              *
              * @returns Label of surface (from mesh generator).
              */
-            const char* getSurfaceMarkerLabel(void) const;
+            const char* getSurfaceLabelName(void) const;
+
+            /** Set value of label marking surface of interface.
+             *
+             * @param[in] value Value of label of surface (from mesh generator).
+             */
+            void setSurfaceLabelValue(const int value);
+
+            /** Get value of label marking surface of interface.
+             *
+             * @returns Value of label of surface (from mesh generator).
+             */
+            int getSurfaceLabelValue(void) const;
 
             /** Set label marking buried edges of interface surface.
              *
              * @param[in] value Label of buried surface edge (from mesh generator).
              */
-            void setBuriedEdgesMarkerLabel(const char* value);
+            void setBuriedEdgesLabelName(const char* value);
 
             /** Get label marking buried edges of interface surface.
              *
              * @returns Label of buried surface edge (from mesh generator).
              */
-            const char* getBuriedEdgesMarkerLabel(void) const;
+            const char* getBuriedEdgesLabelName(void) const;
+
+            /** Set value of label marking buried edges of interface surface.
+             *
+             * @param[in] value Value of label of buried surface edge (from mesh generator).
+             */
+            void setBuriedEdgesLabelValue(const int value);
+
+            /** Get value of label marking buried edges of interface surface.
+             *
+             * @returns Value of label of buried surface edge (from mesh generator).
+             */
+            int getBuriedEdgesLabelValue(void) const;
 
             /** Set first choice for reference direction to discriminate among tangential directions in 3-D.
              *

--- a/modulesrc/materials/Material.i
+++ b/modulesrc/materials/Material.i
@@ -23,7 +23,7 @@
 
 namespace pylith {
     namespace materials {
-        class Material : public pylith::problems::Physics {
+        class Material: public pylith::problems::Physics {
             // PUBLIC METHODS //////////////////////////////////////////////////////////////////////////////////////////
 public:
 
@@ -40,29 +40,41 @@ public:
             virtual
             void deallocate(void);
 
-            /** Set value of label material-id used to identify material cells.
-             *
-             * @param value Material identifier
-             */
-            void setMaterialId(const int value);
-
-            /** Get value of label material-id used to identify material cells.
-             *
-             * @returns Material identifier
-             */
-            int getMaterialId(void) const;
-
             /** Set descriptive label for material.
              *
              * @param value Label of material.
              */
-            void setDescriptiveLabel(const char* value);
+            void setDescription(const char* value);
 
             /** Get descruptive label of material.
              *
              * @returns Label of material
              */
-            const char* getDescriptiveLabel(void) const;
+            const char* getDescription(void) const;
+
+            /** Set name of label marking material.
+             *
+             * @param[in] value Name of label for material (from mesh generator).
+             */
+            void setLabelName(const char* value);
+
+            /** Get name of label marking material.
+             *
+             * @returns Name of label for material (from mesh generator).
+             */
+            const char* getLabelName(void) const;
+
+            /** Set value of label marking material.
+             *
+             * @param[in] value Value of label for material (from mesh generator).
+             */
+            void setLabelValue(const int value);
+
+            /** Get value of label marking material.
+             *
+             * @returns Value of label for material (from mesh generator).
+             */
+            int getLabelValue(void) const;
 
             /** Set gravity field.
              *
@@ -70,13 +82,13 @@ public:
              */
             void setGravityField(spatialdata::spatialdb::GravityField* const g);
 
-	    /** Create constraint and set kernels.
-	     *
-	     * @param[in] solution Solution field.
-	     * @returns Constraint if applicable, otherwise NULL.
-	     */
-	    virtual
-	    std::vector<pylith::feassemble::Constraint*> createConstraints(const pylith::topology::Field& solution);
+            /** Create constraint and set kernels.
+             *
+             * @param[in] solution Solution field.
+             * @returns Constraint if applicable, otherwise NULL.
+             */
+            virtual
+            std::vector < pylith::feassemble::Constraint* > createConstraints(const pylith::topology::Field& solution);
 
         }; // class Material
 

--- a/modulesrc/meshio/OutputSolnBoundary.i
+++ b/modulesrc/meshio/OutputSolnBoundary.i
@@ -24,7 +24,7 @@
 
 namespace pylith {
     namespace meshio {
-        class OutputSolnBoundary : public pylith::meshio::OutputSoln {
+        class OutputSolnBoundary: public pylith::meshio::OutputSoln {
             // PUBLIC METHODS //////////////////////////////////////////////////////////////////////////////////////////
 public:
 
@@ -34,11 +34,17 @@ public:
             /// Destructor
             virtual ~OutputSolnBoundary(void);
 
-            /** Set label identifier for subdomain.
+            /** Set name of label identifier for subdomain.
              *
-             * @param[in] value Label of subdomain.
+             * @param[in] value Name of label for subdomain.
              */
-            void setLabel(const char* value);
+            void setLabelName(const char* value);
+
+            /** Set value of label identifier for subdomain.
+             *
+             * @param[in] value Value of label for subdomain.
+             */
+            void setLabelValue(const int value);
 
             /** Verify configuration.
              *

--- a/modulesrc/problems/InitialConditionPatch.i
+++ b/modulesrc/problems/InitialConditionPatch.i
@@ -24,7 +24,7 @@
 
 namespace pylith {
     namespace problems {
-        class InitialConditionPatch : public pylith::problems::InitialCondition {
+        class InitialConditionPatch: public pylith::problems::InitialCondition {
             // PUBLIC MEMBERS //////////////////////////////////////////////////////////////////////////////////////////
 public:
 
@@ -37,17 +37,29 @@ public:
             /// Deallocate PETSc and local data structures.
             void deallocate(void);
 
-            /** Set material id associated with patch.
+            /** Set name of label marking material.
              *
-             * @param[in] value Material id associated with patch.
+             * @param[in] value Name of label for material (from mesh generator).
              */
-            void setMaterialId(const int value);
+            void setLabelName(const char* value);
 
-            /** Get material id associated with patch.
+            /** Get name of label marking material.
              *
-             * @returns Material id associated with patch.
+             * @returns Name of label for material (from mesh generator).
              */
-            int getMaterialId(void) const;
+            const char* getLabelName(void) const;
+
+            /** Set value of label marking material.
+             *
+             * @param[in] value Value of label for material (from mesh generator).
+             */
+            void setLabelValue(const int value);
+
+            /** Get value of label marking material.
+             *
+             * @returns Value of label for material (from mesh generator).
+             */
+            int getLabelValue(void) const;
 
             /** Set spatial database holding initial conditions.
              *

--- a/modulesrc/topology/Mesh.i
+++ b/modulesrc/topology/Mesh.i
@@ -38,7 +38,7 @@ public:
              * @param comm MPI communicator for mesh.
              */
             Mesh(const int dim,
-                 const MPI_Comm& comm=PETSC_COMM_WORLD);
+                 const MPI_Comm& comm = PETSC_COMM_WORLD);
 
             /// Default destructor
             ~Mesh(void);
@@ -109,13 +109,6 @@ public:
              *   VTK vtk:refined.vtk:ascii_vtk
              */
             void view(const char* viewOption="") const;
-
-            /** Get name of label for all mesh cells, including hybrid cells.
-             *
-             * @returns Name of label.
-             */
-            static
-            const char* const getCellsLabelName(void);
 
         }; // Mesh
 

--- a/pylith/bc/BoundaryCondition.py
+++ b/pylith/bc/BoundaryCondition.py
@@ -12,15 +12,6 @@
 # See LICENSE.md for license information.
 #
 # ----------------------------------------------------------------------
-#
-# @file pylith/bc/BoundaryCondition.py
-#
-# @brief Python abstract base class for managing a boundary condition.
-#
-# This implementation of a boundary condition applies to a single
-# boundary of an domain.
-#
-# Factory: boundary_condition
 
 from pylith.problems.Physics import Physics
 from .bc import BoundaryCondition as ModuleBoundaryCondition
@@ -34,8 +25,7 @@ def validateLabel(value):
     return value
 
 
-class BoundaryCondition(Physics,
-                        ModuleBoundaryCondition):
+class BoundaryCondition(Physics, ModuleBoundaryCondition):
     """
     Abstract base class for boundary conditions.
     """
@@ -45,8 +35,11 @@ class BoundaryCondition(Physics,
     field = pythia.pyre.inventory.str("field", default="displacement")
     field.meta['tip'] = "Solution subfield associated with boundary condition."
 
-    label = pythia.pyre.inventory.str("label", default="", validator=validateLabel)
-    label.meta['tip'] = "Label identifying boundary."
+    labelName = pythia.pyre.inventory.str("label", default="", validator=validateLabel)
+    labelName.meta['tip'] = "Name of label identifying boundary."
+
+    labelValue = pythia.pyre.inventory.int("label_value", default=1)
+    labelValue.meta['tip'] = "Value of label identifying boundary (tag of physical group in Gmsh files)."
 
     def __init__(self, name="boundarycondition"):
         """Constructor.
@@ -59,8 +52,9 @@ class BoundaryCondition(Physics,
         """
         Physics.preinitialize(self, problem)
 
-        ModuleBoundaryCondition.setMarkerLabel(self, self.label)
         ModuleBoundaryCondition.setSubfieldName(self, self.field)
+        ModuleBoundaryCondition.setLabelName(self, self.labelName)
+        ModuleBoundaryCondition.setLabelValue(self, self.labelValue)
         return
 
     def _configure(self):

--- a/pylith/faults/FaultCohesive.py
+++ b/pylith/faults/FaultCohesive.py
@@ -48,14 +48,17 @@ class FaultCohesive(Physics, ModuleFaultCohesive):
 
     import pythia.pyre.inventory
 
-    matId = pythia.pyre.inventory.int("id", default=100)
-    matId.meta['tip'] = "Fault identifier (must be unique across all faults and materials)."
+    labelName = pythia.pyre.inventory.str("label", default="", validator=validateLabel)
+    labelName.meta['tip'] = "Name of label identifier for fault."
 
-    label = pythia.pyre.inventory.str("label", default="", validator=validateLabel)
-    label.meta['tip'] = "Label identifier for fault."
+    labelValue = pythia.pyre.inventory.int("label_value", default=1)
+    labelValue.meta['tip'] = "Value of label identifier for fault."
 
-    edge = pythia.pyre.inventory.str("edge", default="")
-    edge.meta['tip'] = "Label identifier for buried fault edges."
+    edgeName = pythia.pyre.inventory.str("edge", default="")
+    edgeName.meta['tip'] = "Name of label identifier for buried fault edges."
+
+    edgeValue = pythia.pyre.inventory.int("edge_value", default=1)
+    edgeValue.meta['tip'] = "Value of label identifier for buried fault edges."
 
     refDir1 = pythia.pyre.inventory.list("ref_dir_1", default=[0.0, 0.0, 1.0], validator=validateDir)
     refDir1.meta['tip'] = "First choice for reference direction to discriminate among tangential directions in 3-D."
@@ -74,9 +77,10 @@ class FaultCohesive(Physics, ModuleFaultCohesive):
         """
         Physics.preinitialize(self, problem)
 
-        ModuleFaultCohesive.setInterfaceId(self, self.matId)
-        ModuleFaultCohesive.setSurfaceMarkerLabel(self, self.label)
-        ModuleFaultCohesive.setBuriedEdgesMarkerLabel(self, self.edge)
+        ModuleFaultCohesive.setSurfaceLabelName(self, self.labelName)
+        ModuleFaultCohesive.setSurfaceLabelValue(self, self.labelValue)
+        ModuleFaultCohesive.setBuriedEdgesLabelName(self, self.edgeName)
+        ModuleFaultCohesive.setBuriedEdgesLabelValue(self, self.edgeValue)
         ModuleFaultCohesive.setRefDir1(self, self.refDir1)
         ModuleFaultCohesive.setRefDir2(self, self.refDir2)
         return

--- a/pylith/faults/FaultCohesiveKin.py
+++ b/pylith/faults/FaultCohesiveKin.py
@@ -40,7 +40,7 @@ class FaultCohesiveKin(FaultCohesive, ModuleFaultCohesiveKin):
             # Specify prescribed slip on a fault via two earthquakes in a 2D domain.
             [pylithapp.problem.interfaces.fault]
             label = fault
-            id = 10
+            edge = fault_edge
 
             observers.observer.data_fields = [slip]
 
@@ -78,10 +78,6 @@ class FaultCohesiveKin(FaultCohesive, ModuleFaultCohesiveKin):
     from pylith.utils.NullComponent import NullComponent
     auxiliaryFieldDB = pythia.pyre.inventory.facility("db_auxiliary_field", family="spatial_database", factory=NullComponent)
 
-    #from pylith.meshio.OutputFaultKin import OutputFaultKin
-    #outputManager = pythia.pyre.inventory.facility("output", family="output_manager", factory=OutputFaultKin)
-    #output.meta['tip'] = "Output manager associated with fault information."
-
     def __init__(self, name="faultcohesivekin"):
         """Initialize configuration.
         """
@@ -94,7 +90,7 @@ class FaultCohesiveKin(FaultCohesive, ModuleFaultCohesiveKin):
         from pylith.mpi.Communicator import mpi_comm_world
         comm = mpi_comm_world()
         if 0 == comm.rank:
-            self._info.log("Pre-initializing fault '%s'." % self.label)
+            self._info.log("Pre-initializing fault '%s'." % self.labelName)
 
         FaultCohesive.preinitialize(self, problem)
 
@@ -122,8 +118,6 @@ class FaultCohesiveKin(FaultCohesive, ModuleFaultCohesiveKin):
         for eqsrc in self.eqRuptures.components():
             eqsrc.finalize()
         FaultCohesive.finalize(self)
-        # self.output.close()
-        # self.output.finalize()
         return
 
     def _configure(self):

--- a/pylith/materials/Elasticity.py
+++ b/pylith/materials/Elasticity.py
@@ -28,8 +28,8 @@ class Elasticity(Material, ModuleElasticity):
     DOC_CONFIG = {
         "cfg": """
             [pylithapp.problem.materials.mat_elastic]
-            id = 4
-            label = Upper crust elastic material
+            label_value = 4
+            description = Upper crust elastic material
             use_body_force = False
             bulk_rheology = pylith.materials.IsotropicLinearElasticity
 

--- a/pylith/materials/IncompressibleElasticity.py
+++ b/pylith/materials/IncompressibleElasticity.py
@@ -28,8 +28,8 @@ class IncompressibleElasticity(Material, ModuleIncompressibleElasticity):
     DOC_CONFIG = {
         "cfg": """
             [pylithapp.problem.materials.mat_incompelastic]
-            id = 3
-            label = Upper crust incompressible elastic material
+            description = Upper crust incompressible elastic material
+            label_value = 3
             use_body_force = True
             bulk_rheology = pylith.materials.IsotropicLinearIncompElasticity
 

--- a/pylith/materials/Material.py
+++ b/pylith/materials/Material.py
@@ -17,11 +17,11 @@ from pylith.problems.Physics import Physics
 from .materials import Material as ModuleMaterial
 
 
-def validateLabel(value):
-    """Validate descriptive label.
+def validateDescription(value):
+    """Validate description.
     """
     if 0 == len(value):
-        raise ValueError("Descriptive label for material not specified.")
+        raise ValueError("Description for material not specified.")
     return value
 
 
@@ -32,11 +32,14 @@ class Material(Physics, ModuleMaterial):
 
     import pythia.pyre.inventory
 
-    materialId = pythia.pyre.inventory.int("id", default=0)
-    materialId.meta['tip'] = "Material identifier (from mesh generator)."
+    description = pythia.pyre.inventory.str("description", default="", validator=validateDescription)
+    description.meta['tip'] = "Descriptive label for material."
 
-    label = pythia.pyre.inventory.str("label", default="", validator=validateLabel)
-    label.meta['tip'] = "Descriptive label for material."
+    labelName = pythia.pyre.inventory.str("label", default="material-id", validator=pythia.pyre.inventory.choice(["material-id"]))
+    labelName.meta['tip'] = "Name of label for material. Currently only 'material-id' is allowed."
+
+    labelValue = pythia.pyre.inventory.int("label_value", default=1)
+    labelValue.meta["tip"] = "Value of label for material."
 
     def __init__(self, name="material"):
         """Constructor.
@@ -47,8 +50,9 @@ class Material(Physics, ModuleMaterial):
         """Setup material.
         """
         Physics.preinitialize(self, problem)
-        ModuleMaterial.setMaterialId(self, self.materialId)
-        ModuleMaterial.setDescriptiveLabel(self, self.label)
+        ModuleMaterial.setDescription(self, self.description)
+        ModuleMaterial.setLabelName(self, self.labelName)
+        ModuleMaterial.setLabelValue(self, self.labelValue)
 
 
 # End of file

--- a/pylith/materials/Poroelasticity.py
+++ b/pylith/materials/Poroelasticity.py
@@ -28,8 +28,8 @@ class Poroelasticity(Material, ModulePoroelasticity):
     DOC_CONFIG = {
         "cfg": """
             [pylithapp.problem.materials.mat_poroelastic]
-            id = 3
-            label = Upper crust poroelastic material
+            description = Upper crust poroelastic material
+            label_value = 3
             use_body_force = True
             use_source_density = False
             use_state_variables = True

--- a/pylith/meshio/OutputSolnBoundary.py
+++ b/pylith/meshio/OutputSolnBoundary.py
@@ -56,8 +56,11 @@ class OutputSolnBoundary(OutputSoln, ModuleOutputSolnBoundary):
 
     import pythia.pyre.inventory
 
-    label = pythia.pyre.inventory.str("label", default="", validator=validateLabel)
-    label.meta['tip'] = "Label identifier for external boundary."
+    labelName = pythia.pyre.inventory.str("label", default="", validator=validateLabel)
+    labelName.meta['tip'] = "Name of label identifier for external boundary."
+
+    labelValue = pythia.pyre.inventory.int("label_value", default=1)
+    labelValue.meta['tip'] = "Value of label identifier for external boundary (tag of physical group in Gmsh files)."
 
     def __init__(self, name="outputsolnsubset"):
         """Constructor.
@@ -68,7 +71,8 @@ class OutputSolnBoundary(OutputSoln, ModuleOutputSolnBoundary):
         """Do mimimal initialization.
         """
         OutputSoln.preinitialize(self, problem)
-        ModuleOutputSolnBoundary.setLabel(self, self.label)
+        ModuleOutputSolnBoundary.setLabelName(self, self.labelName)
+        ModuleOutputSolnBoundary.setLabelValue(self, self.labelValue)
 
         identifier = self.aliases[-1]
         self.writer.setFilename(problem.defaults.outputDir, problem.defaults.simName, identifier)

--- a/pylith/problems/InitialConditionPatch.py
+++ b/pylith/problems/InitialConditionPatch.py
@@ -33,13 +33,13 @@ class InitialConditionPatch(InitialCondition, ModuleInitialCondition):
             ic.mat2 = pylith.problems.InitialConditionPatch
 
             [pylithapp.problem.ic.mat1]
-            id = 1
+            label_value = 1
             db = spatialdata.spatialdb.SimpleGridDB
             db.description = Initial conditions over material 1
             db.filename = shearmat1_ic.spatialdb
 
             [pylithapp.problem.ic.mat2]
-            id = 2
+            label_value = 2
             db = spatialdata.spatialdb.SimpleGridDB
             db.description = Initial conditions over material 2
             db.filename = shearmat2_ic.spatialdb
@@ -49,8 +49,11 @@ class InitialConditionPatch(InitialCondition, ModuleInitialCondition):
     import pythia.pyre.inventory
     from spatialdata.spatialdb.SimpleDB import SimpleDB
 
-    matId = pythia.pyre.inventory.int("id", default=0)
-    matId.meta["tip"] = "Material id associated with patch."
+    labelName = pythia.pyre.inventory.str("label", default="material-id")
+    labelName.meta['tip'] = "Name of label for patch."
+
+    labelValue = pythia.pyre.inventory.int("label_value", default=1)
+    labelValue.meta["tip"] = "Value of label associated with initial condition patch, usually the material label value."
 
     db = pythia.pyre.inventory.facility("db", family="spatial_database", factory=SimpleDB)
     db.meta["tip"] = "Spatial database with values for initial condition."
@@ -64,7 +67,8 @@ class InitialConditionPatch(InitialCondition, ModuleInitialCondition):
         """Setup initial conditions.
         """
         InitialCondition.preinitialize(self, problem)
-        ModuleInitialCondition.setMaterialId(self, self.matId)
+        ModuleInitialCondition.setLabelName(self, self.labelName)
+        ModuleInitialCondition.setLabelValue(self, self.labelValue)
         ModuleInitialCondition.setDB(self, self.db)
 
     def _configure(self):

--- a/pylith/topology/MeshGenerator.py
+++ b/pylith/topology/MeshGenerator.py
@@ -68,7 +68,7 @@ class MeshGenerator(PetscComponent):
         if not interfaces is None:
             for interface in interfaces:
                 if 0 == comm.rank:
-                    self._info.log("Adjusting topology for fault '%s'." % interface.label)
+                    self._info.log("Adjusting topology for fault '%s'." % interface.labelName)
                 interface.preinitialize(problem)
                 interface.adjustTopology(mesh)
 

--- a/pylith/topology/MeshGenerator.py
+++ b/pylith/topology/MeshGenerator.py
@@ -47,7 +47,7 @@ class MeshGenerator(PetscComponent):
 
         # Need to nondimensionalize coordinates.
 
-        raise NotImplementedError("MeshGenerator.create() not implemented.")
+        raise NotImplementedError("MeshGenerator.create() not implemented.")    
 
     # PRIVATE METHODS ////////////////////////////////////////////////////
 
@@ -66,11 +66,17 @@ class MeshGenerator(PetscComponent):
         comm = mpi_comm_world()
 
         if not interfaces is None:
+            cohesiveLabelValue = 100
+            for material in problem.materials.components():
+                labelValue = material.labelValue
+                cohesiveLabelValue = max(cohesiveLabelValue, labelValue+1)
             for interface in interfaces:
                 if 0 == comm.rank:
                     self._info.log("Adjusting topology for fault '%s'." % interface.labelName)
                 interface.preinitialize(problem)
+                interface.setCohesiveLabelValue(cohesiveLabelValue)
                 interface.adjustTopology(mesh)
+                cohesiveLabelValue += 1
 
         self._eventLogger.eventEnd(logEvent)
 

--- a/tests/fullscale/cornercases/nofaults-2d/pylithapp.cfg
+++ b/tests/fullscale/cornercases/nofaults-2d/pylithapp.cfg
@@ -61,8 +61,8 @@ solution_observers = [domain]
 materials = [elastic]
 
 [pylithapp.problem.materials.elastic]
-label = Elastic material
-id = 1
+description = Elastic material
+label_value = 1
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0

--- a/tests/fullscale/cornercases/nofaults-3d/pylithapp.cfg
+++ b/tests/fullscale/cornercases/nofaults-3d/pylithapp.cfg
@@ -61,8 +61,8 @@ solution_observers = [domain]
 materials = [elastic]
 
 [pylithapp.problem.materials.elastic]
-label = Elastic material
-id = 1
+description = Elastic material
+label_value = 1
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0

--- a/tests/fullscale/incompressibleelasticity/nofaults-2d/pylithapp.cfg
+++ b/tests/fullscale/incompressibleelasticity/nofaults-2d/pylithapp.cfg
@@ -73,16 +73,16 @@ reader.coordsys.space_dim = 2
 materials = [elastic_xneg, elastic_xpos]
 
 [pylithapp.problem.materials.elastic_xneg]
-label = Elastic material on -x side of main fault
-id = 1
+description = Elastic material on -x side of main fault
+label_value = 1
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0
 bulk_rheology.auxiliary_subfields.shear_modulus.basis_order = 0
 
 [pylithapp.problem.materials.elastic_xpos]
-label = Elastic material on +x side of main fault
-id = 2
+description = Elastic material on +x side of main fault
+label_value = 2
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0

--- a/tests/fullscale/incompressibleelasticity/nofaults-3d/pylithapp.cfg
+++ b/tests/fullscale/incompressibleelasticity/nofaults-3d/pylithapp.cfg
@@ -77,16 +77,16 @@ reader.filename = output_points.txt
 materials = [upper_crust, lower_crust]
 
 [pylithapp.problem.materials.upper_crust]
-label = Elastic material for upper crust
-id = 1
+description = Elastic material for upper crust
+label_value = 1
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0
 bulk_rheology.auxiliary_subfields.shear_modulus.basis_order = 0
 
 [pylithapp.problem.materials.lower_crust]
-label = Elastic material for lower crust
-id = 2
+description = Elastic material for lower crust
+label_value = 2
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0

--- a/tests/fullscale/linearelasticity/faults-2d/pylithapp.cfg
+++ b/tests/fullscale/linearelasticity/faults-2d/pylithapp.cfg
@@ -81,8 +81,8 @@ label = edge_ypos
 materials = [mat_xneg, mat_xmid, mat_xposypos, mat_xposyneg]
 
 [pylithapp.problem.materials.mat_xneg]
-label = Elastic material on -x side of xneg fault
-id = 1
+description = Elastic material on -x side of xneg fault
+label_value = 1
 
 db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.description = Elastic properties
@@ -96,8 +96,8 @@ bulk_rheology.auxiliary_subfields.shear_modulus.basis_order = 0
 
 
 [pylithapp.problem.materials.mat_xmid]
-label = Elastic material between xneg and xmid faults
-id = 2
+description = Elastic material between xneg and xmid faults
+label_value = 2
 
 db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.description = Elastic properties
@@ -110,8 +110,8 @@ bulk_rheology.auxiliary_subfields.shear_modulus.basis_order = 0
 
 
 [pylithapp.problem.materials.mat_xposypos]
-label = Elastic material on +x and +y sides of xmid fault
-id = 3
+description = Elastic material on +x and +y sides of xmid fault
+label_value = 3
 
 db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.description = Elastic properties
@@ -124,8 +124,8 @@ bulk_rheology.auxiliary_subfields.shear_modulus.basis_order = 0
 
 
 [pylithapp.problem.materials.mat_xposyneg]
-label = Elastic material on +x and -y sides of xmid fault
-id = 4
+description = Elastic material on +x and -y sides of xmid fault
+label_value = 4
 
 db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.description = Elastic properties

--- a/tests/fullscale/linearelasticity/faults-2d/twoblocks.cfg
+++ b/tests/fullscale/linearelasticity/faults-2d/twoblocks.cfg
@@ -31,7 +31,6 @@ basis_order = 1
 interfaces = [fault]
 
 [pylithapp.problem.interfaces.fault]
-id = 10
 label = fault_xmid
 
 observers.observer.data_fields = [slip]

--- a/tests/fullscale/linearelasticity/nofaults-2d/pylithapp.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-2d/pylithapp.cfg
@@ -73,16 +73,16 @@ reader.coordsys.space_dim = 2
 materials = [elastic_xneg, elastic_xpos]
 
 [pylithapp.problem.materials.elastic_xneg]
-label = Elastic material on -x side of main fault
-id = 1
+description = Elastic material on -x side of main fault
+label_value = 1
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0
 bulk_rheology.auxiliary_subfields.shear_modulus.basis_order = 0
 
 [pylithapp.problem.materials.elastic_xpos]
-label = Elastic material on +x side of main fault
-id = 2
+description = Elastic material on +x side of main fault
+label_value = 2
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0

--- a/tests/fullscale/linearelasticity/nofaults-3d/pylithapp.cfg
+++ b/tests/fullscale/linearelasticity/nofaults-3d/pylithapp.cfg
@@ -77,16 +77,16 @@ reader.filename = output_points.txt
 materials = [upper_crust, lower_crust]
 
 [pylithapp.problem.materials.upper_crust]
-label = Elastic material for upper crust
-id = 1
+description = Elastic material for upper crust
+label_value = 1
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0
 bulk_rheology.auxiliary_subfields.shear_modulus.basis_order = 0
 
 [pylithapp.problem.materials.lower_crust]
-label = Elastic material for lower crust
-id = 2
+description = Elastic material for lower crust
+label_value = 2
 
 auxiliary_subfields.density.basis_order = 0
 bulk_rheology.auxiliary_subfields.bulk_modulus.basis_order = 0

--- a/tests/fullscale/poroelasticity/cryer/cryer.cfg
+++ b/tests/fullscale/poroelasticity/cryer/cryer.cfg
@@ -92,9 +92,8 @@ materials = [poroelastic]
 materials.poroelastic = pylith.materials.Poroelasticity
 
 [pylithapp.problem.materials.poroelastic]
-# id must match the values in the mesh material-ids.
-label = Poroelastic material
-id = 1
+description = Poroelastic material
+label_value = 1
 
 db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.description = Poroelastic properties

--- a/tests/fullscale/poroelasticity/mandel/mandel.cfg
+++ b/tests/fullscale/poroelasticity/mandel/mandel.cfg
@@ -93,9 +93,8 @@ materials = [poroelastic]
 materials.poroelastic = pylith.materials.Poroelasticity
 
 [pylithapp.problem.materials.poroelastic]
-# id must match the values in the mesh material-ids.
-label = Poroelastic material
-id = 1
+description = Poroelastic material
+label_value = 1
 
 # We will use uniform material properties, so we use the UniformDB spatial database.
 db_auxiliary_field = spatialdata.spatialdb.UniformDB

--- a/tests/fullscale/poroelasticity/mandel/mandel_compaction.cfg
+++ b/tests/fullscale/poroelasticity/mandel/mandel_compaction.cfg
@@ -99,9 +99,8 @@ poroelastic.bulk_rheology = pylith.materials.IsotropicLinearPoroelasticity
 poroelastic.use_state_variables = True
 
 [pylithapp.problem.materials.poroelastic]
-# id must match the values in the mesh material-ids.
-label = Poroelastic material
-id = 1
+description = Poroelastic material
+label_value = 1
 
 # We will use uniform material properties, so we use the UniformDB spatial database.
 db_auxiliary_field = spatialdata.spatialdb.UniformDB

--- a/tests/fullscale/poroelasticity/terzaghi/terzaghi.cfg
+++ b/tests/fullscale/poroelasticity/terzaghi/terzaghi.cfg
@@ -97,10 +97,8 @@ materials = [poroelastic]
 materials.poroelastic = pylith.materials.Poroelasticity
 
 [pylithapp.problem.materials.poroelastic]
-
-# id must match the values in the mesh material-ids.
-label = Poroelastic material
-id = 1
+description = Poroelastic material
+label_value = 1
 
 # We will use uniform material properties, so we use the UniformDB
 # spatial database.

--- a/tests/fullscale/poroelasticity/terzaghi/terzaghi_compaction.cfg
+++ b/tests/fullscale/poroelasticity/terzaghi/terzaghi_compaction.cfg
@@ -101,9 +101,8 @@ poroelastic.bulk_rheology = pylith.materials.IsotropicLinearPoroelasticity
 poroelastic.use_state_variables = True
 
 [pylithapp.problem.materials.poroelastic]
-# id must match the values in the mesh material-ids.
-label = Poroelastic material
-id = 1
+description = Poroelastic material
+label_value = 1
 
 # We will use uniform material properties, so we use the UniformDB
 # spatial database.

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialstrain_genmaxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialstrain_genmaxwell.cfg
@@ -34,8 +34,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicLinearGenMaxwell
 
 [pylithapp.problem.materials.viscomat]
-label = Generalized Maxwell material
-id = 1
+description = Generalized Maxwell material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Generalized Maxwell viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_genmaxwell.spatialdb

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialstrainrate_genmaxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialstrainrate_genmaxwell.cfg
@@ -34,8 +34,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicLinearGenMaxwell
 
 [pylithapp.problem.materials.viscomat]
-label = Generalized Maxwell material
-id = 1
+description = Generalized Maxwell material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Generalized Maxwell viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_genmaxwell.spatialdb

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialtraction_maxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialtraction_maxwell.cfg
@@ -37,8 +37,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicLinearMaxwell
 
 [pylithapp.problem.materials.viscomat]
-label = Maxwell material
-id = 1
+description = Maxwell material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Maxwell viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_maxwell.spatialdb

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialstrain_genmaxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialstrain_genmaxwell.cfg
@@ -34,8 +34,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicLinearGenMaxwell
 
 [pylithapp.problem.materials.viscomat]
-label = Generalized Maxwell material
-id = 1
+description = Generalized Maxwell material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Generalized Maxwell viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_genmaxwell.spatialdb

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialstrainrate_genmaxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialstrainrate_genmaxwell.cfg
@@ -34,8 +34,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicLinearGenMaxwell
 
 [pylithapp.problem.materials.viscomat]
-label = Generalized Maxwell material
-id = 1
+description = Generalized Maxwell material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Generalized Maxwell viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_genmaxwell.spatialdb

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialtraction_maxwell.cfg
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialtraction_maxwell.cfg
@@ -37,8 +37,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicLinearMaxwell
 
 [pylithapp.problem.materials.viscomat]
-label = Maxwell material
-id = 1
+description = Maxwell material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Maxwell viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_maxwell.spatialdb

--- a/tests/libtests/faults/TestAdjustTopology.cc
+++ b/tests/libtests/faults/TestAdjustTopology.cc
@@ -76,10 +76,13 @@ pylith::faults::TestAdjustTopology::testAdjustTopology(void) {
         CPPUNIT_ASSERT(_data->faultSurfaceLabels);
         CPPUNIT_ASSERT(_data->faultEdgeLabels);
 
-        fault.setInterfaceId(_data->interfaceIds[i]);
-        fault.setSurfaceMarkerLabel(_data->faultSurfaceLabels[i]);
+        fault.setCohesiveLabelName(pylith::topology::Mesh::cells_label_name);
+        fault.setCohesiveLabelValue(_data->interfaceIds[i]);
+        fault.setSurfaceLabelName(_data->faultSurfaceLabels[i]);
+        fault.setSurfaceLabelValue(1);
         if (_data->faultEdgeLabels[i]) {
-            fault.setBuriedEdgesMarkerLabel(_data->faultEdgeLabels[i]);
+            fault.setBuriedEdgesLabelName(_data->faultEdgeLabels[i]);
+            fault.setBuriedEdgesLabelValue(1);
         } // if
         if (!_data->failureExpected) {
             fault.adjustTopology(_mesh);
@@ -127,7 +130,7 @@ pylith::faults::TestAdjustTopology::testAdjustTopology(void) {
     // check materials
     CPPUNIT_ASSERT(_data->materialIds);
     PetscDMLabel labelMaterials = NULL;
-    const char* const cellsLabelName = pylith::topology::Mesh::getCellsLabelName();
+    const char* const cellsLabelName = pylith::topology::Mesh::cells_label_name;
     err = DMGetLabel(dmMesh, cellsLabelName, &labelMaterials);PYLITH_CHECK_ERROR(err);
     CPPUNIT_ASSERT(labelMaterials);
     const PetscInt idDefault = -999;
@@ -157,7 +160,7 @@ pylith::faults::TestAdjustTopology::testAdjustTopology(void) {
         const char *labelName = NULL;
         std::set<std::string> ignoreLabels;
         ignoreLabels.insert("depth");
-        ignoreLabels.insert("material-id");
+        ignoreLabels.insert(pylith::topology::Mesh::cells_label_name);
         ignoreLabels.insert("vtk");
         ignoreLabels.insert("ghost");
         ignoreLabels.insert("dim");

--- a/tests/libtests/faults/TestFaultCohesive.cc
+++ b/tests/libtests/faults/TestFaultCohesive.cc
@@ -20,6 +20,7 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
+#include "pylith/topology/Mesh.hh" // USES Mesh::cells_label_name
 #include "pylith/testing/FaultCohesiveStub.hh" // USES FaultCohesiveStub
 #include "pylith/utils/error.hh" // USES PYLITH_METHOD_*
 
@@ -41,37 +42,52 @@ class pylith::faults::TestFaultCohesive : public CppUnit::TestFixture {
     // PUBLIC METHODS /////////////////////////////////////////////////////
 public:
 
-    /// Test set/getInterfaceId(), set/getSurfaceMarkerLabel(), set/getBuriedEdgesMarkerLabel(), setRefDir1/2().
+    /// Test set/getCohesiveLabelValue(), set/getSurfaceLabelName(), set/getBuriedEdgesLabelName(), setRefDir1/2().
     void testAccessors(void);
 
 }; // class TestFaultCohesive
 
 // ------------------------------------------------------------------------------------------------
-// Test set/getInterfaceId(), set/getSurfaceMarkerLabel(), set/getBuriedEdgesMarkerLabel(), setRefDir1/2().
+// Test set/getCohesiveLabelValue(), set/getSurfaceLabelName(), set/getBuriedEdgesLabelName(), setRefDir1/2().
 void
 pylith::faults::TestFaultCohesive::testAccessors(void) {
     PYLITH_METHOD_BEGIN;
 
     FaultCohesiveStub fault;
 
-    const int interfaceId = 23;
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default interface id.", 100, fault.getInterfaceId());
-    fault.setInterfaceId(interfaceId);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in interface id.", interfaceId, fault.getInterfaceId());
+    const std::string& cohesiveLabelName = "cohesive-id";
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default cohesive label name.", std::string(pylith::topology::Mesh::cells_label_name), std::string(fault.getCohesiveLabelName()));
+    fault.setCohesiveLabelName(cohesiveLabelName.c_str());
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in cohesive label name.", cohesiveLabelName, std::string(fault.getCohesiveLabelName()));
+
+    const int cohesiveLabelValue = 23;
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default cohesive label value.", 100, fault.getCohesiveLabelValue());
+    fault.setCohesiveLabelValue(cohesiveLabelValue);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in cohesive label value.", cohesiveLabelValue, fault.getCohesiveLabelValue());
 
     const std::string& surfaceLabel = "surface label";
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default surface marker label.",
-                                 std::string(""), std::string(fault.getSurfaceMarkerLabel()));
-    fault.setSurfaceMarkerLabel(surfaceLabel.c_str());
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in surface marker label.",
-                                 surfaceLabel, std::string(fault.getSurfaceMarkerLabel()));
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default surface label name.",
+                                 std::string(""), std::string(fault.getSurfaceLabelName()));
+    fault.setSurfaceLabelName(surfaceLabel.c_str());
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in surface label name.",
+                                 surfaceLabel, std::string(fault.getSurfaceLabelName()));
+
+    const int surfaceValue = 4;
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default surface label value.", 1, fault.getSurfaceLabelValue());
+    fault.setSurfaceLabelValue(surfaceValue);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in surface label value.", surfaceValue, fault.getSurfaceLabelValue());
 
     const std::string& edgeLabel = "edge label";
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default edge marker label.",
-                                 std::string(""), std::string(fault.getBuriedEdgesMarkerLabel()));
-    fault.setBuriedEdgesMarkerLabel(edgeLabel.c_str());
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in edge marker label.",
-                                 edgeLabel, std::string(fault.getBuriedEdgesMarkerLabel()));
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default edge label name.",
+                                 std::string(""), std::string(fault.getBuriedEdgesLabelName()));
+    fault.setBuriedEdgesLabelName(edgeLabel.c_str());
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in edge label name.",
+                                 edgeLabel, std::string(fault.getBuriedEdgesLabelName()));
+
+    const int edgeValue = 4;
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default edge label value.", 1, fault.getBuriedEdgesLabelValue());
+    fault.setBuriedEdgesLabelValue(edgeValue);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in edge label value.", edgeValue, fault.getBuriedEdgesLabelValue());
 
     const int dim = 3;
     const PylithReal default1[3] = { 0.0, 0.0, 1.0 };

--- a/tests/libtests/feassemble/TestIntegratorDomain.cc
+++ b/tests/libtests/feassemble/TestIntegratorDomain.cc
@@ -88,7 +88,7 @@ pylith::feassemble::TestIntegratorDomain::testAccessors(void) {
 
     CPPUNIT_ASSERT(_data);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("Test of default label name failed.",
-                                 std::string("material-id"), std::string(_integrator->getLabelName()));
+                                 std::string(pylith::topology::Mesh::cells_label_name), std::string(_integrator->getLabelName()));
     const std::string& labelName = "material-label";
     _integrator->setLabelName(labelName.c_str());
     CPPUNIT_ASSERT_EQUAL_MESSAGE("Test of custom label name failed.",

--- a/tests/libtests/feassemble/TestInterfacePatches.cc
+++ b/tests/libtests/feassemble/TestInterfacePatches.cc
@@ -64,7 +64,7 @@ pylith::feassemble::TestInterfacePatches::testAccessors(void) {
 
     InterfacePatches patches;
 
-    const std::string& defaultName = pylith::topology::Mesh::getCellsLabelName();
+    const std::string& defaultName = pylith::topology::Mesh::cells_label_name;
     CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default label name.", defaultName, patches._labelName);
 
     const std::string& name = "fault patches";
@@ -94,7 +94,7 @@ pylith::feassemble::TestInterfacePatches::testCreateMaterialPairs(void) {
     CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in number of integration patches",
                                  numPatches, patches->_keys.size());
 
-    const std::string& cellsLabelName = pylith::topology::Mesh::getCellsLabelName();
+    const std::string& cellsLabelName = pylith::topology::Mesh::cells_label_name;
     CPPUNIT_ASSERT(_data->patchKeys);
     CPPUNIT_ASSERT(_data->patchNumCells);
     CPPUNIT_ASSERT(_data->patchCells);
@@ -167,10 +167,13 @@ pylith::feassemble::TestInterfacePatches::_initialize() {
 
     CPPUNIT_ASSERT(_data->faultLabel);
     _fault = new pylith::faults::FaultCohesiveStub();CPPUNIT_ASSERT(_fault);
-    _fault->setInterfaceId(101);
-    _fault->setSurfaceMarkerLabel(_data->faultLabel);
+    _fault->setCohesiveLabelName(pylith::topology::Mesh::cells_label_name);
+    _fault->setCohesiveLabelValue(101);
+    _fault->setSurfaceLabelName(_data->faultLabel);
+    _fault->setSurfaceLabelValue(1);
     if (_data->edgeLabel) {
-        _fault->setBuriedEdgesMarkerLabel(_data->edgeLabel);
+        _fault->setBuriedEdgesLabelName(_data->edgeLabel);
+        _fault->setBuriedEdgesLabelValue(1);
     } // if
     _fault->adjustTopology(_mesh);
 

--- a/tests/libtests/meshio/TestDataWriterMaterial.cc
+++ b/tests/libtests/meshio/TestDataWriterMaterial.cc
@@ -85,13 +85,13 @@ pylith::meshio::TestDataWriterMaterial::_initialize(void) {
 
     if (data->faultLabel) {
         pylith::faults::FaultCohesiveStub fault;
-        fault.setSurfaceMarkerLabel(data->faultLabel);
-        fault.setInterfaceId(data->faultId);
+        fault.setSurfaceLabelName(data->faultLabel);
+        fault.setCohesiveLabelValue(data->faultId);
         fault.adjustTopology(_domainMesh);
     } // if
 
     delete _materialMesh;
-    _materialMesh = pylith::topology::MeshOps::createSubdomainMesh(*_domainMesh, "material-id", data->materialId, ":UNKNOWN:");
+    _materialMesh = pylith::topology::MeshOps::createSubdomainMesh(*_domainMesh, pylith::topology::Mesh::cells_label_name, data->materialId, ":UNKNOWN:");
     CPPUNIT_ASSERT(_materialMesh);
 
     PYLITH_METHOD_END;

--- a/tests/libtests/meshio/TestDataWriterMesh.cc
+++ b/tests/libtests/meshio/TestDataWriterMesh.cc
@@ -83,8 +83,8 @@ pylith::meshio::TestDataWriterMesh::_initialize(void) {
 
     if (data->faultLabel) {
         pylith::faults::FaultCohesiveStub fault;
-        fault.setInterfaceId(data->faultId);
-        fault.setSurfaceMarkerLabel(data->faultLabel);
+        fault.setCohesiveLabelValue(data->faultId);
+        fault.setSurfaceLabelName(data->faultLabel);
         fault.adjustTopology(_mesh);
     } // if
 

--- a/tests/libtests/meshio/TestDataWriterSubmesh.cc
+++ b/tests/libtests/meshio/TestDataWriterSubmesh.cc
@@ -85,8 +85,8 @@ pylith::meshio::TestDataWriterSubmesh::_initialize(void) {
 
     if (data->faultLabel) {
         pylith::faults::FaultCohesiveStub fault;
-        fault.setSurfaceMarkerLabel(data->faultLabel);
-        fault.setInterfaceId(data->faultId);
+        fault.setSurfaceLabelName(data->faultLabel);
+        fault.setCohesiveLabelValue(data->faultId);
         fault.adjustTopology(_mesh);
     } // if
 

--- a/tests/libtests/meshio/TestDataWriterSubmesh.cc
+++ b/tests/libtests/meshio/TestDataWriterSubmesh.cc
@@ -91,7 +91,8 @@ pylith::meshio::TestDataWriterSubmesh::_initialize(void) {
     } // if
 
     CPPUNIT_ASSERT(data->bcLabel);
-    delete _submesh;_submesh = pylith::topology::MeshOps::createLowerDimMesh(*_mesh, data->bcLabel);CPPUNIT_ASSERT(_submesh);
+    const int labelValue = 1;
+    delete _submesh;_submesh = pylith::topology::MeshOps::createLowerDimMesh(*_mesh, data->bcLabel, labelValue);CPPUNIT_ASSERT(_submesh);
 
     PYLITH_METHOD_END;
 } // _initialize

--- a/tests/libtests/meshio/TestMeshIO.cc
+++ b/tests/libtests/meshio/TestMeshIO.cc
@@ -130,7 +130,7 @@ pylith::meshio::TestMeshIO::_createMesh(void) { // _createMesh
     PylithInt cStart, cEnd;
     err = DMPlexGetHeightStratum(dmMesh, 0, &cStart, &cEnd);PYLITH_CHECK_ERROR(err);
     for (PylithInt c = cStart; c < cEnd; ++c) {
-        err = DMSetLabelValue(dmMesh, "material-id", c, data->materialIds[c-cStart]);PYLITH_CHECK_ERROR(err);
+        err = DMSetLabelValue(dmMesh, pylith::topology::Mesh::cells_label_name, c, data->materialIds[c-cStart]);PYLITH_CHECK_ERROR(err);
     } // for
 
     // Groups
@@ -235,7 +235,7 @@ pylith::meshio::TestMeshIO::_checkVals(void) { // _checkVals
     // check materials
     PylithInt matId = 0;
     for (PylithInt c = cStart; c < cEnd; ++c) {
-        err = DMGetLabelValue(dmMesh, "material-id", c, &matId);PYLITH_CHECK_ERROR(err);
+        err = DMGetLabelValue(dmMesh, pylith::topology::Mesh::cells_label_name, c, &matId);PYLITH_CHECK_ERROR(err);
         CPPUNIT_ASSERT_EQUAL(data->materialIds[c-cStart], matId);
     } // for
 

--- a/tests/libtests/topology/TestMeshOps.cc
+++ b/tests/libtests/topology/TestMeshOps.cc
@@ -163,14 +163,14 @@ pylith::topology::TestMeshOps::testCheckMaterialIds(void) {
     iohandler.filename("data/tri3.mesh");
     iohandler.read(&mesh);
 
-    pylith::int_array materialIds(2);
-    materialIds[0] = 4;
-    materialIds[1] = 3;
+    pylith::int_array materialValues(2);
+    materialValues[0] = 4;
+    materialValues[1] = 3;
 
-    MeshOps::checkMaterialIds(mesh, materialIds);
+    MeshOps::checkMaterialLabels(mesh, materialValues);
 
-    materialIds[0] = 99;
-    CPPUNIT_ASSERT_THROW(MeshOps::checkMaterialIds(mesh, materialIds), std::runtime_error);
+    materialValues[0] = 99;
+    CPPUNIT_ASSERT_THROW(MeshOps::checkMaterialLabels(mesh, materialValues), std::runtime_error);
 
     PYLITH_METHOD_END;
 } // testCheckMaterialIds

--- a/tests/libtests/topology/TestRefineUniform.cc
+++ b/tests/libtests/topology/TestRefineUniform.cc
@@ -130,7 +130,7 @@ pylith::topology::TestRefineUniform::testRefine(void) {
     PetscInt matId = 0;
     PetscInt matIdSum = 0; // Use sum of material ids as simple checksum.
     for (PetscInt c = cStart; c < cEnd; ++c) {
-        err = DMGetLabelValue(dmMesh, "material-id", c, &matId);CPPUNIT_ASSERT(!err);
+        err = DMGetLabelValue(dmMesh, pylith::topology::Mesh::cells_label_name, c, &matId);CPPUNIT_ASSERT(!err);
         matIdSum += matId;
     } // for
     CPPUNIT_ASSERT_EQUAL(_data->matIdSum, matIdSum);
@@ -206,15 +206,15 @@ pylith::topology::TestRefineUniform::_initializeMesh(Mesh* const mesh) {
     // Adjust topology if necessary.
     if (_data->faultA) {
         faults::FaultCohesiveStub faultA;
-        faultA.setInterfaceId(100);
-        faultA.setSurfaceMarkerLabel(_data->faultA);
+        faultA.setCohesiveLabelValue(100);
+        faultA.setSurfaceLabelName(_data->faultA);
         faultA.adjustTopology(mesh);
     } // if
 
     if (_data->faultB) {
         faults::FaultCohesiveStub faultB;
-        faultB.setInterfaceId(101);
-        faultB.setSurfaceMarkerLabel(_data->faultB);
+        faultB.setCohesiveLabelValue(101);
+        faultB.setSurfaceLabelName(_data->faultB);
         faultB.adjustTopology(mesh);
     } // if
 

--- a/tests/libtests/topology/TestReverseCuthillMcKee.cc
+++ b/tests/libtests/topology/TestReverseCuthillMcKee.cc
@@ -212,8 +212,8 @@ pylith::topology::TestReverseCuthillMcKee::_initialize() {
     // Adjust topology if necessary.
     if (_data->faultLabel) {
         pylith::faults::FaultCohesiveStub fault;
-        fault.setInterfaceId(100);
-        fault.setSurfaceMarkerLabel(_data->faultLabel);
+        fault.setCohesiveLabelValue(100);
+        fault.setSurfaceLabelName(_data->faultLabel);
         fault.adjustTopology(_mesh);
     } // if
 

--- a/tests/libtests/topology/TestSubmesh.cc
+++ b/tests/libtests/topology/TestSubmesh.cc
@@ -62,7 +62,8 @@ pylith::topology::TestSubmesh::testCreateLowerDimMesh(void) {
     CPPUNIT_ASSERT(_data);
 
     _buildMesh();
-    delete _testMesh;_testMesh = MeshOps::createLowerDimMesh(*_domainMesh, _data->groupLabel);CPPUNIT_ASSERT(_testMesh);
+    const int labelValue = 1;
+    delete _testMesh;_testMesh = MeshOps::createLowerDimMesh(*_domainMesh, _data->groupLabel, labelValue);CPPUNIT_ASSERT(_testMesh);
 
     CPPUNIT_ASSERT_EQUAL(_data->cellDim-1, _testMesh->getDimension());
 
@@ -93,7 +94,8 @@ pylith::topology::TestSubmesh::testCreateLowerDimMesh(void) {
         CPPUNIT_ASSERT_EQUAL(_data->submeshCells[iC], c);
     } // for
 
-    CPPUNIT_ASSERT_THROW(MeshOps::createLowerDimMesh(*_domainMesh, "zzyyxx"), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(MeshOps::createLowerDimMesh(*_domainMesh, "zzyyxx", labelValue), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(MeshOps::createLowerDimMesh(*_domainMesh, _data->groupLabel, labelValue+99), std::runtime_error);
 
     PYLITH_METHOD_END;
 } // testCreateLowerDimMesh
@@ -155,7 +157,8 @@ pylith::topology::TestSubmesh::testAccessors(void) {
     CPPUNIT_ASSERT(_data);
 
     _buildMesh();
-    delete _testMesh;_testMesh = MeshOps::createLowerDimMesh(*_domainMesh, _data->groupLabel);CPPUNIT_ASSERT(_testMesh);
+    const int labelValue = 1;
+    delete _testMesh;_testMesh = MeshOps::createLowerDimMesh(*_domainMesh, _data->groupLabel, labelValue);CPPUNIT_ASSERT(_testMesh);
     CPPUNIT_ASSERT(_testMesh->getCoordSys());
 
     CPPUNIT_ASSERT_EQUAL(size_t(_data->cellDim), _testMesh->getCoordSys()->getSpaceDim());
@@ -179,7 +182,8 @@ pylith::topology::TestSubmesh::testSizes(void) {
     CPPUNIT_ASSERT_EQUAL(0, submesh.getDimension());
 
     _buildMesh();
-    delete _testMesh;_testMesh = MeshOps::createLowerDimMesh(*_domainMesh, _data->groupLabel);CPPUNIT_ASSERT(_testMesh);
+    const int labelValue = 1;
+    delete _testMesh;_testMesh = MeshOps::createLowerDimMesh(*_domainMesh, _data->groupLabel, labelValue);CPPUNIT_ASSERT(_testMesh);
     CPPUNIT_ASSERT(_testMesh);
 
     CPPUNIT_ASSERT_EQUAL(_data->cellDim-1, _testMesh->getDimension());

--- a/tests/manual/2d/powerlaw/axialtraction_powerlaw.cfg
+++ b/tests/manual/2d/powerlaw/axialtraction_powerlaw.cfg
@@ -46,8 +46,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicPowerLaw
 
 [pylithapp.problem.materials.viscomat]
-label = Power-law viscoelastic material
-id = 1
+description = Power-law viscoelastic material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Power-law viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_powerlaw.spatialdb

--- a/tests/manual/2d/powerlaw/axialtraction_powerlaw_n1.cfg
+++ b/tests/manual/2d/powerlaw/axialtraction_powerlaw_n1.cfg
@@ -46,8 +46,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicPowerLaw
 
 [pylithapp.problem.materials.viscomat]
-label = Power-law viscoelastic material
-id = 1
+description = Power-law viscoelastic material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Power-law viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_powerlaw_n1.spatialdb

--- a/tests/manual/2d/powerlaw/sheartraction_powerlaw.cfg
+++ b/tests/manual/2d/powerlaw/sheartraction_powerlaw.cfg
@@ -46,8 +46,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicPowerLaw
 
 [pylithapp.problem.materials.viscomat]
-label = Power-law viscoelastic material
-id = 1
+description = Power-law viscoelastic material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Power-law viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_powerlaw.spatialdb

--- a/tests/manual/3d/powerlaw/axialtraction_powerlaw.cfg
+++ b/tests/manual/3d/powerlaw/axialtraction_powerlaw.cfg
@@ -46,8 +46,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicPowerLaw
 
 [pylithapp.problem.materials.viscomat]
-label = Power-law viscoelastic material
-id = 1
+description = Power-law viscoelastic material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Power-law viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_powerlaw.spatialdb

--- a/tests/manual/3d/powerlaw/axialtraction_powerlaw_n1.cfg
+++ b/tests/manual/3d/powerlaw/axialtraction_powerlaw_n1.cfg
@@ -46,8 +46,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicPowerLaw
 
 [pylithapp.problem.materials.viscomat]
-label = Power-law viscoelastic material
-id = 1
+description = Power-law viscoelastic material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Power-law viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_powerlaw_n1.spatialdb

--- a/tests/manual/3d/powerlaw/sheartraction_powerlaw.cfg
+++ b/tests/manual/3d/powerlaw/sheartraction_powerlaw.cfg
@@ -46,8 +46,9 @@ materials = [viscomat]
 viscomat.bulk_rheology = pylith.materials.IsotropicPowerLaw
 
 [pylithapp.problem.materials.viscomat]
-label = Power-law viscoelastic material
-id = 1
+description = Power-law viscoelastic material
+label_value = 1
+
 db_auxiliary_field = spatialdata.spatialdb.SimpleDB
 db_auxiliary_field.description = Power-law viscoelastic properties
 db_auxiliary_field.iohandler.filename = mat_powerlaw.spatialdb

--- a/tests/mmstests/faults/TestFaultKin2D_RigidBlocksStatic.cc
+++ b/tests/mmstests/faults/TestFaultKin2D_RigidBlocksStatic.cc
@@ -293,17 +293,19 @@ protected:
         _bcs.resize(2);
         { // boundary_xpos
             pylith::bc::DirichletUserFn* bc = new pylith::bc::DirichletUserFn();
-            bc->setConstrainedDOF(constrainedDOF, numConstrained);
-            bc->setMarkerLabel("boundary_xpos");
             bc->setSubfieldName("displacement");
+            bc->setLabelName("boundary_xpos");
+            bc->setLabelValue(1);
+            bc->setConstrainedDOF(constrainedDOF, numConstrained);
             bc->setUserFn(solnkernel_disp);
             _bcs[0] = bc;
         } // boundary_xpos
         { // boundary_xneg
             pylith::bc::DirichletUserFn* bc = new pylith::bc::DirichletUserFn();
-            bc->setConstrainedDOF(constrainedDOF, numConstrained);
-            bc->setMarkerLabel("boundary_xneg");
             bc->setSubfieldName("displacement");
+            bc->setLabelName("boundary_xneg");
+            bc->setLabelValue(1);
+            bc->setConstrainedDOF(constrainedDOF, numConstrained);
             bc->setUserFn(solnkernel_disp);
             _bcs[1] = bc;
         } // boundary_zneg

--- a/tests/mmstests/faults/TestFaultKin2D_RigidBlocksStatic.cc
+++ b/tests/mmstests/faults/TestFaultKin2D_RigidBlocksStatic.cc
@@ -34,6 +34,7 @@
 #include "pylith/materials/IsotropicLinearElasticity.hh" // USES IsotropicLinearElasticity
 #include "pylith/bc/DirichletUserFn.hh" // USES DirichletUserFn
 
+#include "pylith/topology/Mesh.hh" // USES pylith::topology::Mesh::cells_label_name
 #include "pylith/topology/Field.hh" // USES pylith::topology::Field::Discretization
 #include "pylith/utils/journals.hh" // USES pythia::journal::debug_t
 
@@ -273,8 +274,8 @@ protected:
             pylith::materials::Elasticity* material = new pylith::materials::Elasticity();assert(material);
             material->setFormulation(pylith::problems::Physics::QUASISTATIC);
             material->useBodyForce(false);
-            material->setDescriptiveLabel("Isotropic Linear Elascitity Plane Strain");
-            material->setMaterialId(10);
+            material->setDescription("Isotropic Linear Elascitity Plane Strain");
+            material->setLabelValue(10);
             material->setBulkRheology(_data->rheology);
             _materials[0] = material;
         } // xneg
@@ -282,8 +283,8 @@ protected:
             pylith::materials::Elasticity* material = new pylith::materials::Elasticity();assert(material);
             material->setFormulation(pylith::problems::Physics::QUASISTATIC);
             material->useBodyForce(false);
-            material->setDescriptiveLabel("Isotropic Linear Elascitity Plane Strain");
-            material->setMaterialId(20);
+            material->setDescription("Isotropic Linear Elascitity Plane Strain");
+            material->setLabelValue(20);
             material->setBulkRheology(_data->rheology);
             _materials[1] = material;
         } // xpos
@@ -310,8 +311,8 @@ protected:
             _bcs[1] = bc;
         } // boundary_zneg
 
-        _fault->setInterfaceId(100);
-        _fault->setSurfaceMarkerLabel("fault");
+        _fault->setCohesiveLabelValue(100);
+        _fault->setSurfaceLabelName("fault");
 
     } // setUp
 
@@ -328,8 +329,8 @@ protected:
         PetscDS prob = NULL;
         err = DMGetDS(dm, &prob);CPPUNIT_ASSERT(!err);
         err = PetscDSSetExactSolution(prob, 0, solnkernel_disp, dm);CPPUNIT_ASSERT(!err);
-        err = DMGetLabel(dm, "material-id", &label);CPPUNIT_ASSERT(!err);
-        err = DMLabelGetStratumIS(label, _fault->getInterfaceId(), &is);CPPUNIT_ASSERT(!err);
+        err = DMGetLabel(dm, pylith::topology::Mesh::cells_label_name, &label);CPPUNIT_ASSERT(!err);
+        err = DMLabelGetStratumIS(label, _fault->getCohesiveLabelValue(), &is);CPPUNIT_ASSERT(!err);
         err = ISGetMinMax(is, &cohesiveCell, NULL);CPPUNIT_ASSERT(!err);
         err = ISDestroy(&is);CPPUNIT_ASSERT(!err);
         err = DMGetCellDS(dm, cohesiveCell, &prob);CPPUNIT_ASSERT(!err);

--- a/tests/mmstests/faults/TestFaultKin2D_ShearNoSlipStatic.cc
+++ b/tests/mmstests/faults/TestFaultKin2D_ShearNoSlipStatic.cc
@@ -34,6 +34,7 @@
 #include "pylith/bc/DirichletUserFn.hh" // USES DirichletUserFn
 #include "pylith/bc/NeumannUserFn.hh" // USES NeumannUserFn
 
+#include "pylith/topology/Mesh.hh" // USES pylith::topology::Mesh::cells_label_name
 #include "pylith/topology/Field.hh" // USES pylith::topology::Field::Discretization
 #include "pylith/utils/journals.hh" // USES pythia::journal::debug_t
 
@@ -295,8 +296,8 @@ protected:
             pylith::materials::Elasticity* material = new pylith::materials::Elasticity();assert(material);
             material->setFormulation(pylith::problems::Physics::QUASISTATIC);
             material->useBodyForce(false);
-            material->setDescriptiveLabel("Isotropic Linear Elasticity Plane Strain");
-            material->setMaterialId(10);
+            material->setDescription("Isotropic Linear Elasticity Plane Strain");
+            material->setLabelValue(10);
             material->setBulkRheology(_data->rheology);
             _materials[0] = material;
         } // xneg
@@ -304,8 +305,8 @@ protected:
             pylith::materials::Elasticity* material = new pylith::materials::Elasticity();assert(material);
             material->setFormulation(pylith::problems::Physics::QUASISTATIC);
             material->useBodyForce(false);
-            material->setDescriptiveLabel("Isotropic Linear Elasticity Plane Strain");
-            material->setMaterialId(20);
+            material->setDescription("Isotropic Linear Elasticity Plane Strain");
+            material->setLabelValue(20);
             material->setBulkRheology(_data->rheology);
             _materials[1] = material;
         } // xpos
@@ -349,8 +350,8 @@ protected:
             _bcs[3] = bc;
         } // boundary_ypos
 
-        _fault->setInterfaceId(100);
-        _fault->setSurfaceMarkerLabel("fault");
+        _fault->setCohesiveLabelValue(100);
+        _fault->setSurfaceLabelName("fault");
 
     } // setUp
 
@@ -367,8 +368,8 @@ protected:
         PetscDS prob = NULL;
         err = DMGetDS(dm, &prob);CPPUNIT_ASSERT(!err);
         err = PetscDSSetExactSolution(prob, 0, solnkernel_disp, dm);CPPUNIT_ASSERT(!err);
-        err = DMGetLabel(dm, "material-id", &label);CPPUNIT_ASSERT(!err);
-        err = DMLabelGetStratumIS(label, _fault->getInterfaceId(), &is);CPPUNIT_ASSERT(!err);
+        err = DMGetLabel(dm, pylith::topology::Mesh::cells_label_name, &label);CPPUNIT_ASSERT(!err);
+        err = DMLabelGetStratumIS(label, _fault->getCohesiveLabelValue(), &is);CPPUNIT_ASSERT(!err);
         err = ISGetMinMax(is, &cohesiveCell, NULL);CPPUNIT_ASSERT(!err);
         err = ISDestroy(&is);CPPUNIT_ASSERT(!err);
         err = DMGetCellDS(dm, cohesiveCell, &prob);CPPUNIT_ASSERT(!err);

--- a/tests/mmstests/faults/TestFaultKin2D_ShearNoSlipStatic.cc
+++ b/tests/mmstests/faults/TestFaultKin2D_ShearNoSlipStatic.cc
@@ -316,31 +316,35 @@ protected:
         _bcs.resize(4);
         { // boundary_xneg
             pylith::bc::DirichletUserFn* bc = new pylith::bc::DirichletUserFn();
-            bc->setConstrainedDOF(constrainedDOF, numConstrained);
-            bc->setMarkerLabel("boundary_xneg");
             bc->setSubfieldName("displacement");
+            bc->setLabelName("boundary_xneg");
+            bc->setLabelValue(1);
+            bc->setConstrainedDOF(constrainedDOF, numConstrained);
             bc->setUserFn(solnkernel_disp);
             _bcs[0] = bc;
         } // boundary_xneg
         { // boundary_xpos
             pylith::bc::DirichletUserFn* bc = new pylith::bc::DirichletUserFn();
-            bc->setConstrainedDOF(constrainedDOF, numConstrained);
-            bc->setMarkerLabel("boundary_xpos");
             bc->setSubfieldName("displacement");
+            bc->setLabelName("boundary_xpos");
+            bc->setLabelValue(1);
+            bc->setConstrainedDOF(constrainedDOF, numConstrained);
             bc->setUserFn(solnkernel_disp);
             _bcs[1] = bc;
         } // boundary_xpos
         { // boundary_yneg
             pylith::bc::NeumannUserFn* bc = new pylith::bc::NeumannUserFn();
-            bc->setMarkerLabel("boundary_yneg");
             bc->setSubfieldName("displacement");
+            bc->setLabelName("boundary_yneg");
+            bc->setLabelValue(1);
             bc->setUserFn(boundary_tractions);
             _bcs[2] = bc;
         } // boundary_yneg
         { // boundary_ypos
             pylith::bc::NeumannUserFn* bc = new pylith::bc::NeumannUserFn();
-            bc->setMarkerLabel("boundary_ypos");
             bc->setSubfieldName("displacement");
+            bc->setLabelName("boundary_ypos");
+            bc->setLabelValue(1);
             bc->setUserFn(boundary_tractions);
             _bcs[3] = bc;
         } // boundary_ypos

--- a/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_BodyForce.cc
+++ b/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_BodyForce.cc
@@ -221,8 +221,8 @@ protected:
         _material->useBodyForce(true);
         _rheology->useReferenceState(false);
 
-        _material->setDescriptiveLabel("Isotropic Linear Incompressible Elasticity Plane Strain");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Incompressible Elasticity Plane Strain");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDispDOF[2] = {0, 1};
         static const PylithInt numConstrainedDisp = 2;

--- a/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_BodyForce.cc
+++ b/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_BodyForce.cc
@@ -226,16 +226,18 @@ protected:
 
         static const PylithInt constrainedDispDOF[2] = {0, 1};
         static const PylithInt numConstrainedDisp = 2;
-        _bcDisplacement->setConstrainedDOF(constrainedDispDOF, numConstrainedDisp);
-        _bcDisplacement->setMarkerLabel("boundary");
         _bcDisplacement->setSubfieldName("displacement");
+        _bcDisplacement->setLabelName("boundary");
+        _bcDisplacement->setLabelValue(1);
+        _bcDisplacement->setConstrainedDOF(constrainedDispDOF, numConstrainedDisp);
         _bcDisplacement->setUserFn(solnkernel_disp);
 
         static const PylithInt constrainedPressureDOF[1] = {0};
         static const PylithInt numConstrainedPressure = 1;
-        _bcPressure->setConstrainedDOF(constrainedPressureDOF, numConstrainedPressure);
-        _bcPressure->setMarkerLabel("boundary");
         _bcPressure->setSubfieldName("pressure");
+        _bcPressure->setLabelName("boundary");
+        _bcPressure->setLabelValue(1);
+        _bcPressure->setConstrainedDOF(constrainedPressureDOF, numConstrainedPressure);
         _bcPressure->setUserFn(solnkernel_pressure);
 
     } // setUp

--- a/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_Gravity.cc
+++ b/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_Gravity.cc
@@ -221,8 +221,8 @@ protected:
         _material->useBodyForce(false);
         _rheology->useReferenceState(false);
 
-        _material->setDescriptiveLabel("Isotropic Linear Incompressible Elascitity Plane Strain");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Incompressible Elascitity Plane Strain");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDispDOF[2] = {0, 1};
         static const PylithInt numConstrainedDisp = 2;

--- a/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_Gravity.cc
+++ b/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_Gravity.cc
@@ -226,16 +226,18 @@ protected:
 
         static const PylithInt constrainedDispDOF[2] = {0, 1};
         static const PylithInt numConstrainedDisp = 2;
-        _bcDisplacement->setConstrainedDOF(constrainedDispDOF, numConstrainedDisp);
-        _bcDisplacement->setMarkerLabel("boundary");
         _bcDisplacement->setSubfieldName("displacement");
+        _bcDisplacement->setLabelName("boundary");
+        _bcDisplacement->setLabelValue(1);
+        _bcDisplacement->setConstrainedDOF(constrainedDispDOF, numConstrainedDisp);
         _bcDisplacement->setUserFn(solnkernel_disp);
 
         static const PylithInt constrainedPressureDOF[1] = {0};
         static const PylithInt numConstrainedPressure = 1;
-        _bcPressure->setConstrainedDOF(constrainedPressureDOF, numConstrainedPressure);
-        _bcPressure->setMarkerLabel("boundary");
         _bcPressure->setSubfieldName("pressure");
+        _bcPressure->setLabelName("boundary");
+        _bcPressure->setLabelValue(1);
+        _bcPressure->setConstrainedDOF(constrainedPressureDOF, numConstrainedPressure);
         _bcPressure->setUserFn(solnkernel_pressure);
 
     } // setUp

--- a/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_UniformPressure.cc
+++ b/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_UniformPressure.cc
@@ -188,8 +188,8 @@ protected:
         _material->useBodyForce(false);
         _rheology->useReferenceState(false);
 
-        _material->setDescriptiveLabel("Isotropic Linear Incompressible Elascitity Plane Strain");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Incompressible Elascitity Plane Strain");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDispDOF[2] = {0, 1};
         static const PylithInt numConstrainedDisp = 2;

--- a/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_UniformPressure.cc
+++ b/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_UniformPressure.cc
@@ -193,16 +193,18 @@ protected:
 
         static const PylithInt constrainedDispDOF[2] = {0, 1};
         static const PylithInt numConstrainedDisp = 2;
-        _bcDisplacement->setConstrainedDOF(constrainedDispDOF, numConstrainedDisp);
-        _bcDisplacement->setMarkerLabel("boundary");
         _bcDisplacement->setSubfieldName("displacement");
+        _bcDisplacement->setLabelName("boundary");
+        _bcDisplacement->setLabelValue(1);
+        _bcDisplacement->setConstrainedDOF(constrainedDispDOF, numConstrainedDisp);
         _bcDisplacement->setUserFn(solnkernel_disp);
 
         static const PylithInt constrainedPressureDOF[1] = {0};
         static const PylithInt numConstrainedPressure = 1;
-        _bcPressure->setConstrainedDOF(constrainedPressureDOF, numConstrainedPressure);
-        _bcPressure->setMarkerLabel("boundary");
         _bcPressure->setSubfieldName("pressure");
+        _bcPressure->setLabelName("boundary");
+        _bcPressure->setLabelValue(1);
+        _bcPressure->setConstrainedDOF(constrainedPressureDOF, numConstrainedPressure);
         _bcPressure->setUserFn(solnkernel_pressure);
 
     } // setUp

--- a/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_UniformShear.cc
+++ b/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_UniformShear.cc
@@ -199,8 +199,8 @@ protected:
         _material->useBodyForce(false);
         _rheology->useReferenceState(false);
 
-        _material->setDescriptiveLabel("Isotropic Linear Incompressible Elascitity Plane Strain");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Incompressible Elascitity Plane Strain");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDispDOF[2] = {0, 1};
         static const PylithInt numConstrainedDisp = 2;

--- a/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_UniformShear.cc
+++ b/tests/mmstests/incompressibleelasticity/TestIsotropicLinearIncompElasticity2D_UniformShear.cc
@@ -204,16 +204,18 @@ protected:
 
         static const PylithInt constrainedDispDOF[2] = {0, 1};
         static const PylithInt numConstrainedDisp = 2;
-        _bcDisplacement->setConstrainedDOF(constrainedDispDOF, numConstrainedDisp);
-        _bcDisplacement->setMarkerLabel("boundary");
         _bcDisplacement->setSubfieldName("displacement");
+        _bcDisplacement->setLabelName("boundary");
+        _bcDisplacement->setLabelValue(1);
+        _bcDisplacement->setConstrainedDOF(constrainedDispDOF, numConstrainedDisp);
         _bcDisplacement->setUserFn(solnkernel_disp);
 
         static const PylithInt constrainedPressureDOF[1] = {0};
         static const PylithInt numConstrainedPressure = 1;
-        _bcPressure->setConstrainedDOF(constrainedPressureDOF, numConstrainedPressure);
-        _bcPressure->setMarkerLabel("boundary");
         _bcPressure->setSubfieldName("pressure");
+        _bcPressure->setLabelName("boundary");
+        _bcPressure->setLabelValue(1);
+        _bcPressure->setConstrainedDOF(constrainedPressureDOF, numConstrainedPressure);
         _bcPressure->setUserFn(solnkernel_pressure);
 
     } // setUp

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_BodyForce.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_BodyForce.cc
@@ -202,8 +202,8 @@ protected:
         _material->useBodyForce(true);
         _rheology->useReferenceState(false);
 
-        _material->setDescriptiveLabel("Isotropic Linear Elasticity Plane Strain");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Elasticity Plane Strain");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDOF[2] = {0, 1};
         static const PylithInt numConstrained = 2;

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_BodyForce.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_BodyForce.cc
@@ -207,9 +207,10 @@ protected:
 
         static const PylithInt constrainedDOF[2] = {0, 1};
         static const PylithInt numConstrained = 2;
-        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
-        _bc->setMarkerLabel("boundary");
         _bc->setSubfieldName("displacement");
+        _bc->setLabelName("boundary");
+        _bc->setLabelValue(1);
+        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
         _bc->setUserFn(solnkernel_disp);
 
     } // setUp

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_Gravity.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_Gravity.cc
@@ -210,9 +210,10 @@ protected:
 
         static const PylithInt constrainedDOF[2] = {0, 1};
         static const PylithInt numConstrained = 2;
-        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
-        _bc->setMarkerLabel("boundary");
         _bc->setSubfieldName("displacement");
+        _bc->setLabelName("boundary");
+        _bc->setLabelValue(1);
+        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
         _bc->setUserFn(solnkernel_disp);
 
     } // setUp

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_Gravity.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_Gravity.cc
@@ -205,8 +205,8 @@ protected:
         _material->useBodyForce(false);
         _rheology->useReferenceState(false);
 
-        _material->setDescriptiveLabel("Isotropic Linear Elasticity Plane Strain");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Elasticity Plane Strain");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDOF[2] = {0, 1};
         static const PylithInt numConstrained = 2;

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_GravityRefState.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_GravityRefState.cc
@@ -230,8 +230,8 @@ protected:
         _material->useBodyForce(false);
         _rheology->useReferenceState(true);
 
-        _material->setDescriptiveLabel("Isotropic Linear Elascitity Plane Strain");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Elascitity Plane Strain");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDOF[2] = {0, 1};
         static const PylithInt numConstrained = 2;

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_GravityRefState.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_GravityRefState.cc
@@ -235,9 +235,10 @@ protected:
 
         static const PylithInt constrainedDOF[2] = {0, 1};
         static const PylithInt numConstrained = 2;
-        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
-        _bc->setMarkerLabel("boundary");
         _bc->setSubfieldName("displacement");
+        _bc->setLabelName("boundary");
+        _bc->setLabelValue(1);
+        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
         _bc->setUserFn(solnkernel_disp);
 
     } // setUp

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_UniformStrain.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_UniformStrain.cc
@@ -188,9 +188,10 @@ protected:
 
         static const PylithInt constrainedDOF[2] = {0, 1};
         static const PylithInt numConstrained = 2;
-        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
-        _bc->setMarkerLabel("boundary");
         _bc->setSubfieldName("displacement");
+        _bc->setLabelName("boundary");
+        _bc->setLabelValue(1);
+        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
         _bc->setUserFn(solnkernel_disp);
 
     } // setUp

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_UniformStrain.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity2D_UniformStrain.cc
@@ -183,8 +183,8 @@ protected:
         _material->useBodyForce(false);
         _rheology->useReferenceState(false);
 
-        _material->setDescriptiveLabel("Isotropic Linear Elasticity Plane Strain");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Elasticity Plane Strain");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDOF[2] = {0, 1};
         static const PylithInt numConstrained = 2;

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_BodyForce.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_BodyForce.cc
@@ -223,8 +223,8 @@ protected:
         _material->useBodyForce(true);
         _rheology->useReferenceState(false);
 
-        _material->setDescriptiveLabel("Isotropic Linear Elascitity Plane Strain");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Elascitity Plane Strain");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDOF[3] = { 0, 1, 2 };
         static const PylithInt numConstrained = 3;

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_BodyForce.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_BodyForce.cc
@@ -228,9 +228,10 @@ protected:
 
         static const PylithInt constrainedDOF[3] = { 0, 1, 2 };
         static const PylithInt numConstrained = 3;
-        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
-        _bc->setMarkerLabel("boundary");
         _bc->setSubfieldName("displacement");
+        _bc->setLabelName("boundary");
+        _bc->setLabelValue(1);
+        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
         _bc->setUserFn(solnkernel_disp);
 
     } // setUp

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_Gravity.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_Gravity.cc
@@ -203,8 +203,8 @@ protected:
         _material->useBodyForce(false);
         _rheology->useReferenceState(false);
 
-        _material->setDescriptiveLabel("Isotropic Linear Elascitity");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Elascitity");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDOF[3] = { 0, 1, 2 };
         static const PylithInt numConstrained = 3;

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_Gravity.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_Gravity.cc
@@ -208,9 +208,10 @@ protected:
 
         static const PylithInt constrainedDOF[3] = { 0, 1, 2 };
         static const PylithInt numConstrained = 3;
-        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
-        _bc->setMarkerLabel("boundary");
         _bc->setSubfieldName("displacement");
+        _bc->setLabelName("boundary");
+        _bc->setLabelValue(1);
+        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
         _bc->setUserFn(solnkernel_disp);
 
     } // setUp

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_GravityRefState.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_GravityRefState.cc
@@ -235,8 +235,8 @@ protected:
         _material->useBodyForce(false);
         _rheology->useReferenceState(true);
 
-        _material->setDescriptiveLabel("Isotropic Linear Elascitity");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Elascitity");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDOF[3] = { 0, 1, 2 };
         static const PylithInt numConstrained = 3;

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_GravityRefState.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_GravityRefState.cc
@@ -240,9 +240,10 @@ protected:
 
         static const PylithInt constrainedDOF[3] = { 0, 1, 2 };
         static const PylithInt numConstrained = 3;
-        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
-        _bc->setMarkerLabel("boundary");
         _bc->setSubfieldName("displacement");
+        _bc->setLabelName("boundary");
+        _bc->setLabelValue(1);
+        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
         _bc->setUserFn(solnkernel_disp);
 
     } // setUp

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_UniformStrain.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_UniformStrain.cc
@@ -206,8 +206,8 @@ protected:
         _material->useBodyForce(false);
         _rheology->useReferenceState(false);
 
-        _material->setDescriptiveLabel("Isotropic Linear Elascitity");
-        _material->setMaterialId(24);
+        _material->setDescription("Isotropic Linear Elascitity");
+        _material->setLabelValue(24);
 
         static const PylithInt constrainedDOF[3] = { 0, 1, 2 };
         static const PylithInt numConstrained = 3;

--- a/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_UniformStrain.cc
+++ b/tests/mmstests/linearelasticity/TestIsotropicLinearElasticity3D_UniformStrain.cc
@@ -211,9 +211,10 @@ protected:
 
         static const PylithInt constrainedDOF[3] = { 0, 1, 2 };
         static const PylithInt numConstrained = 3;
-        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
-        _bc->setMarkerLabel("boundary");
         _bc->setSubfieldName("displacement");
+        _bc->setLabelName("boundary");
+        _bc->setLabelValue(1);
+        _bc->setConstrainedDOF(constrainedDOF, numConstrained);
         _bc->setUserFn(solnkernel_disp);
 
     } // setUp


### PR DESCRIPTION
* Use `description` for descriptive labels.
* Use `label` for name of PETSc label for boundary conditions, materials, etc.
* Add use of `label_value` to allow label values other than 1.
* Automatically set the label value for cohesive cells associated with each fault.