### PR TITLE
Fix LaTeX build of documenation. Small enhancements

### DIFF
--- a/docs/developer/contributing/documentation/quickref.md
+++ b/docs/developer/contributing/documentation/quickref.md
@@ -162,7 +162,7 @@ Figure labels cannot contain more than one dash, so we use colons instead.
 This is likely a bug.
 
 :::{figure-md} fig:quickref:example
-<img src="_static/images/cig_short_nolabel.*" alt="Screenshot"  width="100px"/>
+<img src="../../../_static/images/cig_short_nolabel.*" alt="Screenshot"  width="100px"/>
 
 This is the figure caption. Vector graphics should be provided in **both** PDF (latex output) and SVG (html output) formats.
 Raster graphics should be provided in either PNG or JPG formats (whichever is more compact).

--- a/docs/user/appendices/analytical-solns.md
+++ b/docs/user/appendices/analytical-solns.md
@@ -11,10 +11,10 @@ We start with the equilibrium equation for static elasticity in Cartesian coordi
 %
 ```{math}
 :label: eqn:stress:fn:equilibrium
-\begin{gather}
+\begin{gathered}
 \frac{\partial\sigma_{xx}}{\partial x} + \frac{\partial\sigma_{xy}}{\partial y} + f_x = 0 \\
 \frac{\partial\sigma_{yy}}{\partial y} + \frac{\partial\sigma_{xy}}{\partial x} + f_y = 0,
-\end{gather}
+\end{gathered}
 ```
 %
 where $f_x$ and $f_y$ are the body force components in the $x$ and $y$ directions, respectively.
@@ -28,11 +28,11 @@ We choose an Airy stress function $\phi(x,y)$ to trivially satisfy the equilibri
 %
 ```{math}
 :label: eqn:stress:function:components
-\begin{align}
+\begin{aligned}
 \sigma_{xx} &= \frac{\partial^{2}\phi}{\partial y^{2}} + \psi,\\
 \sigma_{yy} &= \frac{\partial^{2}\phi}{\partial x^{2}} + \psi,\\
 \sigma_{xy} &= -\frac{\partial^{2}\phi}{\partial x\partial y}.
-\end{align}
+\end{aligned}
 ```
 
 We must also satisfy the compatibility equations.

--- a/docs/user/examples/paraview-python.md
+++ b/docs/user/examples/paraview-python.md
@@ -39,10 +39,24 @@ This makes it very easy to create the Python script. Note that we have omitted s
 ## Overriding Default Parameters
 
 We setup the ParaView Python scripts, so that when they are run from the command line in the main directory for a given example, e.g., `examples/3d/subduction`, the script will produce the output discussed in the manual.
-If you start ParaView from the macOS Dock or a similar method, like a shortcut, then you will need to override at least the default values for the output directory.
+
+:::{warning}
+If you start ParaView from the macOS Dock or a similar method, like a shortcut, then you will need to override at least the default value for the output directory.
+:::
 
 In order to override the default values from within the ParaView GUI, simply set the values within the Python shell.
-For example, to set the value of the variable `EXODUS_FILE` to the absolute path of the input file,
+For example, to set the value of the variable `OUTPUT_DIR` to the absolute path of the output files from a simulation,
+
+```{code-block} python
+---
+caption: ParaView Python shell
+---
+# Set OUTPUT_DIR to $HOME/pylith/examples/box-2d/output
+>>> import os
+>>> OUTPUT_DIR = os.path.join(os.environ["HOME", "pylith", "examples", "box-2d", "output"])
+```
+
+To set the value of the variable `EXODUS_FILE` to the absolute path of the input file,
 
 ```{code-block} python
 ---
@@ -52,8 +66,8 @@ caption: ParaView Python shell
 >>> EXODUS_FILE = os.path.join(os.environ["HOME", "pylith", "examples", "subduction-3d", "mesh", "mesh_tet.exo"])
 ```
 
-In this case we use the Python `os` module to get the absolute path of the home directory and append the path to the Exodus file with the appropriate separators for the operating system.
+In these two examples we use the Python `os` module to get the absolute path of the home directory and append the path to the Exodus file with the appropriate separators for the operating system.
 
 :::{important}
