### PR TITLE
Update PETSc to 3.19.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ AC_CHECK_HEADER([mpi.h], [], [AC_MSG_ERROR([header 'mpi.h' not found])])
 
 dnl PETSC
 AC_LANG(C)
-CIT_PATH_PETSC([3.19.4])
+CIT_PATH_PETSC([3.19.5])
 CIT_HEADER_PETSC
 CIT_CHECK_LIB_PETSC
 

--- a/libsrc/pylith/meshio/DataWriter.hh
+++ b/libsrc/pylith/meshio/DataWriter.hh
@@ -146,6 +146,18 @@ protected:
     void getCoordsGlobalVec(PetscVec* coordinatesVec,
                             const pylith::topology::Mesh& mesh);
 
+    /** Write PETSc Vec using viewer.
+     *
+     * This method allows us to circumvent the usual place a vector is written and write it to
+     * a desired location. See DMPlexGlobalVectorView_HDF5_Internal() in plexhdf5.c in PETSc.
+     *
+     * @param[in] vector PETSc Vec to write.
+     * @param[inout] viewer PETSc viewer to use to write vector.
+     */
+    static
+    void _writeVec(PetscVec vector,
+                   PetscViewer viewer);
+
     // NOT IMPLEMENTED //////////////////////////////////////////////////////
 private:
 

--- a/libsrc/pylith/meshio/DataWriterHDF5.cc
+++ b/libsrc/pylith/meshio/DataWriterHDF5.cc
@@ -40,15 +40,6 @@
 #include <sstream> // USES std::ostringstream
 #include <stdexcept> // USES std::runtime_error
 
-extern "C" {
-    extern PetscErrorCode VecView_Seq(Vec,
-                                      PetscViewer);
-
-    extern PetscErrorCode VecView_MPI(Vec,
-                                      PetscViewer);
-
-}
-
 #if H5_VERS_MAJOR == 1 && H5_VERS_MINOR >= 8
 #define PYLITH_HDF5_USE_API_18
 #endif
@@ -207,13 +198,7 @@ pylith::meshio::DataWriterHDF5::writeVertexField(const PylithScalar t,
         err = PetscViewerHDF5SetTimestep(_viewer, istep);PYLITH_CHECK_ERROR(err);
 
         PetscVec vector = subfield.getVector();assert(vector);
-        PetscBool isseq;
-        err = PetscObjectTypeCompare((PetscObject) vector, VECSEQ, &isseq);PYLITH_CHECK_ERROR(err);
-        if (isseq) {
-            err = VecView_Seq(vector, _viewer);PYLITH_CHECK_ERROR(err);
-        } else {
-            err = VecView_MPI(vector, _viewer);PYLITH_CHECK_ERROR(err);
-        }
+        DataWriter::_writeVec(vector, _viewer);PYLITH_CHECK_ERROR(err);
         err = PetscViewerHDF5PopTimestepping(_viewer);PYLITH_CHECK_ERROR(err);
         err = PetscViewerHDF5PopGroup(_viewer);PYLITH_CHECK_ERROR(err);
 
@@ -276,13 +261,7 @@ pylith::meshio::DataWriterHDF5::writeCellField(const PylithScalar t,
         err = PetscViewerHDF5SetTimestep(_viewer, istep);PYLITH_CHECK_ERROR(err);
 
         PetscVec vector = subfield.getVector();assert(vector);
-        PetscBool isseq;
-        err = PetscObjectTypeCompare((PetscObject) vector, VECSEQ, &isseq);PYLITH_CHECK_ERROR(err);
-        if (isseq) {
-            err = VecView_Seq(vector, _viewer);PYLITH_CHECK_ERROR(err);
-        } else {
-            err = VecView_MPI(vector, _viewer);PYLITH_CHECK_ERROR(err);
-        } // if/else
+        DataWriter::_writeVec(vector, _viewer);
         err = PetscViewerHDF5PopTimestepping(_viewer);PYLITH_CHECK_ERROR(err);
         err = PetscViewerHDF5PopGroup(_viewer);PYLITH_CHECK_ERROR(err);
 

--- a/libsrc/pylith/meshio/DataWriterHDF5Ext.cc
+++ b/libsrc/pylith/meshio/DataWriterHDF5Ext.cc
@@ -37,15 +37,6 @@
 #include <sstream> // USES std::ostringstream
 #include <stdexcept> // USES std::runtime_error
 
-extern "C" {
-    extern PetscErrorCode VecView_Seq(Vec,
-                                      PetscViewer);
-
-    extern PetscErrorCode VecView_MPI(Vec,
-                                      PetscViewer);
-
-}
-
 // ----------------------------------------------------------------------
 // Constructor
 pylith::meshio::DataWriterHDF5Ext::DataWriterHDF5Ext(void) :
@@ -195,13 +186,7 @@ pylith::meshio::DataWriterHDF5Ext::writeVertexField(const PylithScalar t,
         assert(binaryViewer);
 
         PetscVec vector = subfield.getVector();assert(vector);
-        PetscBool isseq;
-        err = PetscObjectTypeCompare((PetscObject) vector, VECSEQ, &isseq);PYLITH_CHECK_ERROR(err);
-        if (isseq) {
-            err = VecView_Seq(vector, binaryViewer);PYLITH_CHECK_ERROR(err);
-        } else {
-            err = VecView_MPI(vector, binaryViewer);PYLITH_CHECK_ERROR(err);
-        } // if/else
+        DataWriter::_writeVec(vector, binaryViewer);
 
         ExternalDataset& datasetInfo = _datasets[name];
         ++datasetInfo.numTimeSteps;
@@ -339,13 +324,7 @@ pylith::meshio::DataWriterHDF5Ext::writeCellField(const PylithScalar t,
         assert(binaryViewer);
 
         PetscVec vector = subfield.getVector();assert(vector);
-        PetscBool isseq;
-        err = PetscObjectTypeCompare((PetscObject) vector, VECSEQ, &isseq);PYLITH_CHECK_ERROR(err);
-        if (isseq) {
-            err = VecView_Seq(vector, binaryViewer);PYLITH_CHECK_ERROR(err);
-        } else {
-            err = VecView_MPI(vector, binaryViewer);PYLITH_CHECK_ERROR(err);
-        } // if/else
+        DataWriter::_writeVec(vector, binaryViewer);
 
         ExternalDataset& datasetInfo = _datasets[name];
         ++datasetInfo.numTimeSteps;

--- a/tests/mmstests/linearelasticity/faults-2d/ThreeBlocksStatic.cc
+++ b/tests/mmstests/linearelasticity/faults-2d/ThreeBlocksStatic.cc
@@ -213,6 +213,7 @@ public:
         data->journalName = "ThreeBlocksStatic";
 
         data->isJacobianLinear = true;
+        data->allowZeroResidual = true;
 
         data->meshFilename = ":UNKNOWN:"; // Set in child class.
 


### PR DESCRIPTION
- Update to PETSc 3.19.5.
- Use `VecView()` instead of private `VecView_Seq()` and `VecView_MPI()`.
- Allow zero residual in MMS test with rigid block motion.
