### PR TITLE
Add ability to check scale of material properties when getting values from spatial databases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ The version numbers are in the form `MAJOR.MINOR.PATCH`, where major releases in
 * **Added**
   * Default filenames for progress monitor and parameters file are set from the simulation name like
   the other output files.
+  * Consistency check for material properties and scales used in nondimensionalization (currently just the shear modulus).
   * Add section to User Guide on troubleshooting solver issues.
 * **Changed**
   * Switch CI from Azure Pipelines to GitHub Actions.

--- a/libsrc/pylith/materials/AuxiliaryFactoryElastic.cc
+++ b/libsrc/pylith/materials/AuxiliaryFactoryElastic.cc
@@ -55,6 +55,7 @@ pylith::materials::AuxiliaryFactoryElastic::addShearModulus(void) {
     description.componentNames[0] = subfieldName;
     description.scale = pressureScale;
     description.validator = pylith::topology::FieldQuery::validatorNonnegative;
+    description.validatorTolerance = 25.0;
 
     _field->subfieldAdd(description, getSubfieldDiscretization(subfieldName));
     pylith::materials::Query::shearModulusFromVM(subfieldName, this);

--- a/libsrc/pylith/materials/AuxiliaryFactoryElasticity.cc
+++ b/libsrc/pylith/materials/AuxiliaryFactoryElasticity.cc
@@ -72,7 +72,11 @@ pylith::materials::AuxiliaryFactoryElasticity::addBodyForce(void) {
     PYLITH_JOURNAL_DEBUG("addBodyForce(void)");
 
     const char* subfieldName = "body_force";
-    const char* componentNames[3] = { "body_force_x", "body_force_y", "body_force_z" };
+    const char* componentNames[3] = {
+        "body_force_x",
+        "body_force_y",
+        "body_force_z",
+    };
 
     const PylithReal forceScale = _normalizer->getPressureScale() / _normalizer->getLengthScale();
 

--- a/libsrc/pylith/materials/AuxiliaryFactoryPoroelastic.cc
+++ b/libsrc/pylith/materials/AuxiliaryFactoryPoroelastic.cc
@@ -39,7 +39,7 @@ pylith::materials::AuxiliaryFactoryPoroelastic::~AuxiliaryFactoryPoroelastic(voi
 // ----------------------------------------------------------------------------
 // Add isotropic permeability subfield to auxiliary fields.
 void
-pylith::materials::AuxiliaryFactoryPoroelastic::addIsotropicPermeability(void) { // isotropicPermeablity
+pylith::materials::AuxiliaryFactoryPoroelastic::addIsotropicPermeability(void) {
     PYLITH_METHOD_BEGIN;
     PYLITH_JOURNAL_DEBUG("addIsotropicPermeability(void)");
 
@@ -56,7 +56,8 @@ pylith::materials::AuxiliaryFactoryPoroelastic::addIsotropicPermeability(void) {
     description.componentNames.resize(1);
     description.componentNames[0] = subfieldName;
     description.scale = permeabilityScale;
-    description.validator = NULL;
+    // description.validator = pylith::topology::FieldQuery::validatorScale;
+    // description.validatorTolerance = 10.0;
 
     _field->subfieldAdd(description, getSubfieldDiscretization(subfieldName));
     this->setSubfieldQuery(subfieldName);
@@ -68,7 +69,7 @@ pylith::materials::AuxiliaryFactoryPoroelastic::addIsotropicPermeability(void) {
 // ----------------------------------------------------------------------------
 // Add isotropic permeability subfield to auxiliary fields.
 void
-pylith::materials::AuxiliaryFactoryPoroelastic::addTensorPermeability(void) { // tensorPermeablity
+pylith::materials::AuxiliaryFactoryPoroelastic::addTensorPermeability(void) {
     PYLITH_METHOD_BEGIN;
     PYLITH_JOURNAL_DEBUG("addTensorPermeability(void)");
 
@@ -95,7 +96,8 @@ pylith::materials::AuxiliaryFactoryPoroelastic::addTensorPermeability(void) { //
         description.componentNames[i] = componentNames[i];
     } // for
     description.scale = permeabilityScale;
-    description.validator = NULL;
+    // description.validator = pylith::topology::FieldQuery::validatorScale;
+    // description.validatorTolerance = 10.0;
 
     _field->subfieldAdd(description, getSubfieldDiscretization(subfieldName));
     this->setSubfieldQuery(subfieldName);
@@ -107,7 +109,7 @@ pylith::materials::AuxiliaryFactoryPoroelastic::addTensorPermeability(void) { //
 // --------------------------------------------------------------------
 // Add drained bulk modulus subfield to auxiliary fields.
 void
-pylith::materials::AuxiliaryFactoryPoroelastic::addDrainedBulkModulus(void) { // DrainedBulkModulus
+pylith::materials::AuxiliaryFactoryPoroelastic::addDrainedBulkModulus(void) {
     PYLITH_METHOD_BEGIN;
     PYLITH_JOURNAL_DEBUG("addDrainedBulkModulus(void)");
 
@@ -123,6 +125,7 @@ pylith::materials::AuxiliaryFactoryPoroelastic::addDrainedBulkModulus(void) { //
     description.componentNames[0] = subfieldName;
     description.scale = pressureScale;
     description.validator = pylith::topology::FieldQuery::validatorPositive;
+    description.validatorTolerance = 25.0;
 
     _field->subfieldAdd(description, getSubfieldDiscretization(subfieldName));
     this->setSubfieldQuery(subfieldName);
@@ -134,7 +137,7 @@ pylith::materials::AuxiliaryFactoryPoroelastic::addDrainedBulkModulus(void) { //
 // ---------------------------------------------------------------------
 // Add biot coefficient subfield to auxiliary fields.
 void
-pylith::materials::AuxiliaryFactoryPoroelastic::addBiotCoefficient(void) { // biotCoefficient
+pylith::materials::AuxiliaryFactoryPoroelastic::addBiotCoefficient(void) {
     PYLITH_METHOD_BEGIN;
     PYLITH_JOURNAL_DEBUG("addBiotCoefficient(void)");
 
@@ -149,6 +152,7 @@ pylith::materials::AuxiliaryFactoryPoroelastic::addBiotCoefficient(void) { // bi
     description.componentNames[0] = subfieldName;
     description.scale = 1.0;
     description.validator = pylith::topology::FieldQuery::validatorPositive;
+    description.validatorTolerance = 10.0;
 
     _field->subfieldAdd(description, getSubfieldDiscretization(subfieldName));
     this->setSubfieldQuery(subfieldName);
@@ -160,7 +164,7 @@ pylith::materials::AuxiliaryFactoryPoroelastic::addBiotCoefficient(void) { // bi
 // ---------------------------------------------------------------------
 // Add biot modulus subfield to auxiliary fields.
 void
-pylith::materials::AuxiliaryFactoryPoroelastic::addBiotModulus(void) { // biotCoefficient
+pylith::materials::AuxiliaryFactoryPoroelastic::addBiotModulus(void) {
     PYLITH_METHOD_BEGIN;
     PYLITH_JOURNAL_DEBUG("addBiotModulus(void)");
 
@@ -176,6 +180,7 @@ pylith::materials::AuxiliaryFactoryPoroelastic::addBiotModulus(void) { // biotCo
     description.componentNames[0] = subfieldName;
     description.scale = pressureScale;
     description.validator = pylith::topology::FieldQuery::validatorPositive;
+    description.validatorTolerance = 25.0;
 
     _field->subfieldAdd(description, getSubfieldDiscretization(subfieldName));
     pylith::materials::Query::biotModulusFromInput(subfieldName, this);
@@ -187,7 +192,7 @@ pylith::materials::AuxiliaryFactoryPoroelastic::addBiotModulus(void) { // biotCo
 // ----------------------------------------------------------------------
 // Add reference stress subfield to auxiliary fields.
 void
-pylith::materials::AuxiliaryFactoryPoroelastic::addReferenceStress(void) { // referenceStress
+pylith::materials::AuxiliaryFactoryPoroelastic::addReferenceStress(void) {
     PYLITH_METHOD_BEGIN;
     PYLITH_JOURNAL_DEBUG("addReferenceStress(void)");
 
@@ -225,7 +230,7 @@ pylith::materials::AuxiliaryFactoryPoroelastic::addReferenceStress(void) { // re
 // ----------------------------------------------------------------------
 // Add reference strain subfield to auxiliary fields.
 void
-pylith::materials::AuxiliaryFactoryPoroelastic::addReferenceStrain(void) { // addReferenceStrain
+pylith::materials::AuxiliaryFactoryPoroelastic::addReferenceStrain(void) {
     PYLITH_METHOD_BEGIN;
     PYLITH_JOURNAL_DEBUG("addRefrenceStrain(void)");
 

--- a/libsrc/pylith/materials/AuxiliaryFactoryPoroelasticity.cc
+++ b/libsrc/pylith/materials/AuxiliaryFactoryPoroelasticity.cc
@@ -116,7 +116,7 @@ pylith::materials::AuxiliaryFactoryPoroelasticity::addPorosity(void) { // porosi
     PYLITH_JOURNAL_DEBUG("addPorosity(void)");
 
     const char* subfieldName = "porosity";
-    const PylithReal noScale = 1;
+    const PylithReal noScale = 1.0;
 
     pylith::topology::Field::Description description;
     description.label = subfieldName;

--- a/libsrc/pylith/materials/AuxiliaryFactoryPoroelasticity.hh
+++ b/libsrc/pylith/materials/AuxiliaryFactoryPoroelasticity.hh
@@ -10,11 +10,11 @@
 #pragma once
 
 #include "pylith/materials/materialsfwd.hh" // forward declarations
-#include "pylith/feassemble/AuxiliaryFactory.hh" // ISA AuxiliaryFactory
+#include "pylith/materials/AuxiliaryFactoryElasticity.hh" // ISA AuxiliaryFactory
 
 #include "spatialdata/spatialdb/spatialdbfwd.hh" // USES GravityField
 
-class pylith::materials::AuxiliaryFactoryPoroelasticity : public pylith::feassemble::AuxiliaryFactory {
+class pylith::materials::AuxiliaryFactoryPoroelasticity : public pylith::materials::AuxiliaryFactoryElasticity {
     friend class TestAuxiliaryFactoryPoroelasticity; // unit testing
 
     // PUBLIC METHODS //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/libsrc/pylith/materials/AuxiliaryFactoryViscoelastic.cc
+++ b/libsrc/pylith/materials/AuxiliaryFactoryViscoelastic.cc
@@ -114,8 +114,11 @@ pylith::materials::AuxiliaryFactoryViscoelastic::addShearModulusRatioGeneralized
     description.vectorFieldType = pylith::topology::Field::OTHER;
     description.numComponents = 3;
     description.componentNames.resize(3);
-    const char* componentNames[3] = { "shear_modulus_ratio_1", "shear_modulus_ratio_2",
-                                      "shear_modulus_ratio_3" };
+    const char* componentNames[3] = {
+        "shear_modulus_ratio_1",
+        "shear_modulus_ratio_2",
+        "shear_modulus_ratio_3",
+    };
     for (int i = 0; i < 3; ++i) {
         description.componentNames[i] = componentNames[i];
     } // for

--- a/libsrc/pylith/materials/Query.cc
+++ b/libsrc/pylith/materials/Query.cc
@@ -222,9 +222,9 @@ pylith::materials::_Query::vmToShearModulus(PylithScalar valueSubfield[],
 
     std::ostringstream msg;
     if (density <= 0) {
-        msg << "Found negative density (" << density << ").";
+        msg << "Found non-positive density (" << density << ").";
     } // if
-    if (vs <= 0) {
+    if (vs < 0) {
         msg << "Found negative shear wave speed (" << vs << ").";
     } // if
 
@@ -257,13 +257,13 @@ pylith::materials::_Query::vmToBulkModulus(PylithScalar valueSubfield[],
 
     std::ostringstream msg;
     if (density <= 0) {
-        msg << "Found nonpositive density (" << density << ").";
+        msg << "Found non-positive density (" << density << ").";
     } // if
     if (vs < 0) {
         msg << "Found negative shear wave speed (" << vs << ").";
     } // if
     if (vp <= 0) {
-        msg << "Found nonpositive dilatational wave speed (" << vp << ").";
+        msg << "Found non-positive dilatational wave speed (" << vp << ").";
     } // if
 
     PYLITH_METHOD_RETURN(msg.str());
@@ -296,13 +296,13 @@ pylith::materials::_Query::vmToMaxwellTime(PylithScalar valueSubfield[],
 
     std::ostringstream msg;
     if (density <= 0) {
-        msg << "Found negative density (" << density << ").";
+        msg << "Found non-positive density (" << density << ").";
     } // if
     if (vs <= 0) {
-        msg << "Found negative shear wave speed (" << vs << ").";
+        msg << "Found non-positive shear wave speed (" << vs << ").";
     } // if
     if (viscosity <= 0) {
-        msg << "Found nonpositive viscosity (" << viscosity << ").";
+        msg << "Found non-positive viscosity (" << viscosity << ").";
     } // if
 
     PYLITH_METHOD_RETURN(msg.str());
@@ -351,28 +351,28 @@ pylith::materials::_Query::vmToGeneralizedMaxwellTimes(PylithScalar valueSubfiel
 
     std::ostringstream msg;
     if (density <= 0) {
-        msg << "Found negative density (" << density << ").";
+        msg << "Found non-positive density (" << density << ").";
     } // if
     if (vs <= 0) {
-        msg << "Found negative shear wave speed (" << vs << ").";
+        msg << "Found non-positive shear wave speed (" << vs << ").";
     } // if
     if (viscosity1 <= 0) {
-        msg << "Found nonpositive viscosity 1 (" << viscosity1 << ").";
+        msg << "Found non-positive viscosity 1 (" << viscosity1 << ").";
     } // if
     if (viscosity2 <= 0) {
-        msg << "Found nonpositive viscosity 2 (" << viscosity2 << ").";
+        msg << "Found non-positive viscosity 2 (" << viscosity2 << ").";
     } // if
     if (viscosity3 <= 0) {
-        msg << "Found nonpositive viscosity 3 (" << viscosity3 << ").";
+        msg << "Found non-positive viscosity 3 (" << viscosity3 << ").";
     } // if
     if (shearModulusRatio1 <= 0) {
-        msg << "Found negative shear modulus ratio 1 (" << shearModulusRatio1 << ").";
+        msg << "Found non-positive shear modulus ratio 1 (" << shearModulusRatio1 << ").";
     } // if
     if (shearModulusRatio2 <= 0) {
-        msg << "Found negative shear modulus ratio 2 (" << shearModulusRatio2 << ").";
+        msg << "Found non-positive shear modulus ratio 2 (" << shearModulusRatio2 << ").";
     } // if
     if (shearModulusRatio3 <= 0) {
-        msg << "Found negative shear modulus ratio 3 (" << shearModulusRatio3 << ").";
+        msg << "Found non-positive shear modulus ratio 3 (" << shearModulusRatio3 << ").";
     } // if
 
     const double ratioSum = shearModulusRatio1 + shearModulusRatio2 + shearModulusRatio3;
@@ -409,13 +409,13 @@ pylith::materials::_Query::vmToGeneralizedMaxwellShearModulusRatios(PylithScalar
 
     std::ostringstream msg;
     if (shearModulusRatio1 <= 0) {
-        msg << "Found negative shear modulus ratio 1 (" << shearModulusRatio1 << ").";
+        msg << "Found non-positive shear modulus ratio 1 (" << shearModulusRatio1 << ").";
     } // if
     if (shearModulusRatio2 <= 0) {
-        msg << "Found negative shear modulus ratio 2 (" << shearModulusRatio2 << ").";
+        msg << "Found non-positive shear modulus ratio 2 (" << shearModulusRatio2 << ").";
     } // if
     if (shearModulusRatio3 <= 0) {
-        msg << "Found negative shear modulus ratio 3 (" << shearModulusRatio3 << ").";
+        msg << "Found non-positive shear modulus ratio 3 (" << shearModulusRatio3 << ").";
     } // if
     const double ratioSum = shearModulusRatio1 + shearModulusRatio2 + shearModulusRatio3;
     if (ratioSum > 1) {
@@ -498,7 +498,7 @@ pylith::materials::_Query::inputToBiotModulus(PylithScalar valueSubfield[],
         msg << "Found negative porosity (" << porosity << ").";
     } // if
     if (biot_coefficient <= 0) {
-        msg << "Found negative biot coefficient (" << biot_coefficient << ").";
+        msg << "Found non-positive biot coefficient (" << biot_coefficient << ").";
     } // if
 
     // Debug

--- a/libsrc/pylith/topology/FieldBase.hh
+++ b/libsrc/pylith/topology/FieldBase.hh
@@ -46,7 +46,9 @@ public:
 public:
 
     /// Function prototype for validator functions.
-    typedef const char* (*validatorfn_type)(const PylithReal);
+    typedef std::string (*validatorfn_type)(const PylithReal /*value */,
+                                            const PylithReal /* scale */,
+                                            const PylithReal /* tolerance */);
 
     // PUBLIC STRUCTS ///////////////////////////////////////////////////////
 public:
@@ -58,6 +60,7 @@ public:
         pylith::string_vector componentNames; ///< Names of components.
         size_t numComponents; ///< Number of components.
         PylithReal scale; ///< Dimension scale associated with values.
+        PylithReal validatorTolerance; ///< Tolerance relative to scale for validation.
         validatorfn_type validator; ///< Validator for values in field;
         bool hasHistory; ///< Has subfields with history, i.e., state variables.
         size_t historySize; ///< Number of points in time history (currently only).
@@ -68,6 +71,7 @@ public:
             vectorFieldType(OTHER),
             numComponents(0),
             scale(1.0),
+            validatorTolerance(0.0),
             validator(NULL),
             hasHistory(false),
             historySize(0) {}
@@ -79,6 +83,7 @@ public:
                     const size_t numComponentsValue=0,
                     const VectorFieldEnum vectorFieldTypeValue=SCALAR,
                     const PylithReal scaleValue=1.0,
+                    const PylithReal validatorToleranceValue=0.0,
                     const validatorfn_type validatorValue=NULL,
                     bool isFaultOnlyValue=false,
                     bool hasHistoryValue=false,
@@ -89,6 +94,7 @@ public:
             componentNames(componentNamesValue),
             numComponents(numComponentsValue),
             scale(scaleValue),
+            validatorTolerance(validatorToleranceValue),
             validator(validatorValue),
             hasHistory(hasHistoryValue),
             historySize(historySizeValue) {}

--- a/libsrc/pylith/topology/FieldQuery.hh
+++ b/libsrc/pylith/topology/FieldQuery.hh
@@ -36,6 +36,11 @@ class pylith::topology::FieldQuery {
     // PUBLIC TYPEDEF ///////////////////////////////////////////////////////
 public:
 
+    static const PylithReal SCALE_TOLERANCE;
+
+    // PUBLIC TYPEDEF ///////////////////////////////////////////////////////
+public:
+
     /** Function prototype for converter functions.
      *
      * @param[out] values Values for subfield.
@@ -133,19 +138,48 @@ public:
 
     /** Validator for positive values.
      *
+     * If scale and tolerance are greater than zero, then the value must be
+     * in the range [scale/tolerance, scale*tolerance].
+     *
      * @param[in] value Value to validate.
-     * @returns Error message if not positive, NULL otherwise.
+     * @param[in] scale Scale for nondimensionalization.
+     * @param[in] tolerance Tolerance relative to scale for validation.
+     * @returns Error message if not positive, empty string otherwise.
      */
     static
-    const char* validatorPositive(const PylithReal value);
+    std::string validatorPositive(const PylithReal value,
+                                  const PylithReal scale,
+                                  const PylithReal tolerance);
 
     /** Validator for nonnegative values.
      *
+     * If scale and tolerance are greater than zero, then the value must be
+     * in the range [scale/tolerance, scale*tolerance].
+     *
      * @param[in] value Value to validate.
-     * @returns Error message if negative, NULL otherwise.
+     * @param[in] scale Scale for nondimensionalization.
+     * @param[in] tolerance Tolerance relative to scale for validation.
+     * @returns Error message if negative, empty string otherwise.
      */
     static
-    const char* validatorNonnegative(const PylithReal value);
+    std::string validatorNonnegative(const PylithReal value,
+                                     const PylithReal scale,
+                                     const PylithReal tolerance);
+
+    /** Validator for scale only.
+     *
+     * If scale and tolerance are greater than zero, then the value must be
+     * in the range [scale/tolerance, scale*tolerance].
+     *
+     * @param[in] value Value to validate.
+     * @param[in] scale Scale for nondimensionalization.
+     * @param[in] tolerance Tolerance relative to scale for validation.
+     * @returns Error message if negative, empty string otherwise.
+     */
+    static
+    std::string validatorScale(const PylithReal value,
+                               const PylithReal scale,
+                               const PylithReal tolerance);
 
     // PRIVATE TYPEDEFS /////////////////////////////////////////////////////
 private:
@@ -178,6 +212,7 @@ private:
         const spatialdata::geocoords::CoordSys* cs; ///< Coordinate system of input point locations.
         PylithReal lengthScale; ///< Length scale for dimensionalizing coordinates.
         PylithReal valueScale; ///< Scale for dimensionalizing values for subfield.
+        PylithReal validatorTolerance; ///< Tolerance relative to valueScale for validation.
         std::string description; ///< Name of value;
         pylith::scalar_array queryValues; ///< Values returned by spatial database query;
         pylith::int_array queryIndices; ///< Indices of spatial database values to use for subfield.
@@ -189,6 +224,7 @@ private:
             cs(NULL),
             lengthScale(1.0),
             valueScale(1.0),
+            validatorTolerance(0.0),
             description("unknown"),
             converter(NULL),
             validator(NULL) {}

--- a/tests/libtests/materials/TestAuxiliaryFactoryElasticity.cc
+++ b/tests/libtests/materials/TestAuxiliaryFactoryElasticity.cc
@@ -34,12 +34,6 @@ pylith::materials::TestAuxiliaryFactoryElasticity::TestAuxiliaryFactoryElasticit
     _data(data) {
     PYLITH_METHOD_BEGIN;
 
-    assert(_data->normalizer);
-    _data->normalizer->setLengthScale(1.0e+03);
-    _data->normalizer->setTimeScale(2.0);
-    _data->normalizer->setDensityScale(3.0e+3);
-    _data->normalizer->setPressureScale(2.25e+10);
-
     pylith::topology::Field::SubfieldInfo info;
     pylith::string_vector componentNames;
 
@@ -53,6 +47,7 @@ pylith::materials::TestAuxiliaryFactoryElasticity::TestAuxiliaryFactoryElasticit
         componentNames.size(),
         pylith::topology::Field::SCALAR,
         _data->normalizer->getDensityScale(),
+        0.0,
         pylith::topology::FieldQuery::validatorPositive
         );
     info.fe = pylith::topology::Field::Discretization(

--- a/tests/libtests/materials/TestAuxiliaryFactoryElasticity_Cases.cc
+++ b/tests/libtests/materials/TestAuxiliaryFactoryElasticity_Cases.cc
@@ -40,17 +40,24 @@ public:
 
 private:
 
+    static const PylithReal LENGTH_SCALE;
+    static const PylithReal TIME_SCALE;
+    static const PylithReal PRESSURE_SCALE;
+    static const PylithReal DENSITY_SCALE;
+
+private:
+
     static
     double density_2d(const double x,
                       const double y) {
-        return 6.4 + 3.0*fabs(x) + 2.0*fabs(y);
+        return 2500.0 + 3.0*fabs(x)/LENGTH_SCALE + 2.0*fabs(y)/LENGTH_SCALE;
     } // density
 
     static
     double density_3d(const double x,
                       const double y,
                       const double z) {
-        return 6.4 + 3.0*fabs(x) + 2.0*fabs(y) + 1.1*fabs(z);
+        return 2500.0 + 3.0*fabs(x) + 2.0*fabs(y)/LENGTH_SCALE + 1.1*fabs(z)/LENGTH_SCALE;
     } // density
 
     static
@@ -61,34 +68,34 @@ private:
     static
     double body_force_2d_x(const double x,
                            const double y) {
-        return -0.3*x*y + 0.2*y*y;
+        return -0.3*x*y/(LENGTH_SCALE*LENGTH_SCALE) + 0.2*y*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // body_force_x
 
     static
     double body_force_2d_y(const double x,
                            const double y) {
-        return +0.3*x*x + 0.2*x*y;
+        return +0.3*x*x/(LENGTH_SCALE*LENGTH_SCALE) + 0.2*x*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // body_force_y
 
     static
     double body_force_3d_x(const double x,
                            const double y,
                            const double z) {
-        return -0.3*x*y + 0.2*y*y;
+        return -0.3*x*y/(LENGTH_SCALE*LENGTH_SCALE) + 0.2*y*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // body_force_x
 
     static
     double body_force_3d_y(const double x,
                            const double y,
                            const double z) {
-        return +0.3*x*x + 0.2*x*y;
+        return +0.3*x*x/(LENGTH_SCALE*LENGTH_SCALE) + 0.2*x*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // body_force_y
 
     static
     double body_force_3d_z(const double x,
                            const double y,
                            const double z) {
-        return +0.3*x*y + 0.2*x*z;
+        return +0.3*x*y/(LENGTH_SCALE*LENGTH_SCALE) + 0.2*x*z/(LENGTH_SCALE*LENGTH_SCALE);
     } // body_force_z
 
     static
@@ -151,6 +158,11 @@ TEST_CASE("TestAuxiliaryFactoryElasticity::Hex::testSetValuesFromDB", "[TestAuxi
     pylith::materials::TestAuxiliaryFactoryElasticity(pylith::materials::TestAuxiliaryFactoryElasticity_Cases::Hex()).testSetValuesFromDB();
 }
 
+const PylithReal pylith::materials::TestAuxiliaryFactoryElasticity_Cases::LENGTH_SCALE = 1.0e+3;
+const PylithReal pylith::materials::TestAuxiliaryFactoryElasticity_Cases::TIME_SCALE = 2.0;
+const PylithReal pylith::materials::TestAuxiliaryFactoryElasticity_Cases::PRESSURE_SCALE = 2.0e+10;
+const PylithReal pylith::materials::TestAuxiliaryFactoryElasticity_Cases::DENSITY_SCALE = 3.0e+3;
+
 // ------------------------------------------------------------------------------------------------
 pylith::materials::TestAuxiliaryFactoryElasticity_Data*
 pylith::materials::TestAuxiliaryFactoryElasticity_Cases::Tri(void) {
@@ -163,7 +175,11 @@ pylith::materials::TestAuxiliaryFactoryElasticity_Cases::Tri(void) {
     data->cs = new spatialdata::geocoords::CSCart();assert(data->cs);
     data->cs->setSpaceDim(data->dimension);
 
-    data->gravityField->setGravityDir(0.0, -1.0, 0.0);
+    assert(data->normalizer);
+    data->normalizer->setLengthScale(LENGTH_SCALE);
+    data->normalizer->setTimeScale(TIME_SCALE);
+    data->normalizer->setPressureScale(PRESSURE_SCALE);
+    data->normalizer->setDensityScale(DENSITY_SCALE);
 
     assert(data->auxiliaryDB);
     data->auxiliaryDB->addValue("density", density_2d, density_units());
@@ -173,6 +189,9 @@ pylith::materials::TestAuxiliaryFactoryElasticity_Cases::Tri(void) {
     data->auxiliaryDB->addValue("gravitational_acceleration_y", gravity_field_2d_y, gravity_field_units());
     data->auxiliaryDB->setDescription("auxiliary");
     data->auxiliaryDB->setCoordSys(*data->cs);
+
+    assert(data->gravityField);
+    data->gravityField->setGravityDir(0.0, -1.0, 0.0);
 
     return data;
 } // Tri
@@ -190,6 +209,12 @@ pylith::materials::TestAuxiliaryFactoryElasticity_Cases::Hex(void) {
     data->cs = new spatialdata::geocoords::CSCart();assert(data->cs);
     data->cs->setSpaceDim(data->dimension);
 
+    assert(data->normalizer);
+    data->normalizer->setLengthScale(LENGTH_SCALE);
+    data->normalizer->setTimeScale(TIME_SCALE);
+    data->normalizer->setPressureScale(PRESSURE_SCALE);
+    data->normalizer->setDensityScale(DENSITY_SCALE);
+
     assert(data->auxiliaryDB);
     data->auxiliaryDB->addValue("density", density_3d, density_units());
     data->auxiliaryDB->addValue("body_force_x", body_force_3d_x, body_force_units());
@@ -201,6 +226,7 @@ pylith::materials::TestAuxiliaryFactoryElasticity_Cases::Hex(void) {
     data->auxiliaryDB->setDescription("auxiliary");
     data->auxiliaryDB->setCoordSys(*data->cs);
 
+    assert(data->gravityField);
     data->gravityField->setGravityDir(0.0, 0.0, -1.0);
 
     data->subfields["body_force"].description.numComponents = 3;

--- a/tests/libtests/materials/TestAuxiliaryFactoryLinearElastic.cc
+++ b/tests/libtests/materials/TestAuxiliaryFactoryLinearElastic.cc
@@ -36,12 +36,6 @@ pylith::materials::TestAuxiliaryFactoryLinearElastic::TestAuxiliaryFactoryLinear
     _data(data) {
     PYLITH_METHOD_BEGIN;
 
-    assert(_data->normalizer);
-    _data->normalizer->setLengthScale(1.0e+03);
-    _data->normalizer->setTimeScale(2.0);
-    _data->normalizer->setDensityScale(3.0e+3);
-    _data->normalizer->setPressureScale(2.25e+10);
-
     pylith::topology::Field::SubfieldInfo info;
     pylith::string_vector componentNames;
 
@@ -55,6 +49,7 @@ pylith::materials::TestAuxiliaryFactoryLinearElastic::TestAuxiliaryFactoryLinear
         componentNames.size(),
         pylith::topology::Field::SCALAR,
         _data->normalizer->getDensityScale(),
+        0.0,
         pylith::topology::FieldQuery::validatorPositive
         );
     info.fe = pylith::topology::Field::Discretization(
@@ -73,6 +68,7 @@ pylith::materials::TestAuxiliaryFactoryLinearElastic::TestAuxiliaryFactoryLinear
         componentNames.size(),
         pylith::topology::Field::SCALAR,
         _data->normalizer->getPressureScale(),
+        25.0,
         pylith::topology::FieldQuery::validatorNonnegative
         );
     info.fe = pylith::topology::Field::Discretization(
@@ -91,6 +87,7 @@ pylith::materials::TestAuxiliaryFactoryLinearElastic::TestAuxiliaryFactoryLinear
         componentNames.size(),
         pylith::topology::Field::SCALAR,
         _data->normalizer->getPressureScale(),
+        0.0,
         pylith::topology::FieldQuery::validatorPositive
         );
     info.fe = pylith::topology::Field::Discretization(

--- a/tests/libtests/materials/TestAuxiliaryFactoryLinearElastic_Cases.cc
+++ b/tests/libtests/materials/TestAuxiliaryFactoryLinearElastic_Cases.cc
@@ -39,10 +39,17 @@ public:
 
 private:
 
+    static const PylithReal LENGTH_SCALE;
+    static const PylithReal TIME_SCALE;
+    static const PylithReal PRESSURE_SCALE;
+    static const PylithReal DENSITY_SCALE;
+
+private:
+
     static
     double density_2d(const double x,
                       const double y) {
-        return 3.4 + 3.0*fabs(x) + 2.0*fabs(y);
+        return 2500.0 + 3.0*fabs(x)/LENGTH_SCALE + 2.0*fabs(y)/LENGTH_SCALE;
     } // density
 
     static
@@ -53,23 +60,23 @@ private:
     static
     double vs_2d(const double x,
                  const double y) {
-        return 3.4 + 3.0*fabs(x) + 2.0*fabs(y);
+        return 1000.0 + 30.0*fabs(x)/LENGTH_SCALE + 20.0*fabs(y)/LENGTH_SCALE;
     } // vs
 
     static
     const char* vs_units(void) {
-        return "km/s";
+        return "m/s";
     } // vs_units
 
     static
     double vp_2d(const double x,
                  const double y) {
-        return 6.4 + 5.0*fabs(x) + 4.3*fabs(y);
+        return 2000.0 + 50.0*fabs(x)/LENGTH_SCALE + 43.0*fabs(y)/LENGTH_SCALE;
     } // vp
 
     static
     const char* vp_units(void) {
-        return "km/s";
+        return "m/s";
     } // vp_units
 
     static
@@ -95,25 +102,25 @@ private:
     static
     double reference_stress_2d_xx(const double x,
                                   const double y) {
-        return -0.3*x*x + 0.1*x*y;
+        return -0.3*x*x/(LENGTH_SCALE*LENGTH_SCALE) + 0.1*x*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_stress_xx
 
     static
     double reference_stress_2d_yy(const double x,
                                   const double y) {
-        return -0.8*x*y + 0.2*y*y;
+        return -8.0e+6*x*y/(LENGTH_SCALE*LENGTH_SCALE) + 2.0e+6*y*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_stress_2d_yy
 
     static
     double reference_stress_2d_zz(const double x,
                                   const double y) {
-        return -0.3*x*x + 0.5*y*y;
+        return -3.0e+6*x*x/(LENGTH_SCALE*LENGTH_SCALE) + 5.0e+6*y*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_stress_2d_zz
 
     static
     double reference_stress_2d_xy(const double x,
                                   const double y) {
-        return -0.3*x*x + 0.2*x*y;
+        return -3.0e+6*x*x/(LENGTH_SCALE*LENGTH_SCALE) + 2.0e+6*x*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_stress_xy
 
     static
@@ -124,25 +131,25 @@ private:
     static
     double reference_strain_2d_xx(const double x,
                                   const double y) {
-        return -0.3*x*x + 0.1*x*y;
+        return -0.3*x*x/(LENGTH_SCALE*LENGTH_SCALE) + 0.1*x*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_strain_2d_xx
 
     static
     double reference_strain_2d_yy(const double x,
                                   const double y) {
-        return -0.8*x*y + 0.2*y*y;
+        return -0.8*x*y/(LENGTH_SCALE*LENGTH_SCALE) + 0.2*y*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_strain_2d_yy
 
     static
     double reference_strain_2d_zz(const double x,
                                   const double y) {
-        return -0.3*x*x + 0.5*y*y;
+        return -0.3*x*x/(LENGTH_SCALE*LENGTH_SCALE) + 0.5*y*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_strain_2d_zz
 
     static
     double reference_strain_2d_xy(const double x,
                                   const double y) {
-        return -0.3*x*x + 0.2*x*y;
+        return -0.3*x*x/(LENGTH_SCALE*LENGTH_SCALE) + 0.2*x*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_strain_xy
 
     static
@@ -154,21 +161,21 @@ private:
     double density_3d(const double x,
                       const double y,
                       const double z) {
-        return 3.4 + 3.0*fabs(x) + 2.0*fabs(z);
+        return 2500.0 + 3.0*fabs(x)/LENGTH_SCALE + 2.0*fabs(z)/LENGTH_SCALE;
     } // density
 
     static
     double vs_3d(const double x,
                  const double y,
                  const double z) {
-        return 3.4 + 3.0*fabs(x) + 2.0*fabs(z);
+        return 1000.0 + 300.0*fabs(x)/LENGTH_SCALE + 200.0*fabs(z)/LENGTH_SCALE;
     } // vs
 
     static
     double vp_3d(const double x,
                  const double y,
                  const double z) {
-        return 6.4 + 4.0*fabs(x) + 5.3*fabs(z);
+        return 2500.0 + 400.0*fabs(x)/LENGTH_SCALE + 5.3*fabs(z)/LENGTH_SCALE;
     } // vp
 
     static
@@ -192,84 +199,84 @@ private:
     double reference_stress_3d_xx(const double x,
                                   const double y,
                                   const double z) {
-        return -0.3*x*z + 0.1*x*z;
+        return -3.0e+6*x*z/(LENGTH_SCALE*LENGTH_SCALE) + 1.0e+6*x*z/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_stress_3d_xx
 
     static
     double reference_stress_3d_yy(const double x,
                                   const double y,
                                   const double z) {
-        return -0.8*x*z + 0.2*y*y;
+        return -8.0e+6*x*z/(LENGTH_SCALE*LENGTH_SCALE) + 2.0e+6*y*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_stress_3d_yy
 
     static
     double reference_stress_3d_zz(const double x,
                                   const double y,
                                   const double z) {
-        return -0.3*x*x + 0.5*y*z;
+        return -3.0e+6*x*x/(LENGTH_SCALE*LENGTH_SCALE) + 5.0e+6*y*z/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_stress_3d_zz
 
     static
     double reference_stress_3d_xy(const double x,
                                   const double y,
                                   const double z) {
-        return -0.3*x + 0.2*x*y;
+        return -3.0e+6*x/LENGTH_SCALE + 2.0e+6*x*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_stress_3d_xy
 
     static
     double reference_stress_3d_yz(const double x,
                                   const double y,
                                   const double z) {
-        return -0.3*x*z + 0.2*x*y;
+        return -3.0e+6*x*z/(LENGTH_SCALE*LENGTH_SCALE) + 2.0e+6*x*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_stress_3d_yz
 
     static
     double reference_stress_3d_xz(const double x,
                                   const double y,
                                   const double z) {
-        return -0.3*x + 0.2*y;
+        return -3.0e+6*x/LENGTH_SCALE + 2.0e+6*y/LENGTH_SCALE;
     } // reference_stress_3d_xz
 
     static
     double reference_strain_3d_xx(const double x,
                                   const double y,
                                   const double z) {
-        return -0.3*x*x + 0.1*x*z;
+        return -0.3*x*x/(LENGTH_SCALE*LENGTH_SCALE) + 0.1*x*z/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_strain_3d_xx
 
     static
     double reference_strain_3d_yy(const double x,
                                   const double y,
                                   const double z) {
-        return -0.8*x*y + 0.2*y*y;
+        return -0.8*x*y/(LENGTH_SCALE*LENGTH_SCALE) + 0.2*y*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_strain_3d_yy
 
     static
     double reference_strain_3d_zz(const double x,
                                   const double y,
                                   const double z) {
-        return -0.3*x*z + 0.5*y*y;
+        return -0.3*x*z/(LENGTH_SCALE*LENGTH_SCALE) + 0.5*y*y/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_strain_3d_zz
 
     static
     double reference_strain_3d_xy(const double x,
                                   const double y,
                                   const double z) {
-        return -0.3*x*x + 0.2*x*z;
+        return -0.3*x*x/(LENGTH_SCALE*LENGTH_SCALE) + 0.2*x*z/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_strain_3d_xy
 
     static
     double reference_strain_3d_yz(const double x,
                                   const double y,
                                   const double z) {
-        return -0.3*y*z + 0.2*x*z;
+        return -0.3*y*z/(LENGTH_SCALE*LENGTH_SCALE) + 0.2*x*z/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_strain_3d_yz
 
     static
     double reference_strain_3d_xz(const double x,
                                   const double y,
                                   const double z) {
-        return -0.3*y*y + 0.2*x*z;
+        return -0.3*y*y/(LENGTH_SCALE*LENGTH_SCALE) + 0.2*x*z/(LENGTH_SCALE*LENGTH_SCALE);
     } // reference_strain_3d_xz
 
 };
@@ -289,6 +296,11 @@ TEST_CASE("TestAuxiliaryFactoryLinearElastic::Hex::testSetValuesFromDB", "[TestA
     pylith::materials::TestAuxiliaryFactoryLinearElastic(pylith::materials::TestAuxiliaryFactoryLinearElastic_Cases::Hex()).testSetValuesFromDB();
 }
 
+const PylithReal pylith::materials::TestAuxiliaryFactoryLinearElastic_Cases::LENGTH_SCALE = 1.0e+3;
+const PylithReal pylith::materials::TestAuxiliaryFactoryLinearElastic_Cases::TIME_SCALE = 2.0;
+const PylithReal pylith::materials::TestAuxiliaryFactoryLinearElastic_Cases::PRESSURE_SCALE = 2.0e+10;
+const PylithReal pylith::materials::TestAuxiliaryFactoryLinearElastic_Cases::DENSITY_SCALE = 3.0e+3;
+
 // --------------------------------------------------------------------------------------------------------------------
 pylith::materials::TestAuxiliaryFactoryLinearElastic_Data*
 pylith::materials::TestAuxiliaryFactoryLinearElastic_Cases::Tri(void) {
@@ -300,6 +312,12 @@ pylith::materials::TestAuxiliaryFactoryLinearElastic_Cases::Tri(void) {
     data->meshFilename = "data/tri.mesh";
     data->cs = new spatialdata::geocoords::CSCart();assert(data->cs);
     data->cs->setSpaceDim(data->dimension);
+
+    assert(data->normalizer);
+    data->normalizer->setLengthScale(LENGTH_SCALE);
+    data->normalizer->setTimeScale(TIME_SCALE);
+    data->normalizer->setPressureScale(PRESSURE_SCALE);
+    data->normalizer->setDensityScale(DENSITY_SCALE);
 
     assert(data->auxiliaryDB);
     data->auxiliaryDB->addValue("density", density_2d, density_units());
@@ -333,6 +351,12 @@ pylith::materials::TestAuxiliaryFactoryLinearElastic_Cases::Hex(void) {
     data->meshFilename = "data/hex.mesh";
     data->cs = new spatialdata::geocoords::CSCart();assert(data->cs);
     data->cs->setSpaceDim(data->dimension);
+
+    assert(data->normalizer);
+    data->normalizer->setLengthScale(LENGTH_SCALE);
+    data->normalizer->setTimeScale(TIME_SCALE);
+    data->normalizer->setPressureScale(PRESSURE_SCALE);
+    data->normalizer->setDensityScale(DENSITY_SCALE);
 
     assert(data->auxiliaryDB);
     data->auxiliaryDB->addValue("density", density_3d, density_units());

--- a/tests/libtests/topology/TestFieldQuery.cc
+++ b/tests/libtests/topology/TestFieldQuery.cc
@@ -278,9 +278,11 @@ void
 pylith::topology::TestFieldQuery::testValidatorPositive(void) {
     PYLITH_METHOD_BEGIN;
 
-    CHECK(NULL != pylith::topology::FieldQuery::validatorPositive(-1.0));
-    CHECK(NULL != pylith::topology::FieldQuery::validatorPositive(0.0));
-    CHECK(NULL == pylith::topology::FieldQuery::validatorPositive(1.0));
+    CHECK(std::string() != pylith::topology::FieldQuery::validatorPositive(-1.0, 1.0, 0.0));
+    CHECK(std::string() != pylith::topology::FieldQuery::validatorPositive(0.0, 1.0, 0.0));
+    CHECK(std::string() == pylith::topology::FieldQuery::validatorPositive(1.0, 1.0, 0.0));
+    CHECK(std::string() == pylith::topology::FieldQuery::validatorPositive(10.0, 8.0, 2.0));
+    CHECK(std::string() != pylith::topology::FieldQuery::validatorPositive(10.0, 1.0, 5.0));
 
     PYLITH_METHOD_END;
 } // testValidatorPositive
@@ -292,9 +294,11 @@ void
 pylith::topology::TestFieldQuery::testValidatorNonnegative(void) {
     PYLITH_METHOD_BEGIN;
 
-    CHECK(NULL != pylith::topology::FieldQuery::validatorNonnegative(-1.0));
-    CHECK(NULL == pylith::topology::FieldQuery::validatorNonnegative(0.0));
-    CHECK(NULL == pylith::topology::FieldQuery::validatorNonnegative(1.0));
+    CHECK(std::string() != pylith::topology::FieldQuery::validatorNonnegative(-1.0, 1.0, 0.0));
+    CHECK(std::string() == pylith::topology::FieldQuery::validatorNonnegative(0.0, 1.0, 0.0));
+    CHECK(std::string() == pylith::topology::FieldQuery::validatorNonnegative(1.0, 1.0, 0.0));
+    CHECK(std::string() == pylith::topology::FieldQuery::validatorNonnegative(5.0, 2.0, 3.0));
+    CHECK(std::string() != pylith::topology::FieldQuery::validatorNonnegative(5.0, 1.0, 3.0));
 
     PYLITH_METHOD_END;
 } // testValidatorPositive

--- a/tests/src/FieldTester.cc
+++ b/tests/src/FieldTester.cc
@@ -68,6 +68,7 @@ pylith::testing::FieldTester::checkSubfieldInfo(const pylith::topology::Field& f
     } // for
     CHECK(descriptionE.scale == description.scale);
     CHECK(descriptionE.validator == description.validator);
+    CHECK(descriptionE.validatorTolerance == description.validatorTolerance);
     CHECK(descriptionE.hasHistory == description.hasHistory);
     CHECK(descriptionE.historySize == description.historySize);
 


### PR DESCRIPTION
Closes #779

We still need to adjust auxiliary fields to make better use of this feature (will affect parameter files so delaying those changes to v5.0). Refer to #790.