-In each of the ParaView Python scripts, the names of the variables and their default values are given by the DEFAULTS dictionary near the top of the file.
+In each of the ParaView Python scripts, the names of the variables and their default values are given by the `DEFAULTS` dictionary near the top of the file.
 :::

--- a/docs/user/glossary/index.md
+++ b/docs/user/glossary/index.md
@@ -40,8 +40,8 @@ dimension
 It can also mean the dimension of the space in which the mesh is embedded, but this is properly called the embedding dimension.
 
 dual space
-: For any vector space $V$ over a field $F$, the dual space $V^*$ is the set of all linear functions $\phi : V \rightarrow F$.
-If $V$ is finite dimensional, then $V^∗$ has the same dimension as $V$.
+: For any vector space $V$ over a field $F$, the dual space $V^{*}$ is the set of all linear functions $\phi : V \rightarrow F$.
+If $V$ is finite dimensional, then $V^{*}$ has the same dimension as $V$.
 See <https://en.wikipedia.org/wiki/Dual_space> and <https://https://finite-element.github.io/L2_fespaces.html>.
 
 face

--- a/docs/user/governingeqns/elasticity-infstrain-prescribedslip/dynamic.md
+++ b/docs/user/governingeqns/elasticity-infstrain-prescribedslip/dynamic.md
@@ -49,7 +49,7 @@ We first focus on the explicit part and select numerical quadrature that yields 
 
 ```{math}
 :label: eqn:dynamic:prescribed:slip:weak:form
-\begin{gather}
+\begin{gathered}
   % Displacement-velocity
   \frac{\partial \vec{u}}{\partial t} = M_u^{-1} \int_{\Omega} \vec{\psi}_\mathit{trial}^u \cdot \vec{v} \, d\Omega, \\
   % Elasticity
@@ -57,7 +57,7 @@ We first focus on the explicit part and select numerical quadrature that yields 
   \qquad\qquad+ M_{v^+}^{-1} \int_{\Gamma_{f}} \vec{\psi}_\mathit{trial}^{v^+} \cdot \left(-\vec{\lambda}(\vec{x},t)\right) \, d\Gamma + M_{v^-}^{-1} \int_{\Gamma_{f}}\vec{\psi}_\mathit{trial}^{v^-} \cdot \left(+\vec{\lambda}(\vec{x},t)\right) \, d\Gamma, \\
   M_u = \mathit{Lump}\left( \int_\Omega \psi_{\mathit{trial}_i}^u \delta_{ij} \psi_{\mathit{basis}_j}^u \, d\Omega \right), \\
   M_v = \mathit{Lump}\left( \int_\Omega \psi_{\mathit{trial}_i}^v \rho(\vec{x}) \delta_{ij} \psi_{\mathit{basis}_j}^v \, d\Omega \right).
-\end{gather}
+\end{gathered}
 ```
 
 For the implicit part, we can separate the integration of the weak form for negative and positive sides of the fault interface, which yields
@@ -69,9 +69,7 @@ Using these equations to substitute in the expressions for the time derivative o
 
 ```{math}
 :label: eqn:elasticity:prescribed:slip:dynamic:DAE:weak:form
-\begin{equation}
   M_{v^+}^{-1} \int_{\Gamma_f^+} \vec{\psi}_\mathit{trial}^\lambda \cdot \left(\boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda}\right) \, d\Gamma + M_{v^-}^{-1} \int_{\Gamma_f^-} \vec{\psi}_\mathit{trial}^\lambda \cdot \left( -\boldsymbol{\sigma} \cdot \vec{n} + \vec{\lambda} \right) \, d\Gamma + \int_{\Gamma_f} \vec{\psi}_\mathit{trial}^\lambda \cdot \left(-\frac{\partial^2 \vec{d}}{\partial t^2} \right) \, d\Gamma = \vec{0}.
-\end{equation}
 ```
 
 ## Residual Pointwise Functions

--- a/docs/user/governingeqns/elasticity-infstrain-prescribedslip/index.md
+++ b/docs/user/governingeqns/elasticity-infstrain-prescribedslip/index.md
@@ -4,9 +4,9 @@ For each fault, which is an internal interface, we add a boundary condition to t
 %
 ```{math}
 :label: eqn:bc:prescribed:slip
-\begin{gather}
+\begin{gathered}
   \vec{u}^+ - \vec{u}^- - \vec{d}(\vec{x},t) = \vec{0} \text{ on }\Gamma_f,
-\end{gather}
+\end{gathered}
 ```
 %
 where $\vec{u}^+$ is the displacement vector on the "positive" side of the fault, $\vec{u}^-$ is the displacement vector on the "negative" side of the fault, $\vec{d}$ is the slip vector on the fault, and $\vec{n}$ is the fault normal which points from the negative side of the fault to the positive side of the fault.

