### PR TITLE
Update default solver settings for elasticity and poroelasticity

### DIFF
--- a/docs/user/examples/reverse-2d/step05-onefault.md
+++ b/docs/user/examples/reverse-2d/step05-onefault.md
@@ -57,9 +57,9 @@ $ pylith step05_onefault.cfg
  -- timedependent(info)
  -- Solving problem.
 0 TS dt 0.01 time 0.
-    0 SNES Function norm 2.129295960330e-02 
-    Linear solve converged due to CONVERGED_ATOL iterations 330
-    1 SNES Function norm 6.693855246577e-13 
+    0 SNES Function norm 2.129295960330e-02
+    Linear solve converged due to CONVERGED_ATOL iterations 43
+    1 SNES Function norm 1.577267844919e-12
   Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 1
 1 TS dt 0.01 time 0.01
  >> /software/unix/py39-venv/pylith-debug/lib/python3.9/site-packages/pylith/problems/Problem.py:201:finalize
@@ -67,73 +67,8 @@ $ pylith step05_onefault.cfg
  -- Finalizing problem.
 ```
 
-From the end of the output written to the terminal window, we see that the linear solver converged in 330 iterations and met the absolute convergence tolerance (`ksp_atol`).
+From the end of the output written to the terminal window, we see that the linear solver converged in 43 iterations and met the absolute convergence tolerance (`ksp_atol`).
 As we expect for this linear problem, the nonlinear solver converged in 1 iteration.
-You can run this problem using the default PETSc options for a parallel simulation and see how the use of the algebraic multigrid preconditioner reduces the number of iterations.
-
-```{code-block} console
----
-caption: Run Step 5 simulation
----
-$ pylith step05_onefault.cfg --problem.petsc_defaults.parallel
-
-# The output should look something like the following.
- >> /software/baagaard/py38-venv/pylith-debug/lib/python3.8/site-packages/pylith/meshio/MeshIOObj.py:44:read
- -- meshiopetsc(info)
- -- Reading finite-element mesh
- >> /src/cig/pylith/libsrc/pylith/meshio/MeshIO.cc:94:void pylith::meshio::MeshIO::read(pylith::topology::Mesh*)
- -- meshiopetsc(info)
- -- Component 'reader': Domain bounding box:
-    (-100000, 100000)
-    (-100000, 0)
-
-# -- many lines omitted --
-
- >> /src/cig/pylith/libsrc/pylith/utils/PetscOptions.cc:235:static void pylith::utils::_PetscOptions::write(pythia::journal::info_t &, const char *, const pylith::utils::PetscOptions &)
- -- petscoptions(info)
- -- Setting PETSc options:
-fieldsplit_displacement_ksp_type = preonly
-fieldsplit_displacement_mg_levels_ksp_type = richardson
-fieldsplit_displacement_mg_levels_pc_type = sor
-fieldsplit_displacement_pc_type = gamg
-fieldsplit_lagrange_multiplier_fault_ksp_type = preonly
-fieldsplit_lagrange_multiplier_fault_mg_levels_ksp_type = richardson
-fieldsplit_lagrange_multiplier_fault_mg_levels_pc_type = sor
-fieldsplit_lagrange_multiplier_fault_pc_type = gamg
-ksp_atol = 1.0e-12
-ksp_converged_reason = true
-ksp_error_if_not_converged = true
-ksp_rtol = 1.0e-12
-pc_fieldsplit_schur_factorization_type = lower
-pc_fieldsplit_schur_precondition = selfp
-pc_fieldsplit_schur_scale = 1.0
-pc_fieldsplit_type = schur
-pc_type = fieldsplit
-pc_use_amat = true
-snes_atol = 1.0e-9
-snes_converged_reason = true
-snes_error_if_not_converged = true
-snes_monitor = true
-snes_rtol = 1.0e-12
-ts_error_if_step_fails = true
-ts_monitor = true
-ts_type = beuler
-
- >> /software/unix/py39-venv/pylith-debug/lib/python3.9/site-packages/pylith/problems/TimeDependent.py:139:run
- -- timedependent(info)
- -- Solving problem.
-0 TS dt 0.01 time 0.
-    0 SNES Function norm 2.129295960330e-02 
-    Linear solve converged due to CONVERGED_ATOL iterations 47
-    1 SNES Function norm 1.185726544112e-12 
-  Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 1
-1 TS dt 0.01 time 0.01
- >> /software/unix/py39-venv/pylith-debug/lib/python3.9/site-packages/pylith/problems/Problem.py:201:finalize
- -- timedependent(info)
- -- Finalizing problem.
-```
-
-Notice the use of the `GAMG` preconditioner for the displacement and Lagrange multiplier solution subfields.
 
 ## Visualizing the results
 

--- a/docs/user/examples/reverse-2d/step06-twofaults-elastic.md
+++ b/docs/user/examples/reverse-2d/step06-twofaults-elastic.md
@@ -24,6 +24,7 @@ The parameters specific to this example are in `step06_twofaults-elastic.cfg` an
 * `pylithapp` Parameters defining where to write the output.
 * `pylithapp.problem` Parameters for the solution field with displacement and Lagrange multiplier subfields.
 * `pylithapp.problem.fault` Parameters for prescribed slip on the two faults.
+* `pylithapp.petsc` Adjustment to the default PETSc solver options.
 
 :::{important}
 In 2D simulations slip is specified in terms of opening and left-lateral components.
@@ -38,7 +39,6 @@ When PyLith inserts cohesive cells into a mesh with buried edges (in this case a
 
 For properly topology of the cohesive cells, the main fault _must_ be listed first in the array of faults so that it will be created before the splay fault.
 :::
-
 
 ```{code-block} console
 ---

