### PR TITLE
FIX: Add reference stress and strain to pool of IsotropicLinearPoroelasticity auxiliary subfields

### DIFF
--- a/pylith/materials/AuxSubfieldsIsotropicLinearPoroelasticity.py
+++ b/pylith/materials/AuxSubfieldsIsotropicLinearPoroelasticity.py
@@ -53,6 +53,12 @@ class AuxSubfieldsIsotropicLinearPoroelasticity(PetscComponent):
     biotModulus = pythia.pyre.inventory.facility("biot_modulus", family="auxiliary_subfield", factory=Subfield)
     biotModulus.meta['tip'] = "Biot modulus subfield."
 
+    referenceStress = pythia.pyre.inventory.facility("reference_stress", family="auxiliary_subfield", factory=Subfield)
+    referenceStress.meta['tip'] = "Reference stress subfield."
+
+    referenceStrain = pythia.pyre.inventory.facility("reference_strain", family="auxiliary_subfield", factory=Subfield)
+    referenceStrain.meta['tip'] = "Reference strain subfield."
+
     # PUBLIC METHODS /////////////////////////////////////////////////////
 
     def __init__(self, name="auxfieldsisotropiclinearporoelasticity"):


### PR DESCRIPTION
Reference stress and strain were missing from the pool of subfields (used to set discretization information) for IsotropicLinearPoroelasticity.

Fixes #652 