### PR TITLE
A couple of fixes for the cubit cellsize example.

### DIFF
--- a/examples/meshing-cubit/cellsize/mesh_cellsize.jou
+++ b/examples/meshing-cubit/cellsize/mesh_cellsize.jou
@@ -34,10 +34,10 @@ mesh volume all
 # ----------------------------------------------------------------------
 # Export exodus file
 # ----------------------------------------------------------------------
-set large exodus off
 # Create one block so all sizing function information is in one block.
 block 1 volume all
 export mesh "mesh_cellsize.exo" dimension 3 overwrite
 
 
 # End of file
+


### PR DESCRIPTION
Made a few changes to exodus_add_properties.py script, and removed 'set large exodus off' from Cubit journal file.