--- a/docs/user/examples/strikeslip-2d/step01-slip.md
+++ b/docs/user/examples/strikeslip-2d/step01-slip.md
@@ -81,13 +81,9 @@ $ pylith step01_slip.cfg
  -- petscoptions(info)
  -- Setting PETSc options:
 fieldsplit_displacement_ksp_type = preonly
-fieldsplit_displacement_mg_levels_ksp_type = richardson
-fieldsplit_displacement_mg_levels_pc_type = sor
-fieldsplit_displacement_pc_type = gamg
+fieldsplit_displacement_pc_type = lu
 fieldsplit_lagrange_multiplier_fault_ksp_type = preonly
-fieldsplit_lagrange_multiplier_fault_mg_levels_ksp_type = richardson
-fieldsplit_lagrange_multiplier_fault_mg_levels_pc_type = sor
-fieldsplit_lagrange_multiplier_fault_pc_type = gamg
+fieldsplit_lagrange_multiplier_fault_pc_type = lu
 ksp_atol = 1.0e-12
 ksp_converged_reason = true
 ksp_error_if_not_converged = true
@@ -111,9 +107,9 @@ ts_type = beuler
  -- timedependent(info)
  -- Solving problem.
 0 TS dt 0.01 time 0.
-    0 SNES Function norm 4.895713226482e-02 
-    Linear solve converged due to CONVERGED_ATOL iterations 38
-    1 SNES Function norm 2.111685046607e-12 
+    0 SNES Function norm 4.895713226482e-02
+    Linear solve converged due to CONVERGED_ATOL iterations 35
+    1 SNES Function norm 2.540698951426e-12
   Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 1
 1 TS dt 0.01 time 0.01
  >> /software/unix/py39-venv/pylith-debug/lib/python3.9/site-packages/pylith/problems/Problem.py:201:finalize
@@ -126,7 +122,7 @@ The scales for nondimensionalization remain the default values for a quasistatic
 PyLith detects the presence of a fault based on the Lagrange multiplier for the fault in the solution field and selects appropriate preconditioning options as discussed in {ref}`sec-user-run-pylith-petsc-options`.
 
 At the end of the output written to the termial, we see that the solver advanced the solution one time step (static simulation).
-The linear solve converged after 36 iterations and the norm of the residual met the absolute convergence tolerance (`ksp_atol`) .
+The linear solve converged after 35 iterations and the norm of the residual met the absolute convergence tolerance (`ksp_atol`) .
 The nonlinear solve converged in 1 iteration, which we expect because this is a linear problem, and the residual met the absolute convergence tolerance (`snes_atol`).
 
 ## Visualizing the results
