### PR TITLE
Update for using numpy.1.24; require numpy.1.20 or later

### DIFF
--- a/applications/pylith_powerlaw_gendb
+++ b/applications/pylith_powerlaw_gendb
@@ -142,7 +142,7 @@ class PowerLawApp(Application):
 
         (npoints, spaceDim) = points.shape
         data = numpy.zeros((npoints, 1), dtype=numpy.float64)
-        err = numpy.zeros((npoints,), dtype=numpy.int32)
+        err = numpy.zeros((npoints,), dtype=numpy.int64)
 
         db.open()
         db.setQueryValues([valueName])

--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,7 @@ AC_SYS_LARGEFILE
 dnl NUMPY
 CIT_NUMPY_PYTHON_MODULE
 CIT_NUMPY_INCDIR
+CIT_PYTHON_MODULE([numpy],[1.20.0])
 
 dnl SWIG
 if test "$enable_swig" = "yes" ; then

--- a/examples/meshing-cubit/cellsize/exodus_add_properties.py
+++ b/examples/meshing-cubit/cellsize/exodus_add_properties.py
@@ -55,7 +55,7 @@ def getCellSizeDB(points):
     db.open()
     db.setQueryValues(["vs"])
     data = numpy.zeros((npoints, 1), dtype=numpy.float64)
-    err = numpy.zeros((npoints,), dtype=numpy.int32)
+    err = numpy.zeros((npoints,), dtype=numpy.int64)
     db.multiquery(data, err, points, cs)
     db.close()
 

--- a/examples/subduction-3d/utils/generate_initial_stress.py
+++ b/examples/subduction-3d/utils/generate_initial_stress.py
@@ -46,7 +46,7 @@ def generate(sim, fileRoot, materials):
         # Open HDF5 file and get coordinates, cells, and stress.
         h5 = h5py.File(filenameH5, "r")
         vertices = h5['geometry/vertices'][:]
-        cells = numpy.array(h5['viz/topology/cells'][:], dtype=numpy.int)
+        cells = numpy.array(h5['viz/topology/cells'][:], dtype=numpy.int64)
 
         # Get stresses from final time step.
         stress = h5['cell_fields/stress'][-1,:,:]

--- a/examples/subduction-3d/utils/make_synthetic_gpsdisp.py
+++ b/examples/subduction-3d/utils/make_synthetic_gpsdisp.py
@@ -179,7 +179,7 @@ class MakeSyntheticGpsdisp(Application):
     numConnect = 2 * self.numStations
     connectHead = "VERTICES %d %d\n" % (self.numStations, numConnect)
     v.write(connectHead)
-    verts = numpy.arange(self.numStations, dtype=numpy.int)
+    verts = numpy.arange(self.numStations, dtype=numpy.int64)
     sizes = numpy.ones_like(verts)
     outConnect = numpy.column_stack((sizes, verts))
     numpy.savetxt(v, outConnect, fmt="%d")

--- a/examples/subduction-3d/utils/slip_invert.py
+++ b/examples/subduction-3d/utils/slip_invert.py
@@ -170,7 +170,7 @@ class SlipInvert(Application):
         vertsF = s.create_dataset('geometry/vertices', data=self.faultVertCoords)
         timesF = s.create_dataset('time', data=timesF, maxshape=(None, 1, 1))
         topoF = s.create_dataset('viz/topology/cells', data=self.faultCells, dtype='d')
-        topoF.attrs['cell_dim'] = numpy.int32(cellDimF)
+        topoF.attrs['cell_dim'] = numpy.int64(cellDimF)
         slipVec = numpy.zeros((self.numPenaltyWeights, self.numFaultVerts, 3),
                               dtype=numpy.float64)
         slipAlongRake = numpy.zeros((self.numPenaltyWeights, self.numFaultVerts, 1),
@@ -183,7 +183,7 @@ class SlipInvert(Application):
         vertsD = d.create_dataset('geometry/vertices', data=self.dataCoords)
         timesD = d.create_dataset('time', data=timesD, maxshape=(None, 1, 1))
         topoD = d.create_dataset('viz/topology/cells', data=topolD, dtype='d')
-        topoD.attrs['cell_dim'] = numpy.int32(cellDimD)
+        topoD.attrs['cell_dim'] = numpy.int64(cellDimD)
 
         predictedDisp = numpy.zeros((self.numPenaltyWeights, self.numDataPoints, 3), dtype=numpy.float64)
 
@@ -283,7 +283,7 @@ class SlipInvert(Application):
         self.faultVertCoords = impulsesLl['geometry/vertices'][:]
         self.numFaultVerts = self.faultVertCoords.shape[0]
         self.faultCells = numpy.array(impulsesLl['viz/topology/cells'][:],
-                                      dtype=numpy.int)
+                                      dtype=numpy.int64)
         self.numFaultCells = self.faultCells.shape[0]
         llSlip = impulsesLl['vertex_fields/slip'][:,:, 0]
         llImpInds = numpy.nonzero(llSlip != 0.0)

