### PR TITLE
FIX: Resolve bugs associated with running in parallel with faults

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ AC_CHECK_HEADER([mpi.h], [], [AC_MSG_ERROR([header 'mpi.h' not found])])
 
 dnl PETSC
 AC_LANG(C)
-CIT_PATH_PETSC([3.17.3])
+CIT_PATH_PETSC([3.17.4])
 CIT_HEADER_PETSC
 CIT_CHECK_LIB_PETSC
 

--- a/libsrc/pylith/topology/Field.cc
+++ b/libsrc/pylith/topology/Field.cc
@@ -354,14 +354,20 @@ pylith::topology::Field::view(const char* label,
         } // for
     } // if
 
-    PetscSection section = NULL;
     PetscMPIInt numProcs, rank;
     PetscErrorCode err;
 
     const PetscDM dm = _mesh->getDM();assert(dm);
-    err = DMGetSection(dm, &section);PYLITH_CHECK_ERROR(err);
     if ((VIEW_LAYOUT == options) || (VIEW_ALL == options)) {
         err = DMView(dm, PETSC_VIEWER_STDOUT_WORLD);PYLITH_CHECK_ERROR(err);
+
+        PetscSection section = NULL;
+        err = DMGetLocalSection(dm, &section);PYLITH_CHECK_ERROR(err);
+        std::cout << "Local section" << std::endl;
+        err = PetscSectionView(section, PETSC_VIEWER_STDOUT_WORLD);PYLITH_CHECK_ERROR(err);
+
+        err = DMGetGlobalSection(dm, &section);PYLITH_CHECK_ERROR(err);
+        std::cout << "Global section" << std::endl;
         err = PetscSectionView(section, PETSC_VIEWER_STDOUT_WORLD);PYLITH_CHECK_ERROR(err);
     } // if
     if ((VIEW_VALUES == options) || (VIEW_ALL == options)) {


### PR DESCRIPTION
* Updates to PETSc to resolve PetscSF bugs
* Update to `ConstraintSimple` for more flexibility in finding DS to set constraint
* Update to PETSc 3.17.4

Closes #518 #519 