@@ -218,9 +214,9 @@ $ pylith step01_slip_cubit.cfg
  -- timedependent(info)
  -- Solving problem.
 0 TS dt 0.01 time 0.
-    0 SNES Function norm 4.834519229177e-02 
-    Linear solve converged due to CONVERGED_ATOL iterations 39
-    1 SNES Function norm 1.470567368938e-12 
+    0 SNES Function norm 4.834519229177e-02
+    Linear solve converged due to CONVERGED_ATOL iterations 35
+    1 SNES Function norm 2.664525811959e-12
   Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 1
 1 TS dt 0.01 time 0.01
  >> /software/unix/py39-venv/pylith-debug/lib/python3.9/site-packages/pylith/problems/Problem.py:201:finalize

--- a/docs/user/examples/strikeslip-2d/step02-slip-velbc.md
+++ b/docs/user/examples/strikeslip-2d/step02-slip-velbc.md
@@ -47,9 +47,9 @@ $ pylith step02_slip_velbc.cfg
 # -- many lines omitted --
 
 24 TS dt 0.05 time 1.15
-    0 SNES Function norm 5.390420823600e-04 
-    Linear solve converged due to CONVERGED_ATOL iterations 32
-    1 SNES Function norm 1.481819020131e-12 
+    0 SNES Function norm 5.390420823432e-04
+    Linear solve converged due to CONVERGED_ATOL iterations 29
+    1 SNES Function norm 1.250412952119e-12
   Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 1
 25 TS dt 0.05 time 1.2
  >> /software/unix/py39-venv/pylith-debug/lib/python3.9/site-packages/pylith/problems/Problem.py:201:finalize

--- a/docs/user/examples/strikeslip-2d/step03-multislip-velbc.md
+++ b/docs/user/examples/strikeslip-2d/step03-multislip-velbc.md
@@ -48,9 +48,9 @@ $ pylith step03_multislip_velbc.cfg
 # -- many lines omitted --
 
 25 TS dt 0.1 time 2.4
-    0 SNES Function norm 1.078084164693e-03 
-    Linear solve converged due to CONVERGED_ATOL iterations 34
-    1 SNES Function norm 1.061858933468e-12 
+    0 SNES Function norm 1.078084164687e-03
+    Linear solve converged due to CONVERGED_ATOL iterations 29
+    1 SNES Function norm 2.500834427760e-12
   Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 1
 26 TS dt 0.1 time 2.5
  >> /software/unix/py39-venv/pylith-debug/lib/python3.9/site-packages/pylith/problems/Problem.py:201:finalize

--- a/docs/user/examples/strikeslip-2d/step04-varslip.md
+++ b/docs/user/examples/strikeslip-2d/step04-varslip.md
@@ -65,9 +65,9 @@ $ pylith step04_varslip.cfg
  -- timedependent(info)
  -- Solving problem.
 0 TS dt 0.01 time 0.
-    0 SNES Function norm 3.840123479624e-03 
-    Linear solve converged due to CONVERGED_ATOL iterations 113
-    1 SNES Function norm 1.312610978380e-12 
+    0 SNES Function norm 3.840123479624e-03
+    Linear solve converged due to CONVERGED_ATOL iterations 73
+    1 SNES Function norm 2.286140232631e-12
   Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 1
 1 TS dt 0.01 time 0.01
  >> /software/unix/py39-venv/pylith-debug/lib/python3.9/site-packages/pylith/problems/Problem.py:201:finalize
@@ -77,7 +77,7 @@ $ pylith step04_varslip.cfg
 
 The beginning of the output written to the terminal matches that in our previous simulations.
 At the end of the output written to the termial, we see that the solver advanced the solution one time step (static simulation).
-The linear solve converged after 69 iterations and the norm of the residual met the absolute convergence tolerance (`ksp_atol`).
+The linear solve converged after 73 iterations and the norm of the residual met the absolute convergence tolerance (`ksp_atol`).
 The nonlinear solve converged in 1 iteration, which we expect because this is a linear problem, and the residual met the absolute convergence tolerance (`snes_atol`).
 
 ## Visualizing the results