--- a/docs/user/governingeqns/elasticity-infstrain/bulk-rheologies/effective-stress.md
+++ b/docs/user/governingeqns/elasticity-infstrain/bulk-rheologies/effective-stress.md
@@ -7,11 +7,11 @@ As for our linear viscoelastic models, the viscous volumetric strains are zero (
 %
 ```{math}
 :label: eqn:effstress:stress-strain
-\begin{gather}
+\begin{gathered}
 \boldsymbol{\sigma}^{dev}(t + \Delta t) = 2\mu \left[\boldsymbol{\epsilon}^{dev}(t + \Delta t) - \boldsymbol{\epsilon}^{creepdev}(t + \Delta t) - \boldsymbol{\epsilon}^{refdev}\right] + \boldsymbol{\sigma}^{refdev} \\
 \boldsymbol{\sigma}^{dev}(t + \Delta t) = \frac{1}{a_{E}} \left[\boldsymbol{\epsilon}^{dev}(t + \Delta t) - \boldsymbol{\epsilon}^{creepdev}(t + \Delta t) - \boldsymbol{\epsilon}^{refdev}\right] + \boldsymbol{\sigma}^{refdev} \\
 P(t + \Delta t) = 3K\left[\theta(t + \Delta t) - \theta^{ref}\right] + P^{ref} = \frac{1}{a_{m}}\left[\theta(t + \Delta t) - \theta^{ref}\right] + P^{ref}, \\
-\end{gather}
+\end{gathered}
 ```
 %
 where $\boldsymbol{\epsilon}^{dev}(t + \Delta t)$ is the total deviatoric strain, $\boldsymbol{\epsilon}^{creepdev}(t + \Delta t)$ is the total viscous strain, $\boldsymbol{\epsilon}^{refdev}$ is the reference deviatoric strain, $P(t + \Delta t)$ is the total pressure, $\theta (t + \Delta t)$ is the mean strain evaluated at time $t + \Delta t$ and $\theta^{ref}$ is the reference mean strain.
@@ -27,10 +27,10 @@ where
 %
 ```{math}
 :label: eqn:effstress:devstrain-prime
-\begin{gather}
+\begin{gathered}
 \boldsymbol{\epsilon}^{\prime dev}(t + \Delta t) = \boldsymbol{\epsilon}^{dev}(t + \Delta t) - \boldsymbol{\epsilon}^{creepdev}(t) - \boldsymbol{\epsilon}^{refdev}, \\
 \boldsymbol{\Delta \epsilon}^{creepdev} = \boldsymbol{\epsilon}^{creepdev}(t + \Delta t) - \boldsymbol{\epsilon}^{creepdev}(t). \\
-\end{gather}
+\end{gathered}
 ```
 %
 The creep strain increment is approximated using

--- a/docs/user/governingeqns/elasticity-infstrain/bulk-rheologies/elasticity-constitutive.md
+++ b/docs/user/governingeqns/elasticity-infstrain/bulk-rheologies/elasticity-constitutive.md
@@ -12,12 +12,12 @@ In computing the derivative, we consider the linearized form:
 %
 ```{math}
 :label: eqn:linearized:elasticity
-\begin{gather}
+\begin{gathered}
 \sigma_{ik} = C_{ikjl} \epsilon_{jl} \\
 \sigma_{ik} = C_{ikjl} \frac{1}{2}\left(u_{j,l} + u_{l,j}\right) \\
 \sigma_{ik} = \frac{1}{2}\left(C_{ikjl} + C_{iklj}\right)u_{j,l} \\
 \sigma_{ik} = C_{ikjl} u_{j,l}. \\
-\end{gather}
+\end{gathered}
 ```
 %
 In computing the Jacobian, we take the derivative of the stress tensor with respect to the displacement field,
@@ -38,30 +38,30 @@ For many elasticity constitutive models we prefer to separate the stress into th
 %
 ```{math}
 :label: eqn:elasticity:devstress
-\begin{gather}
+\begin{gathered}
 \boldsymbol{\sigma} = \sigma^{mean} \boldsymbol{I} + \boldsymbol{\sigma}^{dev}, \text{where} \\
 \sigma^{mean} = \frac{1}{3}\mathrm{Tr}(\boldsymbol{\sigma}) = \frac{1}{3}\left(\sigma_{11} + \sigma_{22} + \sigma_{33}\right). \\
-\end{gather}
+\end{gathered}
 ```
 %
 Sometimes it is convenient to use pressure (positive pressure corresponds to compression) instead of the mean stress:
 %
 ```{math}
 :label: eqn:elasticity:devstress:pressure
-\begin{gather}
+\begin{gathered}
 \boldsymbol{\sigma} = -p \boldsymbol{I} + \boldsymbol{\sigma}^{dev}, \text{where} \\
 p = -\frac{1}{3}\mathrm{Tr}(\boldsymbol{\sigma}). \\
-\end{gather}
+\end{gathered}
 ```
 %
 The Jacobian with respect to the deviatoric stress is
 %
 ```{math}
 :label: eqn:elasticity:devstress:jacobian
-\begin{gather}
+\begin{gathered}
 \frac{\partial \sigma_{ik}^{dev}}{\partial u_{j}} = \frac{\partial}{\partial u_{j}}\left(\sigma_{ik} - \frac{1}{3}\sigma_{mm}\delta_{ik}\right) \\
 \frac{\partial \sigma_{ik}^{dev}}{\partial u_{j}} = C_{ikjl} {\psi_\mathit{basis^{}}^{u}}_{j,l} - \frac{1}{3}C_{mmjl} \delta_{ik}{\psi_\mathit{basis^{}}^{u}}_{j,l}.
-\end{gather}
+\end{gathered}
 ```
 %
 We call these modified elastic constants $C_{ijkl}^{dev}$, so that we have

--- a/docs/user/governingeqns/elasticity-infstrain/bulk-rheologies/linear-elastic.md
+++ b/docs/user/governingeqns/elasticity-infstrain/bulk-rheologies/linear-elastic.md
@@ -23,10 +23,10 @@ The mean stress is
 %
 ```{math}
 :label: eqn:elasticity:meanstress
-\begin{gather}
+\begin{gathered}
 \sigma^{mean} = \frac{1}{3} \sigma_{kk}, \\
 \sigma^{mean} = \frac{1}{3} \sigma_{kk}^{ref} + K\left(\epsilon_{kk} - \epsilon_{kk}^{ref}\right), \\
-\end{gather}
+\end{gathered}
 ```
 %
 where $K = \lambda + 2 \mu/3$ is the bulk modulus.
@@ -40,7 +40,7 @@ If the reference stress and reference strain are both zero, then this reduces to
 The deviatoric stress is
 %
 ```{math}
-\begin{gather}
+\begin{gathered}
 \sigma_{ij}^{dev} = \sigma_{ij} - \sigma^{mean} \delta_{ij}, \\
 \sigma_{ij}^{dev} = \sigma_{ij}^{ref} + \lambda \left(\epsilon_{kk} -
 \epsilon_{kk}^{ref}\right) \delta_{ij} + 2 \mu \left(\epsilon_{ij} -
@@ -48,27 +48,27 @@ The deviatoric stress is
 \left(\lambda + \frac{2}{3}\mu\right)\left(\epsilon_{kk}-
 \epsilon_{kk}^{ref}\right)\right] \delta_{ij}, \\
 \sigma_{ij}^{dev} = \sigma_{ij}^{ref} - \frac{1}{3}\sigma_{kk}^{ref}\delta_{ij} + 2 \mu \left(\epsilon_{ij} - \epsilon_{ij}^{ref}\right) - \frac{2}{3} \mu\left(\epsilon_{kk}- \epsilon_{kk}^{ref}\right) \delta_{ij}. \\
-\end{gather}
+\end{gathered}
 ```
 %
 For isotropic linear elasticity, all components of $C_{ikjl}$ are zero except for:
 %
 ```{math}
 :label: eqn:elasticity:nonzero:cikjl
-\begin{gather}
+\begin{gathered}
 C_{1111} = C_{2222} = C_{3333} = \lambda + 2 \mu, \\
 C_{1122} = C_{1133} = C_{2233} = \lambda, \\
 C_{1212} = C_{2323} = C_{1313} = \mu. \\
-\end{gather}
+\end{gathered}
 ```
 %
 The deviatoric elastic constants are:
 %
 ```{math}
 :label: eqn:elasticity:nonzero:cikjl:deviatoric
-\begin{gather}
+\begin{gathered}
 C_{1111}^{dev} = C_{2222}^{dev} = C_{3333}^{dev} = \frac{4}{3} \mu, \\
 C_{1122}^{dev} = C_{1133}^{dev} = C_{2233}^{dev} = -\frac{2}{3} \mu, \\
 C_{1212}^{dev} = C_{2323}^{dev} = C_{1313}^{dev} = \mu. \\
-\end{gather}
+\end{gathered}
 ```

--- a/docs/user/governingeqns/elasticity-infstrain/bulk-rheologies/powerlaw.md
+++ b/docs/user/governingeqns/elasticity-infstrain/bulk-rheologies/powerlaw.md
@@ -32,11 +32,11 @@ In a triaxial experiment with confining pressure $P_{c}$, we have
 %
 ```{math}
 :label: eqn:powerlaw:triax2
-\begin{gather}
+\begin{gathered}
 \sigma_{2} = \sigma_{3} = P_{c} \\
 \sigma_{1} = \sigma_{1}^{app} \\
 P = \frac{\sigma_{1} + 2P_{c}}{3}, \\
-\end{gather}
+\end{gathered}
 ```
 %
 where $\sigma_{1}^{app}$ is the applied load.
@@ -44,20 +44,20 @@ The deviatoric stresses are then:
 %
 ```{math}
 :label: eqn:powerlaw:triax:devstress
-\begin{gather}
+\begin{gathered}
 \sigma_{1}^{dev} = \frac{2}{3} \left(\sigma_{1} - P_{c}\right) \\
 \sigma_{2}^{dev} = \sigma_{3}^{dev} = -\frac{1}{3} \left(\sigma_{1} - P_{c}\right). \\
-\end{gather}
+\end{gathered}
 ```
 %
 This gives
 %
 ```{math}
 :label: eqn:powerlaw:triax:devstress2
-\begin{gather}
+\begin{gathered}
 \sigma_{1}^{dev} = \frac{2}{3} \left(\sigma_{1} - \sigma_{3}\right) = \frac{2}{3} \sigma_{d} \\
 \sigma_{2}^{dev} = \sigma_{3}^{dev} = -\frac{1}{3} \left(\sigma_{1} - \sigma_{3}\right) = -\frac{1}{3} \sigma_{d}. \\
-\end{gather}
+\end{gathered}
 ```
 %
 In terms of the second deviatoric stress invariant, we then have
@@ -71,10 +71,10 @@ Under the assumption that the creep measured in the laboratory experiments is in
 %
 ```{math}
 :label: eqn:powerlaw:triax:strainrate
-\begin{gather}
+\begin{gathered}
 \dot{\epsilon}_{11}^{creepdev} = \dot{\epsilon}_{11} \\
 \dot{\epsilon}_{22}^{creepdev} = \dot{\epsilon}_{33} = -\frac{1}{2}\dot{\epsilon}_{11}. \\
-\end{gather}
+\end{gathered}
 ```
 %
 In terms of the second deviatoric strain rate invariant we then have
@@ -192,12 +192,12 @@ where
 %
 ```{math}
 :label: eqn:powerlaw:effstressfn:variables
-\begin{gather}
+\begin{gathered}
 a = a_{E} + \alpha \Delta t \gamma(\tau), \\
 b = \frac{1}{2} \boldsymbol{\epsilon}^{\prime dev}(t + \Delta t) : \boldsymbol{\epsilon}^{\prime dev}(t + \Delta t) + a_{E} \boldsymbol{\epsilon}^{\prime dev}(t + \Delta t) : \boldsymbol{\sigma}^{refdev} + a_{E}^{2} J_{2}^{\prime ref}, \\
 c = \Delta t(1 - \alpha) \boldsymbol{\epsilon}^{\prime dev}(t + \Delta t) : \boldsymbol{\sigma}^{dev}(t) + \Delta t(1 - \alpha) a_{E} \boldsymbol{\sigma}^{dev}(t) : \boldsymbol{\sigma}^{refdev}, \\
 d = \Delta t (1 - \alpha) \sqrt{J_{2}^{\prime}(t)}. \\
-\end{gather}
+\end{gathered}
 ```
 
 Equation {math:numref}`eqn:powerlaw:effstressfn` is a function of a single unknown -- the square root of the second deviatoric stress invariant at time $t + \Delta t$ -- which we can solve by bisection or by Newton’s method.
@@ -208,10 +208,10 @@ To compute the tangent stress-strain relation, we first rewrite {math:numref}`eq
 %
 ```{math}
 :label: eqn:powerlaw:stress-alpha:function
-\begin{gather}
+\begin{gathered}
 \sigma_{ij}^{dev}(t + \Delta t) \left[a_{E} + \alpha \Delta t \gamma(\tau)\right] - \epsilon_{ij}^{\prime dev}(t + \Delta t) + \sigma_{ij}^{dev}(t)\Delta t \gamma(\tau)(1-\alpha) - a_{E} \sigma_{ij}^{refdev} = 0, \\
 \sigma_{ij}^{dev}(t + \Delta t)G  - \epsilon_{ij}^{\prime dev}(t + \Delta t) + \sigma_{ij}^{dev}(t)H - a_{E} \sigma_{ij}^{refdev} = 0. \\
-\end{gather}
+\end{gathered}
 ```
 %
 Taking derivatives with respect to $\epsilon_{kl}$, we obtain

--- a/docs/user/governingeqns/elasticity-infstrain/quasistatic.md
+++ b/docs/user/governingeqns/elasticity-infstrain/quasistatic.md
@@ -5,13 +5,13 @@ Our solution vector is the displacement vector and the elasticity equation reduc
 %
 ```{math}
 :label: eqn:elasticity:strong:form:quasistatic
-\begin{gather}
+\begin{gathered}
 \vec{f}(\vec{x},t) + \boldsymbol{\nabla} \cdot \boldsymbol{\sigma}(\vec{u}) = \vec{0} \text{ in }\Omega, \\
 %
 \boldsymbol{\sigma} \cdot \vec{n} = \vec{\tau}(\vec{x},t) \text{ on }\Gamma_\tau, \\
 %
 \vec{u} = \vec{u}_0(\vec{x},t) \text{ on }\Gamma_u.
-\end{gather}
+\end{gathered}
 ```
 %
 Because we will use implicit time stepping, we place all of the terms in the elasticity equation on the LHS.
@@ -31,14 +31,12 @@ Using the divergence theorem and incorporating the Neumann boundary conditions, 
 
 Identifying $F(t,s,\dot{s})$ and $G(t,s)$, we have
 %
-\begin{equation}
-\begin{aligned}
+\begin{align}
 % Fu
 F^u(t,s,\dot{s}) &=  \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot{\color{blue}\underbrace{\color{black}\vec{f}(\vec{x},t)}_{\color{blue}{\vec{f}^u_0}}} + \nabla {\vec{\psi}_\mathit{trial}^{u}} :{\color{blue} \underbrace{\color{black}-\boldsymbol{\sigma}(\vec{u})}_{\color{blue}{\boldsymbol{f^u_1}}}} \, d\Omega  + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{u}} \cdot {\color{blue}  \underbrace{\color{black}\vec{\tau}(\vec{x},t)}_{\color{blue}{\vec{f}^u_0}}} \, d\Gamma, \\
 % Gu
 G^u(t,s) &= 0
-\end{aligned}
-\end{equation}
+\end{align}
 %
 Note that we have multiple $\vec{f}_0$ functions, each associated with a trial function and an integral over a different domain or boundary.
 Each material and boundary condition (except Dirichlet) contribute pointwise functions.
@@ -52,9 +50,7 @@ We only have a Jacobian for the LHS:
 %
 ```{math}
 :label: eqn:elasticity:quasistatic:jacobian:pointwise
-\begin{equation}
 \begin{aligned}
 J_F^{uu} &= \frac{\partial F^u}{\partial u} = \int_\Omega \nabla {\vec{\psi}_\mathit{trial}^{u}} : \frac{\partial}{\partial u}(-\boldsymbol{\sigma}) \, d\Omega  = \int_\Omega \nabla {\vec{\psi}_\mathit{trial}^{u}} : -\boldsymbol{C} : \frac{1}{2}(\nabla + \nabla^T){\vec{\psi}_\mathit{basis}^{u}}\, d\Omega  = \int_\Omega {\psi_\mathit{trial}^{u}}_{i,k} \, {\color{blue} \underbrace{\color{black}\left( -C_{ikjl} \right)}_{\color{blue}{J_{f3}^{uu}}}} \, {\psi_\mathit{basis}^{u}}_{j,l}\, d\Omega.
 \end{aligned}
-\end{equation}
 ```

--- a/docs/user/governingeqns/incompressible-elasticity.md
+++ b/docs/user/governingeqns/incompressible-elasticity.md
@@ -60,20 +60,20 @@ Using trial functions ${\vec{\psi}_\mathit{trial}^{u}}$ and ${\psi_\mathit{trial
 Identifying $F(t,s,\dot{s})$, we have
 ```{math}
 :label: eqn:incompressible:elasticity:displacement
-\begin{gather}
+\begin{gathered}
 F^u(t,s,\dot{s}) = \int_\Omega {\vec{\psi}_\mathit{trial}^{u}} \cdot{\color{blue}
 \underbrace{\color{black}\vec{f}(t)}_{\color{blue}{f_0^u}}} + \nabla {\vec{\psi}_\mathit{trial}^{u}} :{\color{blue}
 \underbrace{\color{black}\left(-\boldsymbol{\sigma}^\mathit{dev}(\vec{u}) + p\boldsymbol{I}\right)}_{\color{blue}{f_1^u}}}  \, d\Omega
 + \int_{\Gamma_\tau} {\vec{\psi}_\mathit{trial}^{u}} \cdot {\color{blue}\underbrace{\color{black}\vec{\tau}(t)}_{\color{blue}{f_0^u}}} \, d\Gamma, \\
 %
-\end{gather}
+\end{gathered}
 ```
 ```{math}
 :label: eqn:incompressible:elasticity:pressure
-\begin{gather}
+\begin{gathered}
 F^p(t,s,\dot{s}) = \int_\Omega {\psi_\mathit{trial}^{p}} \cdot {\color{blue}\underbrace{\color{black}\left(\vec{\nabla} \cdot \vec{u} +
 \frac{p}{K} \right)}_{\color{blue}{f_0^p}}} \, d\Omega.
-\end{gather}
+\end{gathered}
 ```
 ## Jacobians Pointwise Functions
 

--- a/docs/user/governingeqns/petsc-formulation.md
+++ b/docs/user/governingeqns/petsc-formulation.md
@@ -26,11 +26,11 @@ The LHS Jacobian $J_F = \frac{\partial F}{\partial s} + s_\mathit{tshift} \frac{
 
 ```{math}
 :label: eqn:jacobian:form
-\begin{align}
+\begin{aligned}
   J_F &= \int_\Omega {\vec{\psi}_\mathit{trial}^{}}\cdot \boldsymbol{J}_{f0}(t,s,\dot{s}) \cdot {\vec{\psi}_\mathit{basis}^{}} + {\vec{\psi}_\mathit{trial}^{}}\cdot \boldsymbol{J}_{f1}(t,s,\dot{s}) : \nabla {\vec{\psi}_\mathit{basis}^{}} + \nabla {\vec{\psi}_\mathit{trial}^{}}: \boldsymbol{J}_{f2}(t,s,\dot{s}) \cdot {\vec{\psi}_\mathit{basis}^{}} + \nabla {\vec{\psi}_\mathit{trial}^{}}: \boldsymbol{J}_{f3}(t,s,\dot{s}) : \nabla {\vec{\psi}_\mathit{basis}^{}}\, d\Omega \\
 %
   J_G &= \int_\Omega {\vec{\psi}_\mathit{trial}^{}}\cdot \boldsymbol{J}_{g0}(t,s) \cdot {\vec{\psi}_\mathit{basis}^{}} + {\vec{\psi}_\mathit{trial}^{}}\cdot \boldsymbol{J}_{g1}(t,s) : \nabla {\vec{\psi}_\mathit{basis}^{}} + \nabla {\vec{\psi}_\mathit{trial}^{}}: \boldsymbol{J}_{g2}(t,s) \cdot {\vec{\psi}_\mathit{basis}^{}} + \nabla {\vec{\psi}_\mathit{trial}^{}}: \boldsymbol{J}_{g3}(t,s) : \nabla {\vec{\psi}_\mathit{basis}^{}}\, d\Omega,
-\end{align}
+\end{aligned}
 ```
 
 where ${\vec{\psi}_\mathit{basis}^{}}$ is a basis function.

--- a/docs/user/install/index.md
+++ b/docs/user/install/index.md
@@ -62,6 +62,27 @@ $ source setup.sh
 Ready to run PyLith.
 ```
 
+:::{tip}
+To bypass macOS quarantine restrictions, simply use command line program `curl` to download the tarball from within a terminal rather than using a web browser.
+
+```
+curl -L -O https://github.com/geodynamics/pylith/releases/download/v3.0.0/pylith-3.0.0-macOS-11.6.6-x86_64.tar.gz
+```
+
+Alternatively, if you do download the tarball using a web browser, after you unpack the tarball you can remove the macOS quarantine flags using the following commands (requires Administrator access):
+
+```
+# Show extended attributes
+xattr ./pylith-3.0.0-macOS-11.6.6-x86_64
+
+# Output should be
+com.apple.quarantine
+
+# Remove quarantine attributes
+sudo xattr -r -d com.apple.quarantine ./pylith-3.0.0-macOS-11.6.6-x86_64
+```
+:::
+
 :::{warning}
 The binary distribution contains PyLith and all of its dependencies.
 If you have any of this software already installed on your system, you need to be careful in setting up your environment so that preexisting software does not conflict with the PyLith binary.

--- a/docs/user/physics/faults/index.md
+++ b/docs/user/physics/faults/index.md
@@ -22,7 +22,7 @@ Instead, the user specifies fault parameters in terms of lateral motion, reverse
 :::{figure-md} fig:fault:orientation
 <img src="figs/fault-orientation.*" alt="Orientation of a fault surface in 3D, where $\phi$ denotes the angle of the fault strike, $\delta$ denotes the angle of the fault dip, and $\lambda$ the rake angle." width="600px"/>
 
-Orientation of a fault surface in 3D, where <span class="math inline"><em>&#x3D5;</em></span> denotes the angle of the fault strike, <span class="math inline"><em>&#x3B4;</em></span> denotes the angle of the fault dip, and <span class="math inline"><em>&#x3BB;</em></span> the rake angle.
+Orientation of a fault surface in 3D, where $\phi$ denotes the angle of the fault strike, $\delta$ denotes the angle of the fault dip, and $\lambda$ the rake angle.
 :::
 
 :::{figure-md} fig:fault:slip:motions

--- a/libsrc/pylith/materials/IncompressibleElasticity.cc
+++ b/libsrc/pylith/materials/IncompressibleElasticity.cc
@@ -253,9 +253,9 @@ pylith::materials::IncompressibleElasticity::getSolverDefaults(const bool isPara
                 options->add("-fieldsplit_displacement_pc_type", "gamg");
                 options->add("-fieldsplit_displacement_mg_levels_pc_type", "sor");
                 options->add("-fieldsplit_displacement_mg_levels_ksp_type", "richardson");
-                options->add("-fieldsplit_pressure_pc_type", "gamg");
-                options->add("-fieldsplit_pressure_mg_levels_pc_type", "sor");
-                options->add("-fieldsplit_pressure_mg_levels_ksp_type", "richardson");
+                options->add("-fieldsplit_pressure_pc_type", "bjacobi");
+                //options->add("-fieldsplit_pressure_mg_levels_pc_type", "sor");
+                //options->add("-fieldsplit_pressure_mg_levels_ksp_type", "richardson");
             } // if/else
         } // if/else
         break;


### PR DESCRIPTION
* Fix LaTeX build for documentation. Biggest error was incorrect nested match environments (Sphinx html generator didn't care, but LaTeX did; align -> aligned; gather -> gathered).
* Improve instructions for how to use ParaView Python scripts when starting ParaView with a shortcut.
* Add instructions for how to remove macOS quarantine attributes when downloading the tarball.