--- a/libsrc/pylith/Makefile.am
+++ b/libsrc/pylith/Makefile.am
@@ -79,8 +79,8 @@ libpylith_la_SOURCES = \
 	materials/AuxiliaryFactoryElasticity.cc \
 	materials/DerivedFactoryElasticity.cc \
 	materials/IsotropicLinearElasticity.cc \
-    materials/IsotropicLinearMaxwell.cc \
-    materials/IsotropicLinearGenMaxwell.cc \
+	materials/IsotropicLinearMaxwell.cc \
+	materials/IsotropicLinearGenMaxwell.cc \
 	materials/IsotropicPowerLaw.cc \
 	materials/IncompressibleElasticity.cc \
 	materials/RheologyIncompressibleElasticity.cc \
@@ -157,7 +157,7 @@ libpylith_la_SOURCES = \
 
 
 
-libpylith_la_LDFLAGS = $(AM_LDFLAGS) $(PYTHON_LA_LDFLAGS)
+libpylith_la_LDFLAGS = $(AM_LDFLAGS) $(PYTHON_LDFLAGS) $(PYTHON_LA_LDFLAGS)
 libpylith_la_LIBADD = \
 	-lspatialdata \
 	-lhdf5 \

--- a/playpen/viscorestart/gen_dp3d_statedb.py
+++ b/playpen/viscorestart/gen_dp3d_statedb.py
@@ -21,7 +21,7 @@ filenameDB = "grav_statevars-%s.spatialdb" % material
 # Open HDF5 file and get coordinates, cells, and stress.
 h5 = h5py.File(filenameH5, "r")
 vertices = h5['geometry/vertices'][:]
-cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int)
+cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int64)
 stress = h5['cell_fields/stress'][0,:,:]
 strain = h5['cell_fields/total_strain'][0,:,:]
 strainPlastic = h5['cell_fields/plastic_strain'][0,:,:]

--- a/playpen/viscorestart/gen_dpps_statedb.py
+++ b/playpen/viscorestart/gen_dpps_statedb.py
@@ -21,7 +21,7 @@ filenameDB = "grav_statevars-%s.spatialdb" % material
 # Open HDF5 file and get coordinates, cells, and stress.
 h5 = h5py.File(filenameH5, "r")
 vertices = h5['geometry/vertices'][:]
-cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int)
+cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int64)
 stress = h5['cell_fields/stress'][0,:,:]
 strain = h5['cell_fields/total_strain'][0,:,:]
 strainPlastic = h5['cell_fields/plastic_strain'][0,:,:]

--- a/playpen/viscorestart/gen_genmax3d_statedb.py
+++ b/playpen/viscorestart/gen_genmax3d_statedb.py
@@ -21,7 +21,7 @@ filenameDB = "grav_statevars-%s.spatialdb" % material
 # Open HDF5 file and get coordinates, cells, and stress.
 h5 = h5py.File(filenameH5, "r")
 vertices = h5['geometry/vertices'][:]
-cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int)
+cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int64)
 stress = h5['cell_fields/stress'][0,:,:]
 strain = h5['cell_fields/total_strain'][0,:,:]
 strainViscous1 = h5['cell_fields/viscous_strain_1'][0,:,:]

--- a/playpen/viscorestart/gen_genmaxps_statedb.py
+++ b/playpen/viscorestart/gen_genmaxps_statedb.py
@@ -21,7 +21,7 @@ filenameDB = "grav_statevars-%s.spatialdb" % material
 # Open HDF5 file and get coordinates, cells, and stress.
 h5 = h5py.File(filenameH5, "r")
 vertices = h5['geometry/vertices'][:]
-cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int)
+cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int64)
 stress = h5['cell_fields/stress'][0,:,:]
 strain = h5['cell_fields/total_strain'][0,:,:]
 strainViscous1 = h5['cell_fields/viscous_strain_1'][0,:,:]

