### PR TITLE
FIX: Remove createIntegrator() from classes derived from FaultCohesive

### DIFF
--- a/libsrc/pylith/faults/FaultCohesive.hh
+++ b/libsrc/pylith/faults/FaultCohesive.hh
@@ -146,7 +146,7 @@ public:
      */
     virtual
     pylith::feassemble::Integrator* createIntegrator(const pylith::topology::Field& solution,
-                                                     const std::vector<pylith::materials::Material*>& materials) = 0;
+                                                     const std::vector<pylith::materials::Material*>& materials);
 
     /** Create constraint and set kernels.
      *

--- a/libsrc/pylith/faults/FaultCohesiveImpulses.cc
+++ b/libsrc/pylith/faults/FaultCohesiveImpulses.cc
@@ -182,30 +182,6 @@ pylith::faults::FaultCohesiveImpulses::verifyConfiguration(const pylith::topolog
 
 
 // ------------------------------------------------------------------------------------------------
-// Create integrator and set kernels.
-pylith::feassemble::Integrator*
-pylith::faults::FaultCohesiveImpulses::createIntegrator(const pylith::topology::Field& solution,
-                                                        const std::vector<pylith::materials::Material*>& materials) {
-    PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
-
-    pylith::feassemble::IntegratorInterface* integrator = new pylith::feassemble::IntegratorInterface(this);assert(integrator);
-    integrator->setLabelName(getCohesiveLabelName());
-    integrator->setLabelValue(getCohesiveLabelValue());
-    integrator->setSurfaceLabelName(getSurfaceLabelName());
-
-    pylith::feassemble::InterfacePatches* patches =
-        pylith::feassemble::InterfacePatches::createMaterialPairs(this, solution.getDM());
-    integrator->setIntegrationPatches(patches);
-
-    _setKernelsResidual(integrator, solution, materials);
-    _setKernelsJacobian(integrator, solution, materials);
-
-    PYLITH_METHOD_RETURN(integrator);
-} // createIntegrator
-
-
-// ------------------------------------------------------------------------------------------------
 // Create auxiliary field.
 pylith::topology::Field*
 pylith::faults::FaultCohesiveImpulses::createAuxiliaryField(const pylith::topology::Field& solution,

--- a/libsrc/pylith/faults/FaultCohesiveImpulses.hh
+++ b/libsrc/pylith/faults/FaultCohesiveImpulses.hh
@@ -69,15 +69,6 @@ public:
      */
     void verifyConfiguration(const pylith::topology::Field& solution) const;
 
-    /** Create integrator and set kernels.
-     *
-     * @param[in] solution Solution field.
-     * @param[in] materials Materials in problem.
-     * @returns Integrator if applicable, otherwise NULL.
-     */
-    pylith::feassemble::Integrator* createIntegrator(const pylith::topology::Field& solution,
-                                                     const std::vector<pylith::materials::Material*>& materials);
-
     /** Create auxiliary field.
      *
      * @param[in] solution Solution field.

--- a/libsrc/pylith/faults/FaultCohesiveKin.cc
+++ b/libsrc/pylith/faults/FaultCohesiveKin.cc
@@ -170,30 +170,6 @@ pylith::faults::FaultCohesiveKin::verifyConfiguration(const pylith::topology::Fi
 
 
 // ------------------------------------------------------------------------------------------------
-// Create integrator and set kernels.
-pylith::feassemble::Integrator*
-pylith::faults::FaultCohesiveKin::createIntegrator(const pylith::topology::Field& solution,
-                                                   const std::vector<pylith::materials::Material*>& materials) {
-    PYLITH_METHOD_BEGIN;
-    PYLITH_COMPONENT_DEBUG("createIntegrator(solution="<<solution.getLabel()<<")");
-
-    pylith::feassemble::IntegratorInterface* integrator = new pylith::feassemble::IntegratorInterface(this);assert(integrator);
-    integrator->setLabelName(getCohesiveLabelName());
-    integrator->setLabelValue(getCohesiveLabelValue());
-    integrator->setSurfaceLabelName(getSurfaceLabelName());
-
-    pylith::feassemble::InterfacePatches* patches =
-        pylith::feassemble::InterfacePatches::createMaterialPairs(this, solution.getDM());
-    integrator->setIntegrationPatches(patches);
-
-    _setKernelsResidual(integrator, solution, materials);
-    _setKernelsJacobian(integrator, solution, materials);
-
-    PYLITH_METHOD_RETURN(integrator);
-} // createIntegrator
-
-
-// ------------------------------------------------------------------------------------------------
 // Create auxiliary field.
 pylith::topology::Field*
 pylith::faults::FaultCohesiveKin::createAuxiliaryField(const pylith::topology::Field& solution,

--- a/libsrc/pylith/faults/FaultCohesiveKin.hh
+++ b/libsrc/pylith/faults/FaultCohesiveKin.hh
@@ -64,15 +64,6 @@ public:
      */
     void verifyConfiguration(const pylith::topology::Field& solution) const;
 
