### PR TITLE
FIX: Avoid divide by zero in KinSrcRamp slip time function (zero slip or impulse duration).

### DIFF
--- a/libsrc/pylith/faults/KinSrcRamp.cc
+++ b/libsrc/pylith/faults/KinSrcRamp.cc
@@ -88,7 +88,9 @@ pylith::faults::KinSrcRamp::slipFn(const PylithInt dim,
     const double finalSlipMag = dim == 2 ?
                                 sqrt(pow(finalSlip[0],2) + pow(finalSlip[1],2)) :
                                 sqrt(pow(finalSlip[0],2) + pow(finalSlip[1],2) + pow(finalSlip[2],2));
-    const double slipCoef = 2.0 * _KinSrcRamp::maxAcc(finalSlipMag, riseTime, impulseDuration) / impulseDuration;
+    const double slipCoef = impulseDuration > 0.0 ?
+                            2.0 * _KinSrcRamp::maxAcc(finalSlipMag, riseTime, impulseDuration) / impulseDuration :
+                            0.0;
 
     double slipTimeFn = 0.0;
     if (t-t0 <= 0.0) {
@@ -142,7 +144,7 @@ pylith::faults::KinSrcRamp::slipFn(const PylithInt dim,
     } // if/else
 
     for (PylithInt i = 0; i < dim; ++i) {
-        slip[i] = slipCoef * slipTimeFn * finalSlip[i] / finalSlipMag;
+        slip[i] = finalSlipMag > 0.0 ? slipCoef * slipTimeFn * finalSlip[i] / finalSlipMag : 0.0;
     } // for
 } // slipFn
 

--- a/tests/fullscale/linearelasticity/faults-2d/shearnoslip.cfg
+++ b/tests/fullscale/linearelasticity/faults-2d/shearnoslip.cfg
@@ -31,11 +31,14 @@ db_auxiliary_field.data = [0.0*s, 0.0*m, 0.0*m]
 time_history.description = Slip time function time history
 time_history.filename = zeroslipfn.timedb
 
+[pylithapp.problem.interfaces.fault_xneg.eq_ruptures]
+rupture = pylith.faults.KinSrcRamp
+
 [pylithapp.problem.interfaces.fault_xneg.eq_ruptures.rupture]
 db_auxiliary_field = spatialdata.spatialdb.UniformDB
 db_auxiliary_field.description = Fault rupture auxiliary field spatial database
-db_auxiliary_field.values = [initiation_time, final_slip_left_lateral, final_slip_opening]
-db_auxiliary_field.data = [0.0*s, 0.0*m, 0.0*m]
+db_auxiliary_field.values = [initiation_time, rise_time, impulse_duration, final_slip_left_lateral, final_slip_opening]
+db_auxiliary_field.data = [0.0*s, 2.0*s, 0.1*s, 0.0*m, 0.0*m]
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Close #828