--- a/playpen/viscorestart/gen_max3d_statedb.py
+++ b/playpen/viscorestart/gen_max3d_statedb.py
@@ -21,7 +21,7 @@ filenameDB = "grav_statevars-%s.spatialdb" % material
 # Open HDF5 file and get coordinates, cells, and stress.
 h5 = h5py.File(filenameH5, "r")
 vertices = h5['geometry/vertices'][:]
-cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int)
+cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int64)
 stress = h5['cell_fields/stress'][0,:,:]
 strain = h5['cell_fields/total_strain'][0,:,:]
 strainViscous = h5['cell_fields/viscous_strain'][0,:,:]

--- a/playpen/viscorestart/gen_maxps_statedb.py
+++ b/playpen/viscorestart/gen_maxps_statedb.py
@@ -21,7 +21,7 @@ filenameDB = "grav_statevars-%s.spatialdb" % material
 # Open HDF5 file and get coordinates, cells, and stress.
 h5 = h5py.File(filenameH5, "r")
 vertices = h5['geometry/vertices'][:]
-cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int)
+cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int64)
 stress = h5['cell_fields/stress'][0,:,:]
 strain = h5['cell_fields/total_strain'][0,:,:]
 strainViscous = h5['cell_fields/viscous_strain'][0,:,:]

--- a/playpen/viscorestart/gen_powerlaw3d_statedb.py
+++ b/playpen/viscorestart/gen_powerlaw3d_statedb.py
@@ -21,7 +21,7 @@ filenameDB = "grav_statevars-%s.spatialdb" % material
 # Open HDF5 file and get coordinates, cells, and stress.
 h5 = h5py.File(filenameH5, "r")
 vertices = h5['geometry/vertices'][:]
-cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int)
+cells = numpy.array(h5['topology/cells'][:], dtype=c)
 stress = h5['cell_fields/stress'][0,:,:]
 strain = h5['cell_fields/total_strain'][0,:,:]
 strainViscous = h5['cell_fields/viscous_strain'][0,:,:]

--- a/playpen/viscorestart/gen_powerlawps_statedb.py
+++ b/playpen/viscorestart/gen_powerlawps_statedb.py
@@ -21,7 +21,7 @@ filenameDB = "grav_statevars-%s.spatialdb" % material
 # Open HDF5 file and get coordinates, cells, and stress.
 h5 = h5py.File(filenameH5, "r")
 vertices = h5['geometry/vertices'][:]
-cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int)
+cells = numpy.array(h5['topology/cells'][:], dtype=numpy.int64)
 stress = h5['cell_fields/stress'][0,:,:]
 stress4 = h5['cell_fields/stress4'][0,:,:]
 strain = h5['cell_fields/total_strain'][0,:,:]

--- a/pylith/apps/EqInfoApp.py
+++ b/pylith/apps/EqInfoApp.py
@@ -155,7 +155,7 @@ class EqInfoApp(Application):
 
             h5 = h5py.File(filenameIn, "r", driver='sec2')
             vertices = h5['geometry/vertices'][:]
-            cells = numpy.array(h5['viz/topology/cells'][:], dtype=numpy.int32)
+            cells = numpy.array(h5['viz/topology/cells'][:], dtype=numpy.int64)
             timestamps = h5['time'][:]
             cellsArea = self._calcCellArea(cells, vertices)
             cellsShearMod = self._getShearModulus(cells, vertices)
@@ -252,7 +252,7 @@ class EqInfoApp(Application):
         db.setQueryValues(["density", "vs"])
         (ncells, ndims) = coords.shape
         data = numpy.zeros((ncells, 2), dtype=numpy.float64)
-        err = numpy.zeros((ncells,), dtype=numpy.int32)
+        err = numpy.zeros((ncells,), dtype=numpy.intc)
         db.multiquery(data, err, coords, self.cs)
         db.close()
         shearMod = data[:, 0] * data[:, 1]**2

--- a/pylith/bc/DirichletTimeDependent.py
+++ b/pylith/bc/DirichletTimeDependent.py
@@ -94,7 +94,7 @@ class DirichletTimeDependent(BoundaryCondition, ModuleDirichletTimeDependent):
         BoundaryCondition.preinitialize(self, problem)
 
         ModuleDirichletTimeDependent.setConstrainedDOF(
-            self, numpy.array(self.constrainedDOF, dtype=numpy.int32))
+            self, numpy.array(self.constrainedDOF, dtype=numpy.intc))
         ModuleDirichletTimeDependent.useInitial(self, self.useInitial)
         ModuleDirichletTimeDependent.useRate(self, self.useRate)
         ModuleDirichletTimeDependent.useTimeHistory(self, self.useTimeHistory)