--- a/docs/user/examples/strikeslip-2d/step05-greensfns.md
+++ b/docs/user/examples/strikeslip-2d/step05-greensfns.md
@@ -61,9 +61,9 @@ $  pylith step05_greensfns.cfg
 # -- many lines omitted --
 
  -- Component 'problem': Computing Green's function 12 of 12.
-  0 SNES Function norm 3.027654014360e-03 
-  Linear solve converged due to CONVERGED_ATOL iterations 40
-  1 SNES Function norm 2.344239113383e-12 
+  0 SNES Function norm 3.027654014252e-03
+  Linear solve converged due to CONVERGED_ATOL iterations 46
+  1 SNES Function norm 2.204080482014e-12
 Nonlinear solve converged due to CONVERGED_ITS iterations 1
  >> /software/unix/py39-venv/pylith-debug/lib/python3.9/site-packages/pylith/problems/Problem.py:201:finalize
  -- greensfns(info)

--- a/docs/user/run-pylith/petsc-options.md
+++ b/docs/user/run-pylith/petsc-options.md
@@ -109,7 +109,7 @@ pc_fieldsplit_schur_precondition = selfp
 pc_fieldsplit_schur_scale = 1.0
 
 fieldsplit_displacement_ksp_type = preonly
-fieldsplit_displacement_pc_type = ilu
+fieldsplit_displacement_pc_type = lu
 
 fieldsplit_lagrange_multiplier_fault_ksp_type = preonly
 fieldsplit_lagrange_multiplier_fault_pc_type = lu