-    /** Create integrator and set kernels.
-     *
-     * @param[in] solution Solution field.
-     * @param[in] materials Materials in problem.
-     * @returns Integrator if applicable, otherwise NULL.
-     */
-    pylith::feassemble::Integrator* createIntegrator(const pylith::topology::Field& solution,
-                                                     const std::vector<pylith::materials::Material*>& materials);
-
     /** Create auxiliary field.
      *
      * @param[in] solution Solution field.

--- a/tests/mmstests/incompressibleelasticity/nofaults-2d/TestIncompressibleElasticity.hh
+++ b/tests/mmstests/incompressibleelasticity/nofaults-2d/TestIncompressibleElasticity.hh
@@ -118,7 +118,7 @@ public:
     /// Array of functions providing exact solution time derivative.
     pylith::testing::MMSTest::solution_fn* exactSolnDotFns;
 
-    int numAuxSubfields; ///< Number of auxiliary subfields.
+    size_t numAuxSubfields; ///< Number of auxiliary subfields.
     const char** auxSubfields; ///< Names of auxiliary subfields.
     pylith::topology::Field::Discretization* auxDiscretizations; ///< Discretizations for auxiliary subfields.
     spatialdata::spatialdb::UserFunctionDB auxDB; ///< Spatial database with auxiliary field.

--- a/tests/src/FaultCohesiveStub.cc
+++ b/tests/src/FaultCohesiveStub.cc
@@ -44,6 +44,14 @@ pylith::faults::FaultCohesiveStub::verifyConfiguration(const pylith::topology::F
 
 
 // ------------------------------------------------------------------------------------------------
+// Create integrator and set kernels.
+pylith::feassemble::Integrator*
+pylith::faults::FaultCohesiveStub::createIntegrator(const pylith::topology::Field& solution,
+                                                    const std::vector<pylith::materials::Material*>& materials) {
+    return NULL;
+}
+
+// ------------------------------------------------------------------------------------------------
 // Create auxiliary field.
 pylith::topology::Field*
 pylith::faults::FaultCohesiveStub::createAuxiliaryField(const pylith::topology::Field& solution,
@@ -77,14 +85,6 @@ pylith::faults::FaultCohesiveStub::_setKernelsJacobian(pylith::feassemble::Integ
                                                        const pylith::topology::Field& solution,
                                                        const std::vector<pylith::materials::Material*>& materials) const {}
 
-
-// ------------------------------------------------------------------------------------------------
-// Create integrator and set kernels.
-pylith::feassemble::Integrator*
-pylith::faults::FaultCohesiveStub::createIntegrator(const pylith::topology::Field& solution,
-                                                    const std::vector<pylith::materials::Material*>& materials) {
-    return NULL;
-}
 
 
 // End of file


### PR DESCRIPTION
`createIntegrator()` is implemented in `FaultCohesive` with identical implementation in `FaultCohesiveKin` and `FaultCohesiveImpulses`. There is no reason for this duplicate code and we can just use the implementation in `FaultCohesive`.