--- a/pylith/faults/FaultCohesiveImpulses.py
+++ b/pylith/faults/FaultCohesiveImpulses.py
@@ -102,7 +102,7 @@ class FaultCohesiveImpulses(FaultCohesive, ModuleFaultCohesiveImpulses):
             self._info.log(f"Pre-initializing fault '{self.labelName}={self.labelValue}'.")
         FaultCohesive.preinitialize(self, problem)
         ModuleFaultCohesiveImpulses.setThreshold(self, self.threshold.value)
-        impulseDOF = numpy.array(self.impulseDOF, dtype=numpy.int32)
+        impulseDOF = numpy.array(self.impulseDOF, dtype=numpy.intc)
         ModuleFaultCohesiveImpulses.setImpulseDOF(self, impulseDOF)
   
 

--- a/pylith/testing/FullTestApp.py
+++ b/pylith/testing/FullTestApp.py
@@ -184,7 +184,7 @@ class HDF5Checker(object):
             vertices = self._getVertices()
             self.testcase.assertTrue("topology" in self.h5["viz"].keys())
             self.testcase.assertTrue("cells" in self.h5["viz/topology"].keys())
-            cells = self.h5["viz/topology/cells"][:].astype(numpy.int)
+            cells = self.h5["viz/topology/cells"][:].astype(numpy.int64)
             ncells, ncorners = cells.shape
             (nvertices, spaceDim) = vertices.shape
             centroids = numpy.zeros((ncells, spaceDim), dtype=numpy.float64)

--- a/tests/fullscale/eqinfo/generate.py
+++ b/tests/fullscale/eqinfo/generate.py
@@ -58,7 +58,7 @@ class DataLinea(TestData):
                                     dtype=numpy.float64)
         self.cells = numpy.array([[0, 1],
                                   [1, 2]],
-                                 dtype=numpy.int32)
+                                 dtype=numpy.int64)
         self.slip = numpy.array([
             # t=0
             [[0.4, 0.0],
@@ -86,7 +86,7 @@ class DataLineb(TestData):
                                     dtype=numpy.float64)
         self.cells = numpy.array([[1, 2],
                                   [0, 1]],
-                                 dtype=numpy.int32)
+                                 dtype=numpy.int64)
         self.slip = numpy.array([
             # t=0
             [[0.6, 0.0],
@@ -115,7 +115,7 @@ class DataTri3a(TestData):
                                     dtype=numpy.float64)
         self.cells = numpy.array([[0, 1, 3],
                                   [1, 2, 3]],
-                                 dtype=numpy.int32)
+                                 dtype=numpy.int64)
         self.slip = numpy.array([
             # t=0
             [[0.0, 0.5, 0.0],
@@ -146,7 +146,7 @@ class DataTri3b(TestData):
                                     dtype=numpy.float64)
         self.cells = numpy.array([[0, 1, 3],
                                   [1, 2, 3]],
-                                 dtype=numpy.int32)
+                                 dtype=numpy.int64)
         self.slip = numpy.array([
             # t=0
             [[0.3, 0.0, 0.0],
@@ -179,7 +179,7 @@ class DataQuad4a(TestData):
                                     dtype=numpy.float64)
         self.cells = numpy.array([[0, 1, 4, 3],
                                   [1, 2, 5, 4]],
-                                 dtype=numpy.int32)
+                                 dtype=numpy.int64)
         self.slip = numpy.array([
             # t=0
             [[0.1, 1.3, 0.0],
@@ -216,7 +216,7 @@ class DataQuad4b(TestData):
                                     dtype=numpy.float64)
         self.cells = numpy.array([[0, 1, 4, 3],
                                   [1, 2, 5, 4]],
-                                 dtype=numpy.int32)
+                                 dtype=numpy.int64)
         self.slip = numpy.array([
             # t=0
             [[0.1, 1.3, 0.0],


### PR DESCRIPTION
* numpy v1.24 removes numpy.int; replace use of numpy.int with numpy.intc or numpy.int64.
* Require numpy v1.20.0 or later
* Small fix for using Python framework (binary from python.org) on macOS.