--- a/examples/reverse-2d/step06_twofaults_elastic.cfg
+++ b/examples/reverse-2d/step06_twofaults_elastic.cfg
@@ -103,4 +103,12 @@ db_auxiliary_field.values = [initiation_time, final_slip_left_lateral, final_sli
 db_auxiliary_field.data = [0.0*s, -1.0*m, 0.0*m]
 
 
+# ----------------------------------------------------------------------
+# petsc
+# ----------------------------------------------------------------------
+# Because the wedge is not constrained by any Dirichlet boundary conditions,
+# we change the preconditioner for the displacement field to `ilu` to avoid a zero pivot.
+[pylithapp.petsc]
+fieldsplit_displacement_pc_type = ilu
+
 # End of file

--- a/examples/reverse-2d/step07_twofaults_maxwell.cfg
+++ b/examples/reverse-2d/step07_twofaults_maxwell.cfg
@@ -125,4 +125,13 @@ db_auxiliary_field.values = [initiation_time, final_slip_left_lateral, final_sli
 db_auxiliary_field.data = [0.0*s, -1.0*m, 0.0*m]
 
 
+# ----------------------------------------------------------------------
+# petsc
+# ----------------------------------------------------------------------
+# Because the wedge is not constrained by any Dirichlet boundary conditions,
+# we change the preconditioner for the displacement field to `ilu` to avoid a zero pivot.
+[pylithapp.petsc]
+fieldsplit_displacement_pc_type = ilu
+
+
 # End of file

--- a/examples/reverse-2d/step08_twofaults_powerlaw.cfg
+++ b/examples/reverse-2d/step08_twofaults_powerlaw.cfg
@@ -125,10 +125,14 @@ db_auxiliary_field.description = Fault rupture for splay fault
 db_auxiliary_field.values = [initiation_time, final_slip_left_lateral, final_slip_opening]
 db_auxiliary_field.data = [0.0*s, -1.0*m, 0.0*m]
 
+
 # ----------------------------------------------------------------------
 # PETSc
 # ----------------------------------------------------------------------
+# Because the wedge is not constrained by any Dirichlet boundary conditions,
+# we change the preconditioner for the displacement field to `ilu` to avoid a zero pivot.
 [pylithapp.petsc]
-snes_max_it = 10
+fieldsplit_displacement_pc_type = ilu
+
 
 # End of file

--- a/examples/strikeslip-2d/pylithapp.cfg
+++ b/examples/strikeslip-2d/pylithapp.cfg
@@ -193,11 +193,5 @@ constrained_dof = [0, 1]
 db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.description = Dirichlet BC -x boundary
 
-# ----------------------------------------------------------------------
-# PETSc
-# ----------------------------------------------------------------------
-[pylithapp.problem.petsc_defaults]
-parallel = true
-
 
 # End of file

--- a/libsrc/pylith/materials/Elasticity.cc
+++ b/libsrc/pylith/materials/Elasticity.cc
@@ -272,7 +272,7 @@ pylith::materials::Elasticity::getSolverDefaults(const bool isParallel,
             options->add("-fieldsplit_lagrange_multiplier_fault_ksp_type", "preonly");
 
             if (!isParallel) {
-                options->add("-fieldsplit_displacement_pc_type", "ilu");
+                options->add("-fieldsplit_displacement_pc_type", "lu");
                 options->add("-fieldsplit_lagrange_multiplier_fault_pc_type", "lu");
             } else {
                 options->add("-fieldsplit_displacement_pc_type", "gamg");

--- a/libsrc/pylith/materials/Poroelasticity.cc
+++ b/libsrc/pylith/materials/Poroelasticity.cc
@@ -303,7 +303,7 @@ pylith::materials::Poroelasticity::getSolverDefaults(const bool isParallel,
 
         if (!hasFault) {
             if (!isParallel) {
-                options->add("-pc_type", "ilu");
+                options->add("-pc_type", "lu");
             } else {
                 options->add("-pc_type", "gamg");
                 options->add("-mg_levels_pc_type", "sor");

--- a/tests/fullscale/linearelasticity/faults-2d/threeblocks.cfg
+++ b/tests/fullscale/linearelasticity/faults-2d/threeblocks.cfg
@@ -79,4 +79,11 @@ db_auxiliary_field = pylith.bc.ZeroDB
 db_auxiliary_field.description = Dirichlet BC +x edge
 
 
+# ----------------------------------------------------------------------
+# petsc
+# ----------------------------------------------------------------------
+[pylithapp.petsc]
+fieldsplit_displacement_pc_type = ilu
+
+
 # End of file

--- a/tests/mmstests/faults/TestFaultKin2D_OneFaultShearNoSlip.cc
+++ b/tests/mmstests/faults/TestFaultKin2D_OneFaultShearNoSlip.cc
@@ -373,6 +373,9 @@ protected:
             _faults[0] = fault;
         } // xpos
 
+        pylith::utils::PetscOptions options;
+        options.add("-fieldsplit_displacement_pc_type", "lu");
+        options.override ();
     } // setUp
 
     // Set exact solution in domain.

--- a/tests/mmstests/faults/TestFaultKin2D_ThreeBlocksStatic.cc
+++ b/tests/mmstests/faults/TestFaultKin2D_ThreeBlocksStatic.cc
@@ -361,6 +361,9 @@ protected:
             _faults[1] = fault;
         } // xpos
 
+        pylith::utils::PetscOptions options;
+        options.add("-fieldsplit_displacement_pc_type", "ilu");
+        options.override ();
     } // setUp
 
     // Set exact solution in domain.

--- a/tests/mmstests/faults/TestFaultKin2D_TwoBlocksStatic.cc
+++ b/tests/mmstests/faults/TestFaultKin2D_TwoBlocksStatic.cc
@@ -334,6 +334,9 @@ protected:
             _faults[0] = fault;
         } // xpos
 
+        pylith::utils::PetscOptions options;
+        options.add("-fieldsplit_displacement_pc_type", "lu");
+        options.override ();
     } // setUp
 
     // Set exact solution in domain.

--- a/tests/mmstests/faults/TestFaultKin2D_TwoFaultsShearNoSlip.cc
+++ b/tests/mmstests/faults/TestFaultKin2D_TwoFaultsShearNoSlip.cc
@@ -384,6 +384,9 @@ protected:
             _faults[1] = fault;
         } // xpos
 
+        pylith::utils::PetscOptions options;
+        options.add("-fieldsplit_displacement_pc_type", "ilu");
+        options.override ();
     } // setUp
 
     // Set exact solution in domain.


### PR DESCRIPTION
* Use LU instead of ILU for better performance.
* Update tests and examples with null space to use ILU by setting PETSc option directly.