### PR TITLE
FIX: Fix dynamic simulations (no faults)

### DIFF
--- a/libsrc/pylith/problems/GreensFns.cc
+++ b/libsrc/pylith/problems/GreensFns.cc
@@ -62,8 +62,7 @@ pylith::problems::GreensFns::GreensFns(void) :
     _monitor(NULL) {
     PyreComponent::setName(_GreensFns::pyreComponent);
 
-    _integrationData->setScalar("dt_jacobian", -1.0);
-    _integrationData->setScalar("dt_lhs_jacobian", -1.0);
+    _integrationData->setScalar(pylith::feassemble::IntegrationData::dt_jacobian, -1.0);
     _integrationData->setScalar(pylith::feassemble::IntegrationData::t_state, -HUGE_VAL);
 } // constructor
 

--- a/libsrc/pylith/problems/Problem.cc
+++ b/libsrc/pylith/problems/Problem.cc
@@ -234,7 +234,7 @@ pylith::problems::Problem::setSolution(pylith::topology::Field* field) {
     PYLITH_COMPONENT_DEBUG("Problem::setSolution(field="<<typeid(*field).name()<<")");
 
     assert(_integrationData);
-    _integrationData->setField("solution", field);
+    _integrationData->setField(pylith::feassemble::IntegrationData::solution, field);
 } // setSolution
 
 

--- a/libsrc/pylith/problems/TimeDependent.cc
+++ b/libsrc/pylith/problems/TimeDependent.cc
@@ -66,8 +66,8 @@ pylith::problems::TimeDependent::TimeDependent(void) :
     _shouldNotifyIC(false) {
     PyreComponent::setName(_TimeDependent::pyreComponent);
 
-    _integrationData->setScalar("dt_jacobian", -1.0);
-    _integrationData->setScalar("dt_lhs_jacobian", -1.0);
+    _integrationData->setScalar(pylith::feassemble::IntegrationData::dt_jacobian, -1.0);
+    _integrationData->setScalar(pylith::feassemble::IntegrationData::dt_lumped_jacobian_inverse, -1.0);
     _integrationData->setScalar(pylith::feassemble::IntegrationData::t_state, -HUGE_VAL);
 } // constructor
 
@@ -352,7 +352,7 @@ pylith::problems::TimeDependent::initialize(void) {
     // Initialize residual.
     pylith::topology::Field* residual = new pylith::topology::Field(*solution);assert(residual);
     residual->setLabel("residual");
-    _integrationData->setField("residual", residual);
+    _integrationData->setField(pylith::feassemble::IntegrationData::residual, residual);
 
     // Set callbacks.
     PYLITH_COMPONENT_DEBUG("Setting PetscTS callback for poststep().");
@@ -376,7 +376,7 @@ pylith::problems::TimeDependent::initialize(void) {
         pylith::topology::Field* jacobianLHSLumpedInv = new pylith::topology::Field(*solution);assert(jacobianLHSLumpedInv);
         jacobianLHSLumpedInv->setLabel("JacobianLHS_lumped_inverse");
         jacobianLHSLumpedInv->createGlobalVector();
-        _integrationData->setField("jacobian_lhs_lumped_inverse", jacobianLHSLumpedInv);
+        _integrationData->setField(pylith::feassemble::IntegrationData::lumped_jacobian_inverse, jacobianLHSLumpedInv);
         break;
     }
     default: {


### PR DESCRIPTION
Use names of scalars and fields provided by IntegrationData static data members. Incorrect values are detected at compile time rather than runtime or not at all.

Fixes dynamic simulations without faults.