### PR TITLE
Prepare release v4.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,8 @@ The version numbers are in the form `MAJOR.MINOR.PATCH`, where major releases in
   * Added section to User Guide on how to run PyLith binary offline.
   * Allow output on a finer resolution mesh than used in the simulation to facilitate accurate representation of fields with a basis order of 2 or greater.
 * **Fixed**
-  * Fixed inconsistency in normal direction on fault surfaces. Orientation was correct but direction was flipped at some locations. This affected local slip direction and the resulting deformation close to the fault. This bug fix was not in version 4.1.3.
+  * Fixed inconsistency in normal direction on fault surfaces. Orientation was correct but direction was flipped at some locations. This affected local slip direction and the resulting deformation close to the fault. This bug fix in a PETSc branch was not in version 4.1.3.
+  * Updated `TimeDependentAuxiliaryFactory::updateAuxiliaryField()` to account for some processes potentially not having points in a boundary condition (`auxiliaryFieldArray == NULL_PTR`).
   * Updated autoconf numpy macros for compatibility with location of include files in numpy version 2.x.
 
 ## Version 4.1.3 (2024/07/31)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,12 +15,12 @@ The version numbers are in the form `MAJOR.MINOR.PATCH`, where major releases in
   * Default filenames for progress monitor and parameters file are set from the simulation name like
   the other output files.
   * Consistency check for material properties and scales used in nondimensionalization (currently just the shear modulus).
-  * Add section to User Guide on troubleshooting solver issues.
-  * Add section to User Guide on how to run PyLith binary offline.
+  * Added section to User Guide on troubleshooting solver issues.
+  * Added section to User Guide on how to run PyLith binary offline.
   * Allow output on a finer resolution mesh than used in the simulation to facilitate accurate representation of fields with a basis order of 2 or greater.
 * **Fixed**
-  * Fix inconsistency in normal direction on fault surfaces. Orientation was correct but direction was flipped at some locations. This affected local slip direction and the resulting deformation close to the fault. This bug fix was not in version 4.1.3.
-  * Update autoconf numpy macros for compatibility with location of include files in numpy version 2.x.
+  * Fixed inconsistency in normal direction on fault surfaces. Orientation was correct but direction was flipped at some locations. This affected local slip direction and the resulting deformation close to the fault. This bug fix was not in version 4.1.3.
+  * Updated autoconf numpy macros for compatibility with location of include files in numpy version 2.x.
 
 ## Version 4.1.3 (2024/07/31)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ The version numbers are in the form `MAJOR.MINOR.PATCH`, where major releases in
 
 * **Changed**
   * Updated `examples/strikeslip-2d` Steps 4-7 to use a more realistic slip distribution and mesh refinement in output.
-  * Updated to PETSc 3.22.0
+  * Updated to PETSc 3.22.2
   * Switch CI from Azure Pipelines to GitHub Actions.
 * **Added**
   * Default filenames for progress monitor and parameters file are set from the simulation name like

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,7 +22,7 @@ authors:
     orcid: "https://orcid.org/0000-0001-7435-9196"
 identifiers:
   - type: doi
-    value: 10.5281/zenodo.13134616
+    value: 10.5281/zenodo.14635926
 repository-code: "https://github.com/geodynamics/pylith"
 url: "https://geodynamics.org/resources/pylith"
 keywords:
@@ -31,8 +31,8 @@ keywords:
   - earthquake
   - finite element
 license: MIT
-version: 4.1.3
-date-released: "2024-06-05"
+version: 4.2.0
+date-released: "2025-01-17"
 preferred-citation:
   type: article
   authors:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyLith
 
