### PR TITLE
Update m4 macros (numpy v2 compatibility)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ The version numbers are in the form `MAJOR.MINOR.PATCH`, where major releases in
 * **Added**
 * **Fixed**
   * Fix inconsistency in normal direction on fault surfaces. Orientation was correct but direction was flipped at some locations. This affected local slip direction and the resulting deformation close to the fault. This bug fix was not in version 4.1.3.
+  * Update autoconf macros for numpy for compatibility with location of include files in numpy version 2.x.
 
 ## Version 4.1.3 (2024/07/31)
 

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ dnl ============================================================================
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([PyLith], [4.1.3], [https://geodynamics.org/resources/pylith])
+AC_INIT([PyLith], [4.2.0dev], [https://geodynamics.org/resources/pylith])
 AC_CONFIG_AUX_DIR([./aux-config])
 AC_CONFIG_HEADER([portinfo])
 AC_CONFIG_MACRO_DIR([m4])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2010-2024, University of California, Davis'
 author = 'Brad T. Aagaard, Matthew G. Knepley, Charles A. Williams'
 
 # The full version, including alpha/beta/rc tags
-release = '4.1.3'
+release = '4.2.0dev'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pylith/__init__.py
+++ b/pylith/__init__.py
@@ -8,7 +8,7 @@
 # See https://mit-license.org/ and LICENSE.md and for license information. 
 # =================================================================================================
 
-__version__ = "4.1.3"
+__version__ = "4.2.0dev"
 
 __all__ = ['apps',
            'bc',

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ tag_date = 0
 
 [metadata]
 name = pylith
-version = 4.1.3
+version = 4.2.0dev
 author = Brad Aagaard, Matthew Knepley, Charles Williams
 author_email = baagaard@usgs.gov, knepley@buffalo.edu, c.williams@gns.cri.nz
 description = Finite-element software for modeling crustal deformation with an emphasis on earthquake faulting.


### PR DESCRIPTION
- Update m4 macros for compatibility with numpy v2
- Set version to 4.2.0dev