-[![DOI](https://www.zenodo.org/badge/DOI/10.5281/zenodo.13134616.svg)](https://doi.org/10.5281/zenodo.13134616)
+[![DOI](https://www.zenodo.org/badge/DOI/10.5281/zenodo.14635926.svg)](https://doi.org/10.5281/zenodo.14635926)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/geodynamics/pylith/blob/main/LICENSE.md)
 [![Build Status](https://dev.azure.com/baagaard-usgs/pylith/_apis/build/status/geodynamics.pylith?branchName=main)](https://dev.azure.com/baagaard-usgs/pylith/_build/latest?definitionId=2&branchName=main)
 [![codecov](https://codecov.io/gh/geodynamics/pylith/branch/master/graph/badge.svg?token=JiwLVB64EF)](https://codecov.io/gh/geodynamics/pylith)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![DOI](https://www.zenodo.org/badge/DOI/10.5281/zenodo.14635926.svg)](https://doi.org/10.5281/zenodo.14635926)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/geodynamics/pylith/blob/main/LICENSE.md)
-[![Build Status](https://dev.azure.com/baagaard-usgs/pylith/_apis/build/status/geodynamics.pylith?branchName=main)](https://dev.azure.com/baagaard-usgs/pylith/_build/latest?definitionId=2&branchName=main)
-[![codecov](https://codecov.io/gh/geodynamics/pylith/branch/master/graph/badge.svg?token=JiwLVB64EF)](https://codecov.io/gh/geodynamics/pylith)
+[![Build Status](https://github.com/geodynamics/pylith/actions/workflows/ci-main.yml/badge.svg)](https://github.com/geodynamics/pylith/actions/workflows/ci-main.yml)
 
 ## Description
 

--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,7 @@ AC_CHECK_HEADER([mpi.h], [], [AC_MSG_ERROR([header 'mpi.h' not found])])
 
 dnl PETSC
 AC_LANG(C)
-CIT_PATH_PETSC([3.22.0])
+CIT_PATH_PETSC([3.22.2])
 CIT_HEADER_PETSC
 CIT_CHECK_LIB_PETSC
 

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ dnl ============================================================================
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([PyLith], [4.2.0dev], [https://geodynamics.org/resources/pylith])
+AC_INIT([PyLith], [4.2.0], [https://geodynamics.org/resources/pylith])
 AC_CONFIG_AUX_DIR([./aux-config])
 AC_CONFIG_HEADER([portinfo])
 AC_CONFIG_MACRO_DIR([m4])
@@ -185,7 +185,7 @@ CIT_FUNCTIONSTRING
 dnl VERSION
 CIG_PKG_GIT(PYLITH)
 AC_DEFINE_UNQUOTED([PYLITH_VERSION], ["$PACKAGE_VERSION"], [Define PyLith version])
-AC_DEFINE_UNQUOTED([PYLITH_DOI], ["10.5281/zenodo.13134616"], [Define PyLith doi])
+AC_DEFINE_UNQUOTED([PYLITH_DOI], ["10.5281/zenodo.14635926"], [Define PyLith doi])
 
 dnl ENDIANNESS
 AC_C_BIGENDIAN

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2010-2025, University of California, Davis'
 author = 'Brad T. Aagaard, Matthew G. Knepley, Charles A. Williams'
 
 # The full version, including alpha/beta/rc tags
-release = '4.2.0dev'
+release = '4.2.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/intro/preface.md
+++ b/docs/intro/preface.md
@@ -17,9 +17,9 @@ The following peer-reviewed paper discusses the development of PyLith:
 
 To cite the software and manual, use:
 
-- Aagaard, B., M. Knepley, C. Williams (2024a), *PyLith v4.1.3.* Davis, CA: Computational Infrastructure of Geodynamics. DOI: 10.5281/zenodo.13134616.
+- Aagaard, B., M. Knepley, C. Williams (2025a), *PyLith v4.2.0.* Davis, CA: Computational Infrastructure of Geodynamics. DOI: 10.5281/zenodo.14635926.
 
-- Aagaard, B., M. Knepley, C. Williams (2024b), *PyLith Manual, Version 4.1.3.* Davis, CA: Computational Infrastructure of Geodynamics. https://pylith.readthedocs.io/en/v4.1.3
+- Aagaard, B., M. Knepley, C. Williams (2025b), *PyLith Manual, Version 4.2.0.* Davis, CA: Computational Infrastructure of Geodynamics. https://pylith.readthedocs.io/en/v4.2.0
 
 ## Publishing Models
 
@@ -43,7 +43,7 @@ Common output files include the solution fields and state variables as `.h5`, `.
 
 The configuration files, parameters of the simulation, and solution field for the models in this study are available at DOI (Authors X, Y, Z) under CC BY-NC-SA 4.0.
 
-PyLith version 4.1.3 (Aagaard et al., 2013; Aagaard et al., 2023a; Aagaard et al., 2023b) used in these models is freely available under the MIT license for download through its software landing page https://geodynamics.org/resources/pylith or Zenodo (10.5281/zenodo.11479383).
+PyLith version 4.2.0 (Aagaard et al., 2013; Aagaard et al., 2025a; Aagaard et al., 2025b) used in these models is freely available under the MIT license for download through its software landing page https://geodynamics.org/resources/pylith or Zenodo (10.5281/zenodo.14635926).
 The project is being actively developed on GitHub and can be accessed via https://github.com/geodynamics/pylith.
 
 ## Support

--- a/docs/user/examples/box-3d/step03-sheardisptract.md
+++ b/docs/user/examples/box-3d/step03-sheardisptract.md
@@ -79,7 +79,7 @@ $ pylith step03_sheardisptract.cfg
 
 # -- many lines omitted --
 
- >> /software/baagaard/py38-venv/pylith-debug/lib/python3.8/site-packages/pylith/problems/TimeDependent.py:139:run
+ >> /software/unix/py38-venv/pylith-debug/lib/python3.8/site-packages/pylith/problems/TimeDependent.py:139:run
  -- timedependent(info)
  -- Solving problem.
 0 TS dt 0.01 time 0.
@@ -88,7 +88,7 @@ $ pylith step03_sheardisptract.cfg
     1 SNES Function norm 2.511862662012e-17 
   Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 1
 1 TS dt 0.01 time 0.01
- >> /software/baagaard/py38-venv/pylith-debug/lib/python3.8/site-packages/pylith/problems/Problem.py:201:finalize
+ >> /software/unix/py38-venv/pylith-debug/lib/python3.8/site-packages/pylith/problems/Problem.py:201:finalize
  -- timedependent(info)
  -- Finalizing problem.
 ```

--- a/docs/user/examples/box-3d/step05-sheardisptractrate.md
+++ b/docs/user/examples/box-3d/step05-sheardisptractrate.md
@@ -102,7 +102,7 @@ $ pylith step05_sheardisptractrate.cfg
     1 SNES Function norm 1.130764208982e-17 
   Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 1
 6 TS dt 0.1 time 0.5
- >> /software/baagaard/py38-venv/pylith-debug/lib/python3.8/site-packages/pylith/problems/Problem.py:201:finalize
+ >> /software/unix/py38-venv/pylith-debug/lib/python3.8/site-packages/pylith/problems/Problem.py:201:finalize
  -- timedependent(info)
  -- Finalizing problem.
 ```

--- a/docs/user/examples/crustal-strikeslip-2d/step01-slip.md
+++ b/docs/user/examples/crustal-strikeslip-2d/step01-slip.md
@@ -185,52 +185,52 @@ caption: Run Step 1 simulation with the Cubit mesh
 $ pylith step01_slip_cubit.cfg
 
 # The output should look something like the following.
- >> /Users/baagaard/software/unix/py3.12-venv/pylith-debug/lib/python3.12/site-packages/pylith/apps/PyLithApp.py:77:main
+ >> /software/unix/py3.12-venv/pylith-debug/lib/python3.12/site-packages/pylith/apps/PyLithApp.py:77:main
  -- pylithapp(info)
  -- Running on 1 process(es).
- >> /Users/baagaard/software/unix/py3.12-venv/pylith-debug/lib/python3.12/site-packages/pylith/meshio/MeshIOObj.py:38:read
+ >> /software/unix/py3.12-venv/pylith-debug/lib/python3.12/site-packages/pylith/meshio/MeshIOObj.py:38:read
  -- meshiocubit(info)
  -- Reading finite-element mesh
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:148:void pylith::meshio::MeshIOCubit::_readVertices(ExodusII &, scalar_array *, int *, int *) const
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:148:void pylith::meshio::MeshIOCubit::_readVertices(ExodusII &, scalar_array *, int *, int *) const
  -- meshiocubit(info)
  -- Component 'reader': Reading 1610 vertices.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:208:void pylith::meshio::MeshIOCubit::_readCells(ExodusII &, int_array *, int_array *, int *, int *) const
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:208:void pylith::meshio::MeshIOCubit::_readCells(ExodusII &, int_array *, int_array *, int *, int *) const
  -- meshiocubit(info)
  -- Component 'reader': Reading 3125 cells in 1 blocks.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:270:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:270:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
  -- meshiocubit(info)
  -- Component 'reader': Found 10 node sets.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
  -- meshiocubit(info)
  -- Component 'reader': Reading node set 'boundary_south' with id 10 containing 25 nodes.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
  -- meshiocubit(info)
  -- Component 'reader': Reading node set 'boundary_east' with id 11 containing 25 nodes.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
  -- meshiocubit(info)
  -- Component 'reader': Reading node set 'boundary_north' with id 12 containing 24 nodes.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
  -- meshiocubit(info)
  -- Component 'reader': Reading node set 'boundary_west' with id 13 containing 23 nodes.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
  -- meshiocubit(info)
  -- Component 'reader': Reading node set 'fault_main' with id 20 containing 37 nodes.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
  -- meshiocubit(info)
  -- Component 'reader': Reading node set 'fault_west' with id 21 containing 13 nodes.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
  -- meshiocubit(info)
  -- Component 'reader': Reading node set 'fault_east' with id 22 containing 6 nodes.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
  -- meshiocubit(info)
  -- Component 'reader': Reading node set 'fault_main_ends' with id 30 containing 2 nodes.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
  -- meshiocubit(info)
  -- Component 'reader': Reading node set 'fault_west_ends' with id 31 containing 2 nodes.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIOCubit.cc:296:void pylith::meshio::MeshIOCubit::_readGroups(ExodusII &)
  -- meshiocubit(info)
  -- Component 'reader': Reading node set 'fault_east_ends' with id 32 containing 2 nodes.
- >> /Users/baagaard/src/cig/pylith/libsrc/pylith/meshio/MeshIO.cc:85:void pylith::meshio::MeshIO::read(pylith::topology::Mesh *, const bool)
+ >> /src/cig/pylith/libsrc/pylith/meshio/MeshIO.cc:85:void pylith::meshio::MeshIO::read(pylith::topology::Mesh *, const bool)
  -- meshiocubit(info)
  -- Component 'reader': Domain bounding box:
     (410000, 490000)
@@ -238,7 +238,7 @@ $ pylith step01_slip_cubit.cfg
 
 -- many lines omitted --
 
- >> /Users/baagaard/software/unix/py3.12-venv/pylith-debug/lib/python3.12/site-packages/pylith/problems/TimeDependent.py:132:run
+ >> /software/unix/py3.12-venv/pylith-debug/lib/python3.12/site-packages/pylith/problems/TimeDependent.py:132:run
  -- timedependent(info)
  -- Solving problem.
 0 TS dt 0.01 time 0.
@@ -247,7 +247,7 @@ $ pylith step01_slip_cubit.cfg
     1 SNES Function norm 1.131725395538e-12
     Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 1
 1 TS dt 0.01 time 0.01
- >> /Users/baagaard/software/unix/py3.12-venv/pylith-debug/lib/python3.12/site-packages/pylith/problems/Problem.py:199:finalize
+ >> /software/unix/py3.12-venv/pylith-debug/lib/python3.12/site-packages/pylith/problems/Problem.py:199:finalize
  -- timedependent(info)
  -- Finalizing problem.
 ```

--- a/docs/user/examples/subduction-3d/step04-eqcycle.md
+++ b/docs/user/examples/subduction-3d/step04-eqcycle.md
@@ -91,7 +91,7 @@ ts_type = beuler
     1 SNES Function norm 4.780619312733e-10
   Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 1
 31 TS dt 0.1 time 3.
- >> /software/baagaard/py38-venv/pylith-opt/lib/python3.8/site-packages/pylith/problems/Problem.py:201:finalize
+ >> /software/unix/py38-venv/pylith-opt/lib/python3.8/site-packages/pylith/problems/Problem.py:201:finalize
  -- timedependent(info)
  -- Finalizing problem.
  ```

--- a/docs/user/install/index.md
+++ b/docs/user/install/index.md
@@ -48,10 +48,10 @@ On macOS systems you can check the operating system version by clicking on the A
 3. Unpack the tarball.
     ```{code-block} bash
       # Linux 64-bit
-      tar -xzf pylith-4.1.3-linux-x86_64.tar.gz
+      tar -xzf pylith-4.2.0-linux-x86_64.tar.gz
 
       # macOS
-      tar -xzf pylith-4.1.3-macOS-10.15-x86_64.tar.gz
+      tar -xzf pylith-4.2.0-macOS-10.15-x86_64.tar.gz
       ```
 4. Set environment variables.
 The provided `setup.sh` script only works if you are using bash shell.
@@ -65,20 +65,20 @@ Ready to run PyLith.
 To bypass macOS quarantine restrictions, simply use command line program `curl` to download the tarball from within a terminal rather than using a web browser.
 
 ```{code-block} console
-curl -L -O https://github.com/geodynamics/pylith/releases/download/v4.1.3/pylith-4.1.3-macOS-10.15-x86_64.tar.gz
+curl -L -O https://github.com/geodynamics/pylith/releases/download/v4.2.0/pylith-4.2.0-macOS-10.15-x86_64.tar.gz
 ```
 
 Alternatively, if you do download the tarball using a web browser, after you unpack the tarball you can remove the macOS quarantine flags using the following commands (requires Administrator access):
 
 ```{code-block} bash
 # Show extended attributes
-xattr ./pylith-4.1.3-macOS-10.15-x86_64
+xattr ./pylith-4.2.0-macOS-10.15-x86_64
 
 # Output should be
 com.apple.quarantine
 
 # Remove quarantine attributes
-sudo xattr -r -d com.apple.quarantine ./pylith-4.1.3-macOS-10.15-x86_64
+sudo xattr -r -d com.apple.quarantine ./pylith-4.2.0-macOS-10.15-x86_64
 ```
 :::
 
@@ -176,7 +176,7 @@ For each package this utility downloads the source code, configures it, builds i
 ## Verifying PyLith Installation
 
 The easiest way to verify that PyLith has been installed correctly is to run one or more of the examples supplied with the binary and source code.
-In the binary distribution, the examples are located in `src/pylith-4.1.3/examples` while in the source distribution, they are located in `pylith-4.1.3/examples`.
+In the binary distribution, the examples are located in `src/pylith-4.2.0/examples` while in the source distribution, they are located in `pylith-4.2.0/examples`.
 {ref}`sec-examples` discusses how to run and visualize the results for the examples.
 To run the example discussed in Section {ref}`sec-examples-box-2d`:
 

--- a/docs/user/run-pylith/petsc-options.md
+++ b/docs/user/run-pylith/petsc-options.md
@@ -259,7 +259,7 @@ ksp_converged_reason = true
 snes_converged_reason = true
 snes_monitor = true
 
-ts_monitor = tru
+ts_monitor = true
 ts_error_if_step_fails = true
 ```
 

--- a/libsrc/pylith/bc/TimeDependentAuxiliaryFactory.cc
+++ b/libsrc/pylith/bc/TimeDependentAuxiliaryFactory.cc
@@ -316,6 +316,10 @@ pylith::bc::TimeDependentAuxiliaryFactory::updateAuxiliaryField(pylith::topology
     PetscSection auxiliaryFieldSection = auxiliaryField->getLocalSection();assert(auxiliaryFieldSection);
     PetscInt pStart = 0, pEnd = 0;
     err = PetscSectionGetChart(auxiliaryFieldSection, &pStart, &pEnd);PYLITH_CHECK_ERROR(err);
+    if (pStart == pEnd) {
+        PYLITH_METHOD_END;
+    } // if
+
     pylith::topology::VecVisitorMesh auxiliaryFieldVisitor(*auxiliaryField);
     PetscScalar* auxiliaryFieldArray = auxiliaryFieldVisitor.localArray();assert(auxiliaryFieldArray);
 

--- a/pylith/__init__.py
+++ b/pylith/__init__.py
@@ -8,7 +8,7 @@
 # See https://mit-license.org/ and LICENSE.md and for license information. 
 # =================================================================================================
 
-__version__ = "4.2.0dev"
+__version__ = "4.2.0"
 
 __all__ = ['apps',
            'bc',

--- a/release-notes/Makefile.am
+++ b/release-notes/Makefile.am
@@ -46,7 +46,8 @@ EXTRA_DIST = \
 	announce_v4.1.0.md \
 	announce_v4.1.1.md \
 	announce_v4.1.2.md \
-	announce_v4.1.3.md
+	announce_v4.1.3.md \
+	announce_v4.2.0.md
 
 
 # End of file 

--- a/release-notes/announce_v4.2.0.md
+++ b/release-notes/announce_v4.2.0.md
@@ -1,0 +1,37 @@
+# PyLith v4.2.0 now available
+
+I am pleased to announce the release of PyLith 4.2.0, a finite-element code designed to solve dynamic elastic problems and quasi-static viscoelastic problems in tectonic deformation.
+
+You can download the source code and binaries from
+  <https://geodynamics.org/resources/pylith>
+
+Documentation
+  <https://pylith.readthedocs.org/en/v4.2.0>
+
+## Release Notes
+
+* **Changed**
+  * Updated `examples/strikeslip-2d` Steps 4-7 to use a more realistic slip distribution and mesh refinement in output.
+  * Updated to PETSc 3.22.0
+  * Switch CI from Azure Pipelines to GitHub Actions.
+* **Added**
+  * Default filenames for progress monitor and parameters file are set from the simulation name like
+  the other output files.
+  * Consistency check for material properties and scales used in nondimensionalization (currently just the shear modulus).
+  * Added section to User Guide on troubleshooting solver issues.
+  * Added section to User Guide on how to run PyLith binary offline.
+  * Allow output on a finer resolution mesh than used in the simulation to facilitate accurate representation of fields with a basis order of 2 or greater.
+* **Fixed**
+  * Fixed inconsistency in normal direction on fault surfaces. Orientation was correct but direction was flipped at some locations. This affected local slip direction and the resulting deformation close to the fault. This bug fix was not in version 4.1.3.
+  * Updated autoconf numpy macros for compatibility with location of include files in numpy version 2.x.
+
+### Known issues
+
+* The new default preconditioner for simulations using elasticity and faults can cause convergence issues when running in parallel in which fault faces lie on the boundaries between processors. The workaround is to use the previous preconditioner provided in `share/settings/solver_fault_fieldsplit.cfg`.
+* The default PETSc options provide a computationally expensive preconditioner when solving incompressible elasticity problems. We expect to have a more optimal preconditioner in the next release.
+
+## Contributors
+
+* Brad Aagaard ![ORCID iD](/_static/images/ORCIDiD_icon32x32.png){w=16px}[0000-0002-8795-9833](https://orcid.org/0000-0002-8795-9833)
+* Matthew Knepley ![ORCID iD](/_static/images/ORCIDiD_icon32x32.png){w=16px}[0000-0002-2292-0735](https://orcid.org/0000-0002-2292-0735)
+* Charles Williams ![ORCID iD](/_static/images/ORCIDiD_icon32x32.png){w=16px}[0000-0001-7435-9196](https://orcid.org/0000-0001-7435-9196)

--- a/release-notes/checklist.txt
+++ b/release-notes/checklist.txt
@@ -13,7 +13,7 @@ TESTING
 SOURCE CODE
 
   * Reserve DOI on Zenodo and update version and DOI in code.
-  * Update citation information (year) in preface.tex.
+  * Update citation information (year) in preface.md.
   * Add changes to CHANGES.
     * List contributors https://github.com/geodynamics/pylith/graphs/contributors?from=2024-01-01&to=2024-06-05&type=c
   * Add release notes in release-notes.

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ tag_date = 0
 
 [metadata]
 name = pylith
-version = 4.2.0dev
+version = 4.2.0
 author = Brad Aagaard, Matthew Knepley, Charles Williams
 author_email = baagaard@usgs.gov, knepley@buffalo.edu, c.williams@gns.cri.nz
 description = Finite-element software for modeling crustal deformation with an emphasis on earthquake faulting.


### PR DESCRIPTION
* Update version number and DOI
* Update PETSc to 3.22.2
* Fix bug in TimeDependentAuxiliaryFactory::updateAuxiliaryField() associated with running in parallel.