### PR TITLE
Code clean up

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 ACLOCAL_AMFLAGS = -I m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,6 @@
 # =================================================================================================
 
 ACLOCAL_AMFLAGS = -I m4
-AM_MAKEFLAGS = --output-sync=target
 
 SUBDIRS = \
 	libsrc \

--- a/applications/pylith
+++ b/applications/pylith
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 if __name__ == "__main__":

--- a/applications/pylith_dumpparameters
+++ b/applications/pylith_dumpparameters
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """
 This script dumps all PyLith parameters (defaults plus those

--- a/applications/pylith_eqinfo
+++ b/applications/pylith_eqinfo
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """
 This script creates a Python file with earthquake rupture information computed

--- a/applications/pylith_genxdmf
+++ b/applications/pylith_genxdmf
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """
 This script creates a metadata file (.xmf) from an HDF5 file written by

--- a/applications/pylith_powerlaw_gendb
+++ b/applications/pylith_powerlaw_gendb
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """
 Pyre application to compute power-law parameters used by PyLith, given

--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/benchmarks/linearelasticity/Makefile.am
+++ b/benchmarks/linearelasticity/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/benchmarks/linearelasticity/solver-faults-2d/Makefile.am
+++ b/benchmarks/linearelasticity/solver-faults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_PYTHON = \

--- a/benchmarks/linearelasticity/solver-faults-3d/Makefile.am
+++ b/benchmarks/linearelasticity/solver-faults-3d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_PYTHON = \

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ dnl
 dnl Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 dnl All rights reserved.
 dnl
-dnl See https://mit-license.org/ and LICENSE.md and for license information. 
+dnl See https://mit-license.org/ and LICENSE.md and for license information.
 dnl ================================================================================================
 dnl Process this file with autoconf to produce a configure script.
 

--- a/developer/Makefile.am
+++ b/developer/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_PYTHON = \

--- a/developer/format_source.py
+++ b/developer/format_source.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 """Format C++ and Python to match coding style conventions used in the PyLith projectself.

--- a/developer/headers.txt
+++ b/developer/headers.txt
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2023, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 //
 
@@ -17,7 +17,7 @@
 # Copyright (c) 2010-2023, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 
@@ -29,7 +29,7 @@
  * Copyright (c) 2010-2023, University of California, Davis and the PyLith Development Team.
  * All rights reserved.
  *
- * See https://mit-license.org/ and LICENSE.md and for license information. 
+ * See https://mit-license.org/ and LICENSE.md and for license information.
  * =================================================================================================
  */
 
@@ -41,6 +41,6 @@ dnl
 dnl Copyright (c) 2010-2023, University of California, Davis and the PyLith Development Team.
 dnl All rights reserved.
 dnl
-dnl See https://mit-license.org/ and LICENSE.md and for license information. 
+dnl See https://mit-license.org/ and LICENSE.md and for license information.
 dnl ================================================================================================
       

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_DATA = \

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_DATA = \

--- a/examples/barwaves-2d/Makefile.am
+++ b/examples/barwaves-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/box-2d/Makefile.am
+++ b/examples/box-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_DATA = \

--- a/examples/box-3d/Makefile.am
+++ b/examples/box-3d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_PYTHON = \

--- a/examples/crustal-strikeslip-2d/Makefile.am
+++ b/examples/crustal-strikeslip-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_PYTHON = \

--- a/examples/crustal-strikeslip-3d/Makefile.am
+++ b/examples/crustal-strikeslip-3d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_PYTHON = \

--- a/examples/magma-2d/Makefile.am
+++ b/examples/magma-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_PYTHON = \

--- a/examples/meshing-cubit/Makefile.am
+++ b/examples/meshing-cubit/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/meshing-cubit/cellsize/Makefile.am
+++ b/examples/meshing-cubit/cellsize/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/meshing-cubit/cellsize/exodus_add_properties.py
+++ b/examples/meshing-cubit/cellsize/exodus_add_properties.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # PREREQUISITES: numpy, netCDF4, spatialdata (PyLith)
 

--- a/examples/meshing-cubit/cellsize/geometry.jou
+++ b/examples/meshing-cubit/cellsize/geometry.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 # Cubit journal file with geometry for example showing how to specify

--- a/examples/meshing-cubit/cellsize/mesh_cellsize.jou
+++ b/examples/meshing-cubit/cellsize/mesh_cellsize.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 # Cubit journal file to create an ExodusII file with a mesh at uniform

--- a/examples/meshing-cubit/cellsize/mesh_size_analyticfn.jou
+++ b/examples/meshing-cubit/cellsize/mesh_size_analyticfn.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 # Cubit journal file to create a mesh where the resolution is given as

--- a/examples/meshing-cubit/cellsize/mesh_size_spatialdb.jou
+++ b/examples/meshing-cubit/cellsize/mesh_size_spatialdb.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 # Cubit journal file to create a mesh where the resolution is given as

--- a/examples/meshing-cubit/surface-nurbs/Makefile.am
+++ b/examples/meshing-cubit/surface-nurbs/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/meshing-cubit/surface-nurbs/dem/Makefile.am
+++ b/examples/meshing-cubit/surface-nurbs/dem/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/meshing-cubit/surface-nurbs/dem/ulines/Makefile.am
+++ b/examples/meshing-cubit/surface-nurbs/dem/ulines/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/meshing-cubit/surface-nurbs/dem/vlines/Makefile.am
+++ b/examples/meshing-cubit/surface-nurbs/dem/vlines/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/meshing-cubit/surface-nurbs/merge-surfs/Makefile.am
+++ b/examples/meshing-cubit/surface-nurbs/merge-surfs/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/meshing-cubit/surface-nurbs/merge-surfs/bc.jou
+++ b/examples/meshing-cubit/surface-nurbs/merge-surfs/bc.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # ----------------------------------------------------------------------
 # Create block for materials

--- a/examples/meshing-cubit/surface-nurbs/merge-surfs/geometry.jou
+++ b/examples/meshing-cubit/surface-nurbs/merge-surfs/geometry.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # ----------------------------------------------------------------------
 #

--- a/examples/meshing-cubit/surface-nurbs/merge-surfs/mesh.jou
+++ b/examples/meshing-cubit/surface-nurbs/merge-surfs/mesh.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # ----------------------------------------------------------------------
 #

--- a/examples/meshing-cubit/surface-nurbs/subduction/Makefile.am
+++ b/examples/meshing-cubit/surface-nurbs/subduction/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/meshing-cubit/surface-nurbs/subduction/geometry.jou
+++ b/examples/meshing-cubit/surface-nurbs/subduction/geometry.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 # Cubit journal file with geometry for example showing how to import

--- a/examples/meshing-cubit/surface-nurbs/subduction/interface_netsurf.py
+++ b/examples/meshing-cubit/surface-nurbs/subduction/interface_netsurf.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # PREREQUISITES: numpy
 

--- a/examples/meshing-cubit/surface-nurbs/subduction/mesh.jou
+++ b/examples/meshing-cubit/surface-nurbs/subduction/mesh.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 # Cubit journal file to create an ExodusII file with a mesh at uniform

--- a/examples/meshing-cubit/surface-nurbs/subduction/splay_skinsurf.py
+++ b/examples/meshing-cubit/surface-nurbs/subduction/splay_skinsurf.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # PREREQUISITES: numpy
 

--- a/examples/meshing-cubit/surface-nurbs/subduction/topobath_netsurf.py
+++ b/examples/meshing-cubit/surface-nurbs/subduction/topobath_netsurf.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # PREREQUISITES: numpy
 

--- a/examples/meshing-cubit/surface-nurbs/triangles/Makefile.am
+++ b/examples/meshing-cubit/surface-nurbs/triangles/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/poroelastic-outerrise-2d/Makefile.am
+++ b/examples/poroelastic-outerrise-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_PYTHON = \

--- a/examples/reverse-2d/Makefile.am
+++ b/examples/reverse-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_PYTHON = \

--- a/examples/strikeslip-2d/Makefile.am
+++ b/examples/strikeslip-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_PYTHON = \

--- a/examples/subduction-2d/Makefile.am
+++ b/examples/subduction-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/subduction-3d/Makefile.am
+++ b/examples/subduction-3d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/examples/subduction-3d/generate_gmsh.py
+++ b/examples/subduction-3d/generate_gmsh.py
@@ -354,7 +354,7 @@ class App(GenerateMesh):
         )
 
         point_tags = numpy.concatenate(all_points_on_grid).tolist()
-        surface = gmsh.model.occ.addSurfaceFilling(wire, pointTags=point_tags)
+        surface = gmsh.model.occ.addSurfaceFilling(wire, pointTags=point_tags, tol3d=1.0, numIter=5)
         gmsh.model.occ.remove([(0, point) for point in point_tags])
         return surface, contours
 

--- a/examples/troubleshooting-2d/Makefile.am
+++ b/examples/troubleshooting-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 dist_noinst_DATA = \

--- a/libsrc/Makefile.am
+++ b/libsrc/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/Makefile.am
+++ b/libsrc/pylith/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/bc/Makefile.am
+++ b/libsrc/pylith/bc/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/faults/Makefile.am
+++ b/libsrc/pylith/faults/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/feassemble/Makefile.am
+++ b/libsrc/pylith/feassemble/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/fekernels/Makefile.am
+++ b/libsrc/pylith/fekernels/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/fekernels/jacobian2d.py
+++ b/libsrc/pylith/fekernels/jacobian2d.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Initial attempt to compute plane strain Jacobian matrices symbolically.
 # PREREQUISITES:  sympy

--- a/libsrc/pylith/fekernels/jacobian3d.py
+++ b/libsrc/pylith/fekernels/jacobian3d.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Initial attempt to compute plane strain Jacobian matrices symbolically.
 # PREREQUISITES:  sympy

--- a/libsrc/pylith/friction/Makefile.am
+++ b/libsrc/pylith/friction/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/initializers/Makefile.am
+++ b/libsrc/pylith/initializers/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/materials/Makefile.am
+++ b/libsrc/pylith/materials/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/meshio/Makefile.am
+++ b/libsrc/pylith/meshio/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/problems/Makefile.am
+++ b/libsrc/pylith/problems/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/scales/Makefile.am
+++ b/libsrc/pylith/scales/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the SpatialData Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = scales

--- a/libsrc/pylith/testing/Makefile.am
+++ b/libsrc/pylith/testing/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/topology/Makefile.am
+++ b/libsrc/pylith/topology/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/libsrc/pylith/utils/Makefile.am
+++ b/libsrc/pylith/utils/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/modulesrc/Makefile.am
+++ b/modulesrc/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/modulesrc/bc/Makefile.am
+++ b/modulesrc/bc/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = bc

--- a/modulesrc/bc/bc.i
+++ b/modulesrc/bc/bc.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // SWIG interface
 %module bc

--- a/modulesrc/faults/Makefile.am
+++ b/modulesrc/faults/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = faults

--- a/modulesrc/faults/faults.i
+++ b/modulesrc/faults/faults.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // SWIG interface
 %module faults

--- a/modulesrc/feassemble/Makefile.am
+++ b/modulesrc/feassemble/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = feassemble

--- a/modulesrc/feassemble/feassemble.i
+++ b/modulesrc/feassemble/feassemble.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // SWIG interface
 %module feassemble

--- a/modulesrc/friction/Makefile.am
+++ b/modulesrc/friction/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = friction

--- a/modulesrc/friction/friction.i
+++ b/modulesrc/friction/friction.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // SWIG interface
 %module friction

--- a/modulesrc/include/Makefile.am
+++ b/modulesrc/include/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = swig/include

--- a/modulesrc/include/chararray.i
+++ b/modulesrc/include/chararray.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // Treat const char* const* as a special case.
 %typemap(in) (const char* const* string_list) {

--- a/modulesrc/include/kinsrcarray.i
+++ b/modulesrc/include/kinsrcarray.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // List of earthquake sources.
 %typemap(in) (pylith::faults::KinSrc** ruptures,

--- a/modulesrc/include/outputarray.i
+++ b/modulesrc/include/outputarray.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 // List of solution output managers.

--- a/modulesrc/include/physicsarray.i
+++ b/modulesrc/include/physicsarray.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 // List of materials.

--- a/modulesrc/include/scalartypemaps.i
+++ b/modulesrc/include/scalartypemaps.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 // Map a Python float scalar to PylistReal.

--- a/modulesrc/initializers/Makefile.am
+++ b/modulesrc/initializers/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the SpatialData Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = initializers

--- a/modulesrc/initializers/phasesarray.i
+++ b/modulesrc/initializers/phasesarray.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 // List of phases.

--- a/modulesrc/materials/Makefile.am
+++ b/modulesrc/materials/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = materials

--- a/modulesrc/materials/materials.i
+++ b/modulesrc/materials/materials.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // SWIG interface
 %module materials

--- a/modulesrc/meshio/Makefile.am
+++ b/modulesrc/meshio/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = meshio

--- a/modulesrc/meshio/OutputSolnPoints.i
+++ b/modulesrc/meshio/OutputSolnPoints.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 /**

--- a/modulesrc/meshio/meshio.i
+++ b/modulesrc/meshio/meshio.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // SWIG interface
 %module meshio

--- a/modulesrc/module.am
+++ b/modulesrc/module.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 AM_CPPFLAGS = \

--- a/modulesrc/mpi/Makefile.am
+++ b/modulesrc/mpi/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = mpi

--- a/modulesrc/mpi/mpi.i
+++ b/modulesrc/mpi/mpi.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // SWIG interface
 %module mpi

--- a/modulesrc/mpi/mpi_comm.i
+++ b/modulesrc/mpi/mpi_comm.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 // ----------------------------------------------------------------------

--- a/modulesrc/mpi/mpi_error.i
+++ b/modulesrc/mpi/mpi_error.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 // ----------------------------------------------------------------------

--- a/modulesrc/mpi/mpi_reduce.i
+++ b/modulesrc/mpi/mpi_reduce.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 // ----------------------------------------------------------------------

--- a/modulesrc/problems/Makefile.am
+++ b/modulesrc/problems/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = problems

--- a/modulesrc/problems/problems.i
+++ b/modulesrc/problems/problems.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // SWIG interface
 %module problems

--- a/modulesrc/scales/Makefile.am
+++ b/modulesrc/scales/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the SpatialData Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = scales

--- a/modulesrc/topology/Makefile.am
+++ b/modulesrc/topology/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = topology

--- a/modulesrc/topology/topology.i
+++ b/modulesrc/topology/topology.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // SWIG interface
 %module topology

--- a/modulesrc/utils/Makefile.am
+++ b/modulesrc/utils/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 subpackage = utils

--- a/modulesrc/utils/TestArray.i
+++ b/modulesrc/utils/TestArray.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 /**

--- a/modulesrc/utils/constants.i
+++ b/modulesrc/utils/constants.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 /**

--- a/modulesrc/utils/petsc.i
+++ b/modulesrc/utils/petsc.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 // SWIG interface
 %module petsc

--- a/modulesrc/utils/petsc_general.i
+++ b/modulesrc/utils/petsc_general.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 // ----------------------------------------------------------------------

--- a/modulesrc/utils/petsc_mat.i
+++ b/modulesrc/utils/petsc_mat.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 // ----------------------------------------------------------------------

--- a/modulesrc/utils/pylith_general.i
+++ b/modulesrc/utils/pylith_general.i
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
 // ----------------------------------------------------------------------

--- a/playpen/euler/euler.py
+++ b/playpen/euler/euler.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file euler/euler
 

--- a/playpen/euler/grabfaces.py
+++ b/playpen/euler/grabfaces.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file euler/grabfaces
 

--- a/playpen/euler/grabpoints.py
+++ b/playpen/euler/grabpoints.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file grabpoints/grabpoints
 

--- a/playpen/euler/poleconvert.py
+++ b/playpen/euler/poleconvert.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file euler/poleconvert
 

--- a/playpen/euler/transform.py
+++ b/playpen/euler/transform.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file transform/transform
 

--- a/playpen/postproc/fault/faultinfo.py
+++ b/playpen/postproc/fault/faultinfo.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file postproc/faultinfo
 

--- a/playpen/postproc/princaxes.py
+++ b/playpen/postproc/princaxes.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file postproc/princaxes
 #

--- a/playpen/postproc/stressinfo.py
+++ b/playpen/postproc/stressinfo.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file postproc/stressinfo
 

--- a/playpen/postproc/vtkcff.py
+++ b/playpen/postproc/vtkcff.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file postproc/vtkcff
 

--- a/playpen/postproc/vtkdiff.py
+++ b/playpen/postproc/vtkdiff.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file postproc/vtkdiff
 

--- a/playpen/tsurf/tsurftooff
+++ b/playpen/tsurf/tsurftooff
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 if [ $# == 0 ]; then

--- a/pylith/Makefile.am
+++ b/pylith/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/pylith/apps/ConfigSearchApp.py
+++ b/pylith/apps/ConfigSearchApp.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Application for searching PyLith .cfg files.
 

--- a/pylith/apps/PetscApplication.py
+++ b/pylith/apps/PetscApplication.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/apps/PetscApplication.py
 #

--- a/pylith/apps/RunnerApp.py
+++ b/pylith/apps/RunnerApp.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Application for searching for and running PyLith .cfg files.
 

--- a/pylith/apps/VizApp.py
+++ b/pylith/apps/VizApp.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """Application for visualizing PyLith output."""
 

--- a/pylith/apps/__init__.py
+++ b/pylith/apps/__init__.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/apps/__init__.py
 

--- a/pylith/bc/AbsorbingDampers.py
+++ b/pylith/bc/AbsorbingDampers.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.bc.BoundaryCondition import BoundaryCondition

--- a/pylith/bc/AuxSubfieldsAbsorbingDampers.py
+++ b/pylith/bc/AuxSubfieldsAbsorbingDampers.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/materials/AuxSubfieldsAbsorbingDampers.py
 #

--- a/pylith/bc/AuxSubfieldsTimeDependent.py
+++ b/pylith/bc/AuxSubfieldsTimeDependent.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/materials/AuxSubfieldsTimeDependent.py
 #

--- a/pylith/bc/BoundaryCondition.py
+++ b/pylith/bc/BoundaryCondition.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.problems.Physics import Physics

--- a/pylith/bc/DirichletTimeDependent.py
+++ b/pylith/bc/DirichletTimeDependent.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .BoundaryCondition import BoundaryCondition

--- a/pylith/bc/ZeroDB.py
+++ b/pylith/bc/ZeroDB.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from spatialdata.spatialdb.UniformDB import UniformDB

--- a/pylith/bc/__init__.py
+++ b/pylith/bc/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/bc/__init__.py
 #

--- a/pylith/faults/AuxSubfieldsFault.py
+++ b/pylith/faults/AuxSubfieldsFault.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/faults/FaultCohesiveImpulses.py
+++ b/pylith/faults/FaultCohesiveImpulses.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import numpy

--- a/pylith/faults/FaultCohesiveKin.py
+++ b/pylith/faults/FaultCohesiveKin.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .FaultCohesive import FaultCohesive

--- a/pylith/faults/KinSrcBrune.py
+++ b/pylith/faults/KinSrcBrune.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .KinSrc import KinSrc

--- a/pylith/faults/KinSrcConstRate.py
+++ b/pylith/faults/KinSrcConstRate.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .KinSrc import KinSrc

--- a/pylith/faults/KinSrcLiuCos.py
+++ b/pylith/faults/KinSrcLiuCos.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/faults/KinSrcLiuCos.py
 #

--- a/pylith/faults/KinSrcRamp.py
+++ b/pylith/faults/KinSrcRamp.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .KinSrc import KinSrc

--- a/pylith/faults/KinSrcStep.py
+++ b/pylith/faults/KinSrcStep.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .KinSrc import KinSrc

--- a/pylith/faults/KinSrcTimeHistory.py
+++ b/pylith/faults/KinSrcTimeHistory.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/faults/KinSrcTimeHistory.py
 #

--- a/pylith/faults/SingleRupture.py
+++ b/pylith/faults/SingleRupture.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/faults/__init__.py
+++ b/pylith/faults/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/faults/__init__.py
 #

--- a/pylith/initializers/MeshDistributor.py
+++ b/pylith/initializers/MeshDistributor.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .InitializePhase import InitializePhase

--- a/pylith/initializers/MeshReader.py
+++ b/pylith/initializers/MeshReader.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .InitializePhase import InitializePhase

--- a/pylith/initializers/MeshRefiner.py
+++ b/pylith/initializers/MeshRefiner.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .InitializePhase import InitializePhase

--- a/pylith/initializers/MeshWriter.py
+++ b/pylith/initializers/MeshWriter.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .InitializePhase import InitializePhase

--- a/pylith/initializers/__init__.py
+++ b/pylith/initializers/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 __all__ = [

--- a/pylith/materials/AuxSubfieldsElasticity.py
+++ b/pylith/materials/AuxSubfieldsElasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/AuxSubfieldsIsotropicLinearElasticity.py
+++ b/pylith/materials/AuxSubfieldsIsotropicLinearElasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/AuxSubfieldsIsotropicLinearGenMaxwell.py
+++ b/pylith/materials/AuxSubfieldsIsotropicLinearGenMaxwell.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/AuxSubfieldsIsotropicLinearMaxwell.py
+++ b/pylith/materials/AuxSubfieldsIsotropicLinearMaxwell.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/AuxSubfieldsIsotropicLinearPoroelasticity.py
+++ b/pylith/materials/AuxSubfieldsIsotropicLinearPoroelasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/AuxSubfieldsIsotropicPowerLaw.py
+++ b/pylith/materials/AuxSubfieldsIsotropicPowerLaw.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/AuxSubfieldsPoroelasticity.py
+++ b/pylith/materials/AuxSubfieldsPoroelasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/DerivedSubfieldsElasticity.py
+++ b/pylith/materials/DerivedSubfieldsElasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/DerivedSubfieldsPoroelasticity.py
+++ b/pylith/materials/DerivedSubfieldsPoroelasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.materials.DerivedSubfieldsElasticity import DerivedSubfieldsElasticity

--- a/pylith/materials/Elasticity.py
+++ b/pylith/materials/Elasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .Material import Material

--- a/pylith/materials/Homogeneous.py
+++ b/pylith/materials/Homogeneous.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/IncompressibleElasticity.py
+++ b/pylith/materials/IncompressibleElasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .Material import Material

--- a/pylith/materials/IsotropicLinearElasticity.py
+++ b/pylith/materials/IsotropicLinearElasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .RheologyElasticity import RheologyElasticity

--- a/pylith/materials/IsotropicLinearGenMaxwell.py
+++ b/pylith/materials/IsotropicLinearGenMaxwell.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .RheologyElasticity import RheologyElasticity

--- a/pylith/materials/IsotropicLinearIncompElasticity.py
+++ b/pylith/materials/IsotropicLinearIncompElasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .RheologyIncompressibleElasticity import RheologyIncompressibleElasticity

--- a/pylith/materials/IsotropicLinearMaxwell.py
+++ b/pylith/materials/IsotropicLinearMaxwell.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .RheologyElasticity import RheologyElasticity

--- a/pylith/materials/IsotropicLinearPoroelasticity.py
+++ b/pylith/materials/IsotropicLinearPoroelasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/materials/IsotropicLinearPoroelasticity.py
 #

--- a/pylith/materials/IsotropicPowerLaw.py
+++ b/pylith/materials/IsotropicPowerLaw.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .RheologyElasticity import RheologyElasticity

--- a/pylith/materials/Material.py
+++ b/pylith/materials/Material.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.problems.Physics import Physics

--- a/pylith/materials/Poroelasticity.py
+++ b/pylith/materials/Poroelasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .Material import Material

--- a/pylith/materials/RheologyElasticity.py
+++ b/pylith/materials/RheologyElasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/RheologyIncompressibleElasticity.py
+++ b/pylith/materials/RheologyIncompressibleElasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/RheologyPoroelasticity.py
+++ b/pylith/materials/RheologyPoroelasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/materials/__init__.py
+++ b/pylith/materials/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/materials/__init__"
 

--- a/pylith/meshio/DataWriter.py
+++ b/pylith/meshio/DataWriter.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import pathlib

--- a/pylith/meshio/DataWriterHDF5.py
+++ b/pylith/meshio/DataWriterHDF5.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .DataWriter import DataWriter

--- a/pylith/meshio/DataWriterHDF5Ext.py
+++ b/pylith/meshio/DataWriterHDF5Ext.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .DataWriter import DataWriter

--- a/pylith/meshio/DataWriterVTK.py
+++ b/pylith/meshio/DataWriterVTK.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .DataWriter import DataWriter

--- a/pylith/meshio/MeshIOAscii.py
+++ b/pylith/meshio/MeshIOAscii.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import pathlib

--- a/pylith/meshio/MeshIOCubit.py
+++ b/pylith/meshio/MeshIOCubit.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pythia.pyre/meshio/MeshIOCubit.py
 #

--- a/pylith/meshio/MeshIOObj.py
+++ b/pylith/meshio/MeshIOObj.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/meshio/MeshIOPetsc.py
+++ b/pylith/meshio/MeshIOPetsc.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import pathlib

--- a/pylith/meshio/OutputObserver.py
+++ b/pylith/meshio/OutputObserver.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/meshio/OutputPhysics.py
+++ b/pylith/meshio/OutputPhysics.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pythia.pyre/meshio/OutputPhysics.py
 #

--- a/pylith/meshio/OutputSoln.py
+++ b/pylith/meshio/OutputSoln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .OutputObserver import OutputObserver

--- a/pylith/meshio/OutputSolnBoundary.py
+++ b/pylith/meshio/OutputSolnBoundary.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .OutputSoln import OutputSoln

--- a/pylith/meshio/OutputSolnDomain.py
+++ b/pylith/meshio/OutputSolnDomain.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .OutputSoln import OutputSoln

--- a/pylith/meshio/OutputTrigger.py
+++ b/pylith/meshio/OutputTrigger.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/meshio/OutputTriggerStep.py
+++ b/pylith/meshio/OutputTriggerStep.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .OutputTrigger import OutputTrigger

--- a/pylith/meshio/OutputTriggerTime.py
+++ b/pylith/meshio/OutputTriggerTime.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .OutputTrigger import OutputTrigger

--- a/pylith/meshio/PointsList.py
+++ b/pylith/meshio/PointsList.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pythia.pyre.components.Component import Component

--- a/pylith/meshio/__init__.py
+++ b/pylith/meshio/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/meshio___init__",
 #

--- a/pylith/mpi/Communicator.py
+++ b/pylith/mpi/Communicator.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/mpi/Communicator.py
 #

--- a/pylith/mpi/__init__.py
+++ b/pylith/mpi/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/mpi/__init__.py
 #

--- a/pylith/problems/GreensFns.py
+++ b/pylith/problems/GreensFns.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/problems/GreensFns.py
 #

--- a/pylith/problems/InitialCondition.py
+++ b/pylith/problems/InitialCondition.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/problems/InitialConditionDomain.py
+++ b/pylith/problems/InitialConditionDomain.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.problems.InitialCondition import InitialCondition

--- a/pylith/problems/InitialConditionPatch.py
+++ b/pylith/problems/InitialConditionPatch.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.problems.InitialCondition import InitialCondition

--- a/pylith/problems/ProblemDefaults.py
+++ b/pylith/problems/ProblemDefaults.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pythia.pyre.components.Component import Component

--- a/pylith/problems/ProgressMonitor.py
+++ b/pylith/problems/ProgressMonitor.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/problems/ProgressMonitorStep.py
+++ b/pylith/problems/ProgressMonitorStep.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .ProgressMonitor import ProgressMonitor

--- a/pylith/problems/ProgressMonitorTime.py
+++ b/pylith/problems/ProgressMonitorTime.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .ProgressMonitor import ProgressMonitor

--- a/pylith/problems/SingleObserver.py
+++ b/pylith/problems/SingleObserver.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/problems/SolnDisp.py
+++ b/pylith/problems/SolnDisp.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/problems/SolnDispLagrange.py
+++ b/pylith/problems/SolnDispLagrange.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/problems/SolnDispLagrange.py
 #

--- a/pylith/problems/SolnDispPres.py
+++ b/pylith/problems/SolnDispPres.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/problems/SolnDispPresLagrange.py
+++ b/pylith/problems/SolnDispPresLagrange.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/problems/SolnDispPresTracStrain.py
+++ b/pylith/problems/SolnDispPresTracStrain.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/problems/SolnDispPresTracStrainLagrange.py
+++ b/pylith/problems/SolnDispPresTracStrainLagrange.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/problems/SolnDispPresTracStrainVelPdotTdot.py
+++ b/pylith/problems/SolnDispPresTracStrainVelPdotTdot.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/problems/SolnDispPresTracStrainVelTdotPdot.py
 #

--- a/pylith/problems/SolnDispPresTracStrainVelPdotTdotLagrange.py
+++ b/pylith/problems/SolnDispPresTracStrainVelPdotTdotLagrange.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/problems/SolnDispPresTracStrainVelPdotTdotLagrange.py
 #

--- a/pylith/problems/SolnDispPresVel.py
+++ b/pylith/problems/SolnDispPresVel.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/problems/SolnDispVel.py
+++ b/pylith/problems/SolnDispVel.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/problems/SolnDispVelLagrange.py
+++ b/pylith/problems/SolnDispVelLagrange.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/problems/__init__.py
+++ b/pylith/problems/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/__init__",
 #

--- a/pylith/testing/SolutionPoints.py
+++ b/pylith/testing/SolutionPoints.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/testing/SolutionPoints.py
 #

--- a/pylith/testing/TestCases.py
+++ b/pylith/testing/TestCases.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/pylith/testing/__init__.py
+++ b/pylith/testing/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 __all__ = [
     "FullTestApp",

--- a/pylith/topology/Distributor.py
+++ b/pylith/topology/Distributor.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/topology/Field.py
+++ b/pylith/topology/Field.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .topology import Field as ModuleField

--- a/pylith/topology/Mesh.py
+++ b/pylith/topology/Mesh.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .topology import Mesh as ModuleMesh

--- a/pylith/topology/RefineMesh.py
+++ b/pylith/topology/RefineMesh.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/topology/RefineUniform.py
+++ b/pylith/topology/RefineUniform.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/topology/Subfield.py
+++ b/pylith/topology/Subfield.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pythia.pyre.components.Component import Component

--- a/pylith/topology/__init__.py
+++ b/pylith/topology/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/topology/__init__.py
 

--- a/pylith/utils/CollectVersionInfo.py
+++ b/pylith/utils/CollectVersionInfo.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pythia.pyre.components.Component import Component

--- a/pylith/utils/DumpParameters.py
+++ b/pylith/utils/DumpParameters.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pythia.pyre.components.Component import Component

--- a/pylith/utils/DumpParametersAscii.py
+++ b/pylith/utils/DumpParametersAscii.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .DumpParameters import DumpParameters

--- a/pylith/utils/DumpParametersJson.py
+++ b/pylith/utils/DumpParametersJson.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .DumpParameters import DumpParameters

--- a/pylith/utils/EmptyBin.py
+++ b/pylith/utils/EmptyBin.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.utils.PetscComponent import PetscComponent

--- a/pylith/utils/EventLogger.py
+++ b/pylith/utils/EventLogger.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .utils import EventLogger as ModuleEventLogger

--- a/pylith/utils/NullComponent.py
+++ b/pylith/utils/NullComponent.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .PetscComponent import PetscComponent

--- a/pylith/utils/PetscComponent.py
+++ b/pylith/utils/PetscComponent.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pythia.pyre.components.Component import Component

--- a/pylith/utils/PetscManager.py
+++ b/pylith/utils/PetscManager.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from .PropertyList import PropertyList

--- a/pylith/utils/PropertyList.py
+++ b/pylith/utils/PropertyList.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pythia.pyre.components.Component import Component

--- a/pylith/utils/SimulationMetadata.py
+++ b/pylith/utils/SimulationMetadata.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import os

--- a/pylith/utils/__init__.py
+++ b/pylith/utils/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 __all__ = ['NullComponent',
            'PetscComponent',

--- a/pylith/utils/converters.py
+++ b/pylith/utils/converters.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """Python module for simple conversions.
 """

--- a/pylith/utils/profiling.py
+++ b/pylith/utils/profiling.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/utils/profiling.py
 

--- a/pylith/utils/validators.py
+++ b/pylith/utils/validators.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """Python module for some additional Pyre validation.
 """

--- a/pylith/viz/PlotField.py
+++ b/pylith/viz/PlotField.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """Module for plotting solution and derived fields from PyLith output."""
 

--- a/pylith/viz/PlotMesh.py
+++ b/pylith/viz/PlotMesh.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """Module for plotting mesh and mesh quality from PyLith output."""
 

--- a/pylith/viz/WarpGrid.py
+++ b/pylith/viz/WarpGrid.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """Module for plotting warped grid from PyLith output."""
 

--- a/pylith/viz/core.py
+++ b/pylith/viz/core.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """Module with core functionality for visualizing PyLith output using PyVista."""
 

--- a/pylith/viz/io.py
+++ b/pylith/viz/io.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """Module for reading PyLith output for PyVista."""
 

--- a/release-notes/Makefile.am
+++ b/release-notes/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/share/Makefile.am
+++ b/share/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/subpackage.am
+++ b/subpackage.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/templates/Makefile.am
+++ b/templates/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 

--- a/templates/friction/Makefile.am
+++ b/templates/friction/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 

--- a/templates/friction/ViscousFriction.py
+++ b/templates/friction/ViscousFriction.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file pylith/friction/ViscousFriction.py
 #

--- a/templates/friction/__init__.py
+++ b/templates/friction/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file __init__.py
 #

--- a/templates/friction/configure.ac
+++ b/templates/friction/configure.ac
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 AC_PREREQ(2.59)
 AC_INIT([frictioncontrib], [0.0.2], [cig-short@geodynamics.org])

--- a/templates/friction/tests/Makefile.am
+++ b/templates/friction/tests/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 

--- a/templates/friction/tests/TestViscousFriction.py
+++ b/templates/friction/tests/TestViscousFriction.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 # We cannot test the low-level functionality of the ViscousFriction

--- a/templates/friction/tests/testcontrib.py
+++ b/templates/friction/tests/testcontrib.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/templates/materials/Makefile.am
+++ b/templates/materials/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 

--- a/templates/materials/PlaneStrainState.py
+++ b/templates/materials/PlaneStrainState.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @brief Python object implementing 1-D isotropic linear elastic
 # material for plane strain.

--- a/templates/materials/__init__.py
+++ b/templates/materials/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file __init__.py
 #

--- a/templates/materials/configure.ac
+++ b/templates/materials/configure.ac
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 AC_PREREQ(2.59)
 AC_INIT([materialscontrib], [0.0.1], [cig-short@geodynamics.org])

--- a/templates/materials/tests/Makefile.am
+++ b/templates/materials/tests/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 

--- a/templates/materials/tests/TestPlaneStrainState.py
+++ b/templates/materials/tests/TestPlaneStrainState.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 # We cannot test the low-level functionality of the PlaneStrainState

--- a/templates/materials/tests/testcontrib.py
+++ b/templates/materials/tests/testcontrib.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/check_catch2.am
+++ b/tests/check_catch2.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/data.am
+++ b/tests/data.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/fullscale/Makefile.am
+++ b/tests/fullscale/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/tests/fullscale/convert/Makefile.am
+++ b/tests/fullscale/convert/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_convert.py

--- a/tests/fullscale/convert/test_convert.py
+++ b/tests/fullscale/convert/test_convert.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 import unittest
 

--- a/tests/fullscale/cornercases/Makefile.am
+++ b/tests/fullscale/cornercases/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/tests/fullscale/cornercases/faults-2d/Makefile.am
+++ b/tests/fullscale/cornercases/faults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/cornercases/faults-2d/TestTwoBlocks.py
+++ b/tests/fullscale/cornercases/faults-2d/TestTwoBlocks.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/fullscale/cornercases/faults-2d/test_pylith.py
+++ b/tests/fullscale/cornercases/faults-2d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/cornercases/faults-2d/twoblocks_soln.py
+++ b/tests/fullscale/cornercases/faults-2d/twoblocks_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @brief Analytical solution to three rigid blocks displacement problem.
 #

--- a/tests/fullscale/cornercases/nofaults-2d/Makefile.am
+++ b/tests/fullscale/cornercases/nofaults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/cornercases/nofaults-2d/TestAxialDispConstrained.py
+++ b/tests/fullscale/cornercases/nofaults-2d/TestAxialDispConstrained.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/cornercases/2d/TestAxialDispOneCell.py
 #

--- a/tests/fullscale/cornercases/nofaults-2d/TestAxialDispOneCell.py
+++ b/tests/fullscale/cornercases/nofaults-2d/TestAxialDispOneCell.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/cornercases/2d/TestAxialDispOneCell.py
 #

--- a/tests/fullscale/cornercases/nofaults-2d/axialdisp_gendb.py
+++ b/tests/fullscale/cornercases/nofaults-2d/axialdisp_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/axialdisp_gendb.py
 #

--- a/tests/fullscale/cornercases/nofaults-2d/axialdisp_soln.py
+++ b/tests/fullscale/cornercases/nofaults-2d/axialdisp_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/cornercases/axialdisp_soln.py
 #

--- a/tests/fullscale/cornercases/nofaults-2d/meshes.py
+++ b/tests/fullscale/cornercases/nofaults-2d/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/cornercases/2d/meshes.py
 #

--- a/tests/fullscale/cornercases/nofaults-2d/test_pylith.py
+++ b/tests/fullscale/cornercases/nofaults-2d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/cornercases/nofaults-3d/Makefile.am
+++ b/tests/fullscale/cornercases/nofaults-3d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/cornercases/nofaults-3d/TestAxialDispConstrained.py
+++ b/tests/fullscale/cornercases/nofaults-3d/TestAxialDispConstrained.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/cornercases/3d/TestAxialDispOneCell.py
 #

--- a/tests/fullscale/cornercases/nofaults-3d/TestAxialDispOneCell.py
+++ b/tests/fullscale/cornercases/nofaults-3d/TestAxialDispOneCell.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/cornercases/3d/TestAxialDispOneCell.py
 #

--- a/tests/fullscale/cornercases/nofaults-3d/axialdisp_gendb.py
+++ b/tests/fullscale/cornercases/nofaults-3d/axialdisp_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/cornercases/3d/axialdisp_gendb.py
 #

--- a/tests/fullscale/cornercases/nofaults-3d/axialdisp_soln.py
+++ b/tests/fullscale/cornercases/nofaults-3d/axialdisp_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/cornercases/3d/axialdisp_soln.py
 #

--- a/tests/fullscale/cornercases/nofaults-3d/meshes.py
+++ b/tests/fullscale/cornercases/nofaults-3d/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/cornercases/3d/meshes.py
 #

--- a/tests/fullscale/cornercases/nofaults-3d/test_pylith.py
+++ b/tests/fullscale/cornercases/nofaults-3d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/eqinfo/Makefile.am
+++ b/tests/fullscale/eqinfo/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_eqinfo.py

--- a/tests/fullscale/eqinfo/TestEqInfo.py
+++ b/tests/fullscale/eqinfo/TestEqInfo.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/eqinfo/TestEqInfo.py
 #

--- a/tests/fullscale/eqinfo/TestEqInfoLine.py
+++ b/tests/fullscale/eqinfo/TestEqInfoLine.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/eqinfo/TestEqInfoLine.py
 #

--- a/tests/fullscale/eqinfo/TestEqInfoQuad.py
+++ b/tests/fullscale/eqinfo/TestEqInfoQuad.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/eqinfo/TestEqInfoQuad.py
 #

--- a/tests/fullscale/eqinfo/TestEqInfoTri.py
+++ b/tests/fullscale/eqinfo/TestEqInfoTri.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/eqinfo/TestEqInfoTri.py
 #

--- a/tests/fullscale/eqinfo/generate.py
+++ b/tests/fullscale/eqinfo/generate.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @brief Generate HDF5 data files for eqinfo tests.
 

--- a/tests/fullscale/eqinfo/test_eqinfo.py
+++ b/tests/fullscale/eqinfo/test_eqinfo.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 import unittest
 

--- a/tests/fullscale/incompressibleelasticity/Makefile.am
+++ b/tests/fullscale/incompressibleelasticity/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/tests/fullscale/incompressibleelasticity/nofaults-2d/Makefile.am
+++ b/tests/fullscale/incompressibleelasticity/nofaults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/incompressibleelasticity/nofaults-2d/TestGravityIncompressible.py
+++ b/tests/fullscale/incompressibleelasticity/nofaults-2d/TestGravityIncompressible.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/TestGravityIncompressible.py
 #

--- a/tests/fullscale/incompressibleelasticity/nofaults-2d/gravity_incompressible_soln.py
+++ b/tests/fullscale/incompressibleelasticity/nofaults-2d/gravity_incompressible_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/gravity_incompressible_soln.py
 #

--- a/tests/fullscale/incompressibleelasticity/nofaults-2d/meshes.py
+++ b/tests/fullscale/incompressibleelasticity/nofaults-2d/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults/2d/meshes.py
 #

--- a/tests/fullscale/incompressibleelasticity/nofaults-2d/test_pylith.py
+++ b/tests/fullscale/incompressibleelasticity/nofaults-2d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/incompressibleelasticity/nofaults-3d/Makefile.am
+++ b/tests/fullscale/incompressibleelasticity/nofaults-3d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/incompressibleelasticity/nofaults-3d/TestGravityIncompressible.py
+++ b/tests/fullscale/incompressibleelasticity/nofaults-3d/TestGravityIncompressible.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/TestGravityIncompressible.py
 #

--- a/tests/fullscale/incompressibleelasticity/nofaults-3d/gravity_incompressible_soln.py
+++ b/tests/fullscale/incompressibleelasticity/nofaults-3d/gravity_incompressible_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/gravity_incompressible_soln.py
 #

--- a/tests/fullscale/incompressibleelasticity/nofaults-3d/meshes.py
+++ b/tests/fullscale/incompressibleelasticity/nofaults-3d/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults/2d/meshes.py
 #

--- a/tests/fullscale/incompressibleelasticity/nofaults-3d/test_pylith.py
+++ b/tests/fullscale/incompressibleelasticity/nofaults-3d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/linearelasticity/Makefile.am
+++ b/tests/fullscale/linearelasticity/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/tests/fullscale/linearelasticity/faults-2d/Makefile.am
+++ b/tests/fullscale/linearelasticity/faults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/linearelasticity/faults-2d/TestShearNoSlip.py
+++ b/tests/fullscale/linearelasticity/faults-2d/TestShearNoSlip.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/fullscale/linearelasticity/faults-2d/TestThreeBlocks.py
+++ b/tests/fullscale/linearelasticity/faults-2d/TestThreeBlocks.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/fullscale/linearelasticity/faults-2d/meshes.py
+++ b/tests/fullscale/linearelasticity/faults-2d/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import MeshEntity

--- a/tests/fullscale/linearelasticity/faults-2d/shearnoslip_gendb.py
+++ b/tests/fullscale/linearelasticity/faults-2d/shearnoslip_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """
 Python script to generate spatial database with displacement

--- a/tests/fullscale/linearelasticity/faults-2d/shearnoslip_soln.py
+++ b/tests/fullscale/linearelasticity/faults-2d/shearnoslip_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/faults-2d/sheablocks_soln.py
 #

--- a/tests/fullscale/linearelasticity/faults-2d/test_pylith.py
+++ b/tests/fullscale/linearelasticity/faults-2d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/linearelasticity/faults-2d/threeblocks_soln.py
+++ b/tests/fullscale/linearelasticity/faults-2d/threeblocks_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @brief Analytical solution to three rigid blocks displacement problem.
 #

--- a/tests/fullscale/linearelasticity/faults-3d-buried/Makefile.am
+++ b/tests/fullscale/linearelasticity/faults-3d-buried/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/linearelasticity/faults-3d-buried/TestUniformSlip.py
+++ b/tests/fullscale/linearelasticity/faults-3d-buried/TestUniformSlip.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/fullscale/linearelasticity/faults-3d-buried/meshes.py
+++ b/tests/fullscale/linearelasticity/faults-3d-buried/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import MeshEntity

--- a/tests/fullscale/linearelasticity/faults-3d-buried/test_pylith.py
+++ b/tests/fullscale/linearelasticity/faults-3d-buried/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/linearelasticity/faults-3d-buried/uniformslip_soln.py
+++ b/tests/fullscale/linearelasticity/faults-3d-buried/uniformslip_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @brief Uniform slip on a buried fault (no analytical solution).
 #

--- a/tests/fullscale/linearelasticity/faults-3d/Makefile.am
+++ b/tests/fullscale/linearelasticity/faults-3d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/linearelasticity/faults-3d/meshes.py
+++ b/tests/fullscale/linearelasticity/faults-3d/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import MeshEntity

--- a/tests/fullscale/linearelasticity/faults-3d/test_pylith.py
+++ b/tests/fullscale/linearelasticity/faults-3d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/linearelasticity/faults-3d/twoblocks_soln.py
+++ b/tests/fullscale/linearelasticity/faults-3d/twoblocks_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @brief Analytical solution to three rigid blocks displacement problem.
 #

--- a/tests/fullscale/linearelasticity/greensfns-2d/Makefile.am
+++ b/tests/fullscale/linearelasticity/greensfns-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/linearelasticity/greensfns-2d/TestLeftLateral.py
+++ b/tests/fullscale/linearelasticity/greensfns-2d/TestLeftLateral.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/fullscale/linearelasticity/greensfns-2d/TestOpening.py
+++ b/tests/fullscale/linearelasticity/greensfns-2d/TestOpening.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/fullscale/linearelasticity/greensfns-2d/TestSlipThreshold.py
+++ b/tests/fullscale/linearelasticity/greensfns-2d/TestSlipThreshold.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/fullscale/linearelasticity/greensfns-2d/faultimpulses_soln.py
+++ b/tests/fullscale/linearelasticity/greensfns-2d/faultimpulses_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """Checks for output files from Green's function problem.
 """

--- a/tests/fullscale/linearelasticity/greensfns-2d/meshes.py
+++ b/tests/fullscale/linearelasticity/greensfns-2d/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import MeshEntity

--- a/tests/fullscale/linearelasticity/greensfns-2d/test_pylith.py
+++ b/tests/fullscale/linearelasticity/greensfns-2d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/linearelasticity/nofaults-2d/Makefile.am
+++ b/tests/fullscale/linearelasticity/nofaults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/linearelasticity/nofaults-2d/TestAxialDisp.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/TestAxialDisp.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/fullscale/linearelasticity/nofaults-2d/TestGravity.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/TestGravity.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/fullscale/linearelasticity/nofaults-2d/TestGravityRefState.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/TestGravityRefState.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/fullscale/linearelasticity/nofaults-2d/TestShearTraction.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/TestShearTraction.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/fullscale/linearelasticity/nofaults-2d/axialdisp_gendb.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/axialdisp_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/axialdisp_gendb.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-2d/axialdisp_soln.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/axialdisp_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/axialdisp_soln.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-2d/gravity_refstate_gendb.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/gravity_refstate_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/gravity_refstate_gendb.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-2d/gravity_refstate_soln.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/gravity_refstate_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/gravity_refstate)soln.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-2d/gravity_soln.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/gravity_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/gravity_soln.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-2d/meshes.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import MeshEntity

--- a/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_gendb.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/sheartraction_gendb.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_rate_gendb.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_rate_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/sheartraction_rate_gendb.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_rate_soln.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_rate_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/sheartraction_rate_soln.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_soln.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/sheartraction_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-2d/sheartraction_soln.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-2d/test_pylith.py
+++ b/tests/fullscale/linearelasticity/nofaults-2d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/linearelasticity/nofaults-3d/Makefile.am
+++ b/tests/fullscale/linearelasticity/nofaults-3d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/linearelasticity/nofaults-3d/TestAxialDisp.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/TestAxialDisp.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults/TestAxialDisp.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/TestGravity.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/TestGravity.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/TestGravity.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/TestGravityRefState.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/TestGravityRefState.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/TestGravityRefState.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/TestShearTraction.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/TestShearTraction.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/TestShearTraction.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/TestShearTractionRate.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/TestShearTractionRate.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/TestShearTractionRate.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/axialdisp_gendb.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/axialdisp_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/axialdisp_gendb.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/axialdisp_soln.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/axialdisp_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/axialdisp_soln.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/gravity_refstate_gendb.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/gravity_refstate_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/gravity_refstate_gendb.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/gravity_refstate_soln.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/gravity_refstate_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/gravity_refstate)soln.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/gravity_soln.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/gravity_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/gravity_soln.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/meshes.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults/2d/meshes.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_gendb.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/sheartraction_gendb.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_rate_gendb.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_rate_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/sheartraction_rate_gendb.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_rate_soln.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_rate_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/sheartraction_rate_soln.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_soln.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/sheartraction_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults-3d/sheartraction_soln.py
 #

--- a/tests/fullscale/linearelasticity/nofaults-3d/test_pylith.py
+++ b/tests/fullscale/linearelasticity/nofaults-3d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/petsc/Makefile.am
+++ b/tests/fullscale/petsc/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/fullscale/petsc/TestPetscApp.py
+++ b/tests/fullscale/petsc/TestPetscApp.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/petsc/TestPetscApp.py
 #

--- a/tests/fullscale/petsc/test_petsc.py
+++ b/tests/fullscale/petsc/test_petsc.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 from pylith.testing.FullTestApp import TestDriver
 

--- a/tests/fullscale/poroelasticity/Makefile.am
+++ b/tests/fullscale/poroelasticity/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/tests/fullscale/poroelasticity/cryer/Makefile.am
+++ b/tests/fullscale/poroelasticity/cryer/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/poroelasticity/cryer/TestCryer.py
+++ b/tests/fullscale/poroelasticity/cryer/TestCryer.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/poroelasticity/cryer/TestCryer.py
 #

--- a/tests/fullscale/poroelasticity/cryer/cryer_soln.py
+++ b/tests/fullscale/poroelasticity/cryer/cryer_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/poroelasticity/cryer/cryer_soln.py
 #

--- a/tests/fullscale/poroelasticity/cryer/meshes.py
+++ b/tests/fullscale/poroelasticity/cryer/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/poroelasticty/cryer/meshes.py
 #

--- a/tests/fullscale/poroelasticity/cryer/test_pylith.py
+++ b/tests/fullscale/poroelasticity/cryer/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/poroelasticity/faults-2d/Makefile.am
+++ b/tests/fullscale/poroelasticity/faults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/poroelasticity/faults-2d/test_pylith.py
+++ b/tests/fullscale/poroelasticity/faults-2d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/poroelasticity/mandel/Makefile.am
+++ b/tests/fullscale/poroelasticity/mandel/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/poroelasticity/mandel/TestMandel.py
+++ b/tests/fullscale/poroelasticity/mandel/TestMandel.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/poroelasticity/mandel/TestMandel.py
 #

--- a/tests/fullscale/poroelasticity/mandel/mandel_gendb.py
+++ b/tests/fullscale/poroelasticity/mandel/mandel_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/poroelasticity/mandel/mandel_gendb.py
 #

--- a/tests/fullscale/poroelasticity/mandel/mandel_soln.py
+++ b/tests/fullscale/poroelasticity/mandel/mandel_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/poroelasticity/mandel/mandel_soln.py
 #

--- a/tests/fullscale/poroelasticity/mandel/meshes.py
+++ b/tests/fullscale/poroelasticity/mandel/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/poroelasticty/mandel/meshes.py
 #

--- a/tests/fullscale/poroelasticity/mandel/test_pylith.py
+++ b/tests/fullscale/poroelasticity/mandel/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/poroelasticity/nofaults-2d/Makefile.am
+++ b/tests/fullscale/poroelasticity/nofaults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/poroelasticity/terzaghi/Makefile.am
+++ b/tests/fullscale/poroelasticity/terzaghi/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/poroelasticity/terzaghi/test_pylith.py
+++ b/tests/fullscale/poroelasticity/terzaghi/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/viscoelasticity/Makefile.am
+++ b/tests/fullscale/viscoelasticity/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/tests/fullscale/viscoelasticity/nofaults-2d/Makefile.am
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/viscoelasticity/nofaults-2d/TestAxialStrainGenMaxwell.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/TestAxialStrainGenMaxwell.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-2d/TestAxialStrainGenMaxwell.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-2d/TestAxialStrainRateGenMaxwell.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/TestAxialStrainRateGenMaxwell.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-2d/TestAxialStrainRateGenMaxwell.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-2d/TestAxialTractionMaxwell.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/TestAxialTractionMaxwell.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-2d/TestAxialTractionMaxwell.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialstrain_genmaxwell_gendb.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialstrain_genmaxwell_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-2d/axialstrain_genmaxwell_gendb.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialstrain_genmaxwell_soln.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialstrain_genmaxwell_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-2d/axialstrain_genmaxwell_soln.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialstrainrate_genmaxwell_gendb.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialstrainrate_genmaxwell_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-2d/axialstrainrate_genmaxwell_gendb.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialstrainrate_genmaxwell_soln.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialstrainrate_genmaxwell_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-2d/axialstrainrate_genmaxwell_soln.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialtraction_maxwell_gendb.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialtraction_maxwell_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-2d/axialtraction_maxwell_gendb.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-2d/axialtraction_maxwell_soln.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/axialtraction_maxwell_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-2d/axialtraction_maxwell_soln.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-2d/meshes.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults/2d/meshes.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-2d/test_maxwell.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/test_maxwell.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-2d/axialtraction_maxwell_soln.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-2d/test_pylith.py
+++ b/tests/fullscale/viscoelasticity/nofaults-2d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/fullscale/viscoelasticity/nofaults-3d/Makefile.am
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 TESTS = test_pylith.py

--- a/tests/fullscale/viscoelasticity/nofaults-3d/TestAxialStrainGenMaxwell.py
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/TestAxialStrainGenMaxwell.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-3d/TestAxialStrainGenMaxwell.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-3d/TestAxialStrainRateGenMaxwell.py
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/TestAxialStrainRateGenMaxwell.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-3d/TestAxialStrainRateGenMaxwell.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-3d/TestAxialTractionMaxwell.py
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/TestAxialTractionMaxwell.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-3d/TestAxialTractionMaxwell.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialstrain_genmaxwell_gendb.py
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialstrain_genmaxwell_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-3d/axialstrain_genmaxwell_gendb.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialstrain_genmaxwell_soln.py
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialstrain_genmaxwell_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-3d/axialstrain_genmaxwell_soln.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialstrainrate_genmaxwell_gendb.py
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialstrainrate_genmaxwell_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-3d/axialstrainrate_genmaxwell_gendb.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialstrainrate_genmaxwell_soln.py
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialstrainrate_genmaxwell_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-3d/axialstrainrate_genmaxwell_soln.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialtraction_maxwell_gendb.py
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialtraction_maxwell_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-3d/axialtraction_maxwell_gendb.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-3d/axialtraction_maxwell_soln.py
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/axialtraction_maxwell_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/viscoelasticity/nofaults-3d/axialtraction_maxwell_soln.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-3d/meshes.py
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/meshes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/fullscale/linearelasticity/nofaults/3d/meshes.py
 #

--- a/tests/fullscale/viscoelasticity/nofaults-3d/test_pylith.py
+++ b/tests/fullscale/viscoelasticity/nofaults-3d/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from pylith.testing.FullTestApp import TestDriver, FullTestCase

--- a/tests/libtests/Makefile.am
+++ b/tests/libtests/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/bc/Makefile.am
+++ b/tests/libtests/bc/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/bc/data/AbsorbingDampersDataHex8.cc
+++ b/tests/libtests/bc/data/AbsorbingDampersDataHex8.cc
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
   namespace bc {
         class AbsorbingDampersDataHex8;

--- a/tests/libtests/bc/data/AbsorbingDampersDataHex8.hh
+++ b/tests/libtests/bc/data/AbsorbingDampersDataHex8.hh
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
 
     /// Constructor

--- a/tests/libtests/bc/data/AbsorbingDampersDataTri3.hh
+++ b/tests/libtests/bc/data/AbsorbingDampersDataTri3.hh
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
   namespace bc {
         class AbsorbingDampersDataTri3;

--- a/tests/libtests/bc/data/Makefile.am
+++ b/tests/libtests/bc/data/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/bc/data/PointForceDataTri3.cc
+++ b/tests/libtests/bc/data/PointForceDataTri3.cc
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
  Values
  *   1: 0.3

--- a/tests/libtests/bc/data/absorbingdampers.py
+++ b/tests/libtests/bc/data/absorbingdampers.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/libtests/bc/data/absorbingdampers.py
 

--- a/tests/libtests/faults/Makefile.am
+++ b/tests/libtests/faults/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/faults/data/CohesiveKinDataTri3.hh
+++ b/tests/libtests/faults/data/CohesiveKinDataTri3.hh
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
   namespace faults {
         class CohesiveKinDataTri3;

--- a/tests/libtests/faults/data/CohesiveKinSrcsDataTri3.hh
+++ b/tests/libtests/faults/data/CohesiveKinSrcsDataTri3.hh
@@ -5,7 +5,7 @@
 // Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 // All rights reserved.
 //
-// See https://mit-license.org/ and LICENSE.md and for license information. 
+// See https://mit-license.org/ and LICENSE.md and for license information.
 // =================================================================================================
   namespace faults {
         class CohesiveKinSrcsDataTri3;

--- a/tests/libtests/faults/data/Makefile.am
+++ b/tests/libtests/faults/data/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/feassemble/Makefile.am
+++ b/tests/libtests/feassemble/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/feassemble/data/Makefile.am
+++ b/tests/libtests/feassemble/data/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/initializers/Makefile.am
+++ b/tests/libtests/initializers/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the SpatialData Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 include $(top_srcdir)/tests/check_catch2.am

--- a/tests/libtests/initializers/data/Makefile.am
+++ b/tests/libtests/initializers/data/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/materials/Makefile.am
+++ b/tests/libtests/materials/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/materials/data/IsotropicLinearMaxwellPlaneStrain_VarStrain.py
+++ b/tests/libtests/materials/data/IsotropicLinearMaxwellPlaneStrain_VarStrain.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/libtests/materials/data/IsotropicLinearMaxwellPlaneStrain_VarStrain.py
 

--- a/tests/libtests/materials/data/Makefile.am
+++ b/tests/libtests/materials/data/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/materials/data/maxwell_computevars.py
+++ b/tests/libtests/materials/data/maxwell_computevars.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Code to compute solution and state variables for Maxwell test.
 # ----------------------------------------------------------------------

--- a/tests/libtests/materials/mms_genmax3d.py
+++ b/tests/libtests/materials/mms_genmax3d.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Initial attempt to compute governing equations for generalized Maxwell
 # 3D material and then run assumed solution through these equations.

--- a/tests/libtests/materials/mms_genmaxplanestrain.py
+++ b/tests/libtests/materials/mms_genmaxplanestrain.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Initial attempt to compute governing equations for generalized Maxwell
 # plane strain material and then run assumed solution through these equations.

--- a/tests/libtests/materials/mms_max3d.py
+++ b/tests/libtests/materials/mms_max3d.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Initial attempt to compute governing equations for Maxwell 3D
 # material and then run assumed solution through these equations.

--- a/tests/libtests/materials/mms_maxplanestrain.py
+++ b/tests/libtests/materials/mms_maxplanestrain.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Initial attempt to compute governing equations for Maxwell plane strain
 # material and then run assumed solution through these equations.

--- a/tests/libtests/meshio/Makefile.am
+++ b/tests/libtests/meshio/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 include $(top_srcdir)/tests/check_catch2.am

--- a/tests/libtests/meshio/data/Makefile.am
+++ b/tests/libtests/meshio/data/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/problems/Makefile.am
+++ b/tests/libtests/problems/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/problems/data/Makefile.am
+++ b/tests/libtests/problems/data/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/scales/Makefile.am
+++ b/tests/libtests/scales/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the SpatialData Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 include $(top_srcdir)/tests/check_catch2.am

--- a/tests/libtests/testing/Makefile.am
+++ b/tests/libtests/testing/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/topology/Makefile.am
+++ b/tests/libtests/topology/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 include $(top_srcdir)/tests/check_catch2.am

--- a/tests/libtests/topology/data/Makefile.am
+++ b/tests/libtests/topology/data/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/libtests/utils/Makefile.am
+++ b/tests/libtests/utils/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/manual/2d/nonplanar/bc.jou
+++ b/tests/manual/2d/nonplanar/bc.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 # Cubit journal file for creating blocks and nodesets associated with

--- a/tests/manual/2d/nonplanar/geometry.jou
+++ b/tests/manual/2d/nonplanar/geometry.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 # Cubit journal file with geometry for 2-D nonplanar fault.

--- a/tests/manual/2d/nonplanar/mesh.jou
+++ b/tests/manual/2d/nonplanar/mesh.jou
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 # Cubit journal file for generating a 2-D finite-element mesh with

--- a/tests/manual/3d/relaxation/plot_stressth.py
+++ b/tests/manual/3d/relaxation/plot_stressth.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 from mypylab.Figure import Figure

--- a/tests/manual/Makefile.am
+++ b/tests/manual/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/manual/powerlaw-2d/Makefile.am
+++ b/tests/manual/powerlaw-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/manual/powerlaw-2d/axialtraction_maxwell_soln.py
+++ b/tests/manual/powerlaw-2d/axialtraction_maxwell_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """2-D axial traction solution for linear Maxwell viscoelastic material.
 

--- a/tests/manual/powerlaw-2d/axialtraction_powerlaw_n1_gendb.py
+++ b/tests/manual/powerlaw-2d/axialtraction_powerlaw_n1_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """Create spatial database for power law bulk rheology for axial traction
 problem with n=1 that is consistent with the analytical solution for the

--- a/tests/manual/powerlaw-2d/jacobian_common.py
+++ b/tests/manual/powerlaw-2d/jacobian_common.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Common functions for computing Jacobians.
 # PREREQUISITES:  sympy

--- a/tests/manual/powerlaw-2d/jacobian_powerlaw.py
+++ b/tests/manual/powerlaw-2d/jacobian_powerlaw.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Initial attempt to compute plane strain Jacobian matrices symbolically.
 # PREREQUISITES:  sympy

--- a/tests/manual/powerlaw-2d/plot_axialtraction_powerlaw.py
+++ b/tests/manual/powerlaw-2d/plot_axialtraction_powerlaw.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import numpy

--- a/tests/manual/powerlaw-2d/plot_axialtraction_powerlaw_n1.py
+++ b/tests/manual/powerlaw-2d/plot_axialtraction_powerlaw_n1.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import numpy

--- a/tests/manual/powerlaw-2d/plot_sheartraction_powerlaw.py
+++ b/tests/manual/powerlaw-2d/plot_sheartraction_powerlaw.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import numpy

--- a/tests/manual/powerlaw-2d/run_tests.py
+++ b/tests/manual/powerlaw-2d/run_tests.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import subprocess

--- a/tests/manual/powerlaw-3d/Makefile.am
+++ b/tests/manual/powerlaw-3d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/manual/powerlaw-3d/axialtraction_maxwell_soln.py
+++ b/tests/manual/powerlaw-3d/axialtraction_maxwell_soln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """3-D axial traction solution for linear Maxwell viscoelastic material.
             Tz=T0

--- a/tests/manual/powerlaw-3d/axialtraction_powerlaw_n1_gendb.py
+++ b/tests/manual/powerlaw-3d/axialtraction_powerlaw_n1_gendb.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 """Create spatial database for power law bulk rheology for axial traction
 problem with n=1 that is consistent with the analytical solution for the

--- a/tests/manual/powerlaw-3d/jacobian_common.py
+++ b/tests/manual/powerlaw-3d/jacobian_common.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Common functions for computing Jacobians.
 # PREREQUISITES:  sympy

--- a/tests/manual/powerlaw-3d/jacobian_powerlaw.py
+++ b/tests/manual/powerlaw-3d/jacobian_powerlaw.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # Initial attempt to compute plane strain Jacobian matrices symbolically.
 # PREREQUISITES:  sympy

--- a/tests/manual/powerlaw-3d/plot_axialtraction_powerlaw.py
+++ b/tests/manual/powerlaw-3d/plot_axialtraction_powerlaw.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import numpy

--- a/tests/manual/powerlaw-3d/plot_axialtraction_powerlaw_n1.py
+++ b/tests/manual/powerlaw-3d/plot_axialtraction_powerlaw_n1.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import numpy

--- a/tests/manual/powerlaw-3d/plot_sheartraction_powerlaw.py
+++ b/tests/manual/powerlaw-3d/plot_sheartraction_powerlaw.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import numpy

--- a/tests/manual/powerlaw-3d/run_tests.py
+++ b/tests/manual/powerlaw-3d/run_tests.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import subprocess

--- a/tests/mmstests/Makefile.am
+++ b/tests/mmstests/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/tests/mmstests/incompressibleelasticity/Makefile.am
+++ b/tests/mmstests/incompressibleelasticity/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/tests/mmstests/incompressibleelasticity/nofaults-2d/Makefile.am
+++ b/tests/mmstests/incompressibleelasticity/nofaults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/mmstests/linearelasticity/Makefile.am
+++ b/tests/mmstests/linearelasticity/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/tests/mmstests/linearelasticity/faults-2d/Makefile.am
+++ b/tests/mmstests/linearelasticity/faults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 

--- a/tests/mmstests/linearelasticity/nofaults-2d/Makefile.am
+++ b/tests/mmstests/linearelasticity/nofaults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 include $(top_srcdir)/tests/check_catch2.am

--- a/tests/mmstests/linearelasticity/nofaults-3d/Makefile.am
+++ b/tests/mmstests/linearelasticity/nofaults-3d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 include $(top_srcdir)/tests/check_catch2.am

--- a/tests/mmstests/poroelasticity/Makefile.am
+++ b/tests/mmstests/poroelasticity/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 SUBDIRS = \

--- a/tests/mmstests/poroelasticity/nofaults-2d/Makefile.am
+++ b/tests/mmstests/poroelasticity/nofaults-2d/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 include $(top_srcdir)/tests/check_catch2.am

--- a/tests/pytests/Makefile.am
+++ b/tests/pytests/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 #
 

--- a/tests/pytests/apps/TestEqInfoApp.py
+++ b/tests/pytests/apps/TestEqInfoApp.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/apps/TestPetscApplication.py
+++ b/tests/pytests/apps/TestPetscApplication.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/apps/TestPyLithApp.py
+++ b/tests/pytests/apps/TestPyLithApp.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/pytests/apps/TestPyLithApp.py
 #

--- a/tests/pytests/bc/TestAbsorbingDampers.py
+++ b/tests/pytests/bc/TestAbsorbingDampers.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/bc/TestAuxiliarySubfields.py
+++ b/tests/pytests/bc/TestAuxiliarySubfields.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/pytests/bc/TestAuxiliarySubfields.py
 #

--- a/tests/pytests/bc/TestDirichletTimeDependent.py
+++ b/tests/pytests/bc/TestDirichletTimeDependent.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/bc/TestNeumannTimeDependent.py
+++ b/tests/pytests/bc/TestNeumannTimeDependent.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/bc/TestZeroDB.py
+++ b/tests/pytests/bc/TestZeroDB.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/faults/TestFaultCohesive.py
+++ b/tests/pytests/faults/TestFaultCohesive.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/faults/TestFaultCohesiveImpulses.py
+++ b/tests/pytests/faults/TestFaultCohesiveImpulses.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/faults/TestFaultCohesiveKin.py
+++ b/tests/pytests/faults/TestFaultCohesiveKin.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/faults/TestKinSrc.py
+++ b/tests/pytests/faults/TestKinSrc.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/faults/TestSingleRupture.py
+++ b/tests/pytests/faults/TestSingleRupture.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/initializers/TestConvert.py
+++ b/tests/pytests/initializers/TestConvert.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/initializers/TestInitializePhase.py
+++ b/tests/pytests/initializers/TestInitializePhase.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/initializers/TestInitializer.py
+++ b/tests/pytests/initializers/TestInitializer.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/initializers/TestMeshDistributor.py
+++ b/tests/pytests/initializers/TestMeshDistributor.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/initializers/TestMeshInsertInterfaces.py
+++ b/tests/pytests/initializers/TestMeshInsertInterfaces.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/initializers/TestMeshReader.py
+++ b/tests/pytests/initializers/TestMeshReader.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/initializers/TestMeshRefiner.py
+++ b/tests/pytests/initializers/TestMeshRefiner.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/initializers/TestMeshReordering.py
+++ b/tests/pytests/initializers/TestMeshReordering.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/initializers/TestMeshWriter.py
+++ b/tests/pytests/initializers/TestMeshWriter.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/initializers/TestParallel.py
+++ b/tests/pytests/initializers/TestParallel.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/initializers/TestSerial.py
+++ b/tests/pytests/initializers/TestSerial.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/materials/TestAuxiliarySubfields.py
+++ b/tests/pytests/materials/TestAuxiliarySubfields.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/pytests/materials/TestAuxiliarySubfields.py
 #

--- a/tests/pytests/materials/TestDerivedSubfields.py
+++ b/tests/pytests/materials/TestDerivedSubfields.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/materials/TestElasticity.py
+++ b/tests/pytests/materials/TestElasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/materials/TestHomogeneous.py
+++ b/tests/pytests/materials/TestHomogeneous.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/materials/TestIncompressibleElasticity.py
+++ b/tests/pytests/materials/TestIncompressibleElasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/materials/TestMaterial.py
+++ b/tests/pytests/materials/TestMaterial.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/materials/TestPoroelasticity.py
+++ b/tests/pytests/materials/TestPoroelasticity.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/materials/TestRheologies.py
+++ b/tests/pytests/materials/TestRheologies.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestDataWriter.py
+++ b/tests/pytests/meshio/TestDataWriter.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestDataWriterHDF5.py
+++ b/tests/pytests/meshio/TestDataWriterHDF5.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestDataWriterHDF5Ext.py
+++ b/tests/pytests/meshio/TestDataWriterHDF5Ext.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestDataWriterVTK.py
+++ b/tests/pytests/meshio/TestDataWriterVTK.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestMeshIOAscii.py
+++ b/tests/pytests/meshio/TestMeshIOAscii.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestMeshIOCubit.py
+++ b/tests/pytests/meshio/TestMeshIOCubit.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestMeshIOPetsc.py
+++ b/tests/pytests/meshio/TestMeshIOPetsc.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestOutputObserver.py
+++ b/tests/pytests/meshio/TestOutputObserver.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestOutputPhysics.py
+++ b/tests/pytests/meshio/TestOutputPhysics.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestOutputSoln.py
+++ b/tests/pytests/meshio/TestOutputSoln.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestOutputSolnBoundary.py
+++ b/tests/pytests/meshio/TestOutputSolnBoundary.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestOutputSolnDomain.py
+++ b/tests/pytests/meshio/TestOutputSolnDomain.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestOutputSolnPoints.py
+++ b/tests/pytests/meshio/TestOutputSolnPoints.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestOutputTrigger.py
+++ b/tests/pytests/meshio/TestOutputTrigger.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestOutputTriggerStep.py
+++ b/tests/pytests/meshio/TestOutputTriggerStep.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestOutputTriggerTime.py
+++ b/tests/pytests/meshio/TestOutputTriggerTime.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestPointsList.py
+++ b/tests/pytests/meshio/TestPointsList.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/meshio/TestXdmf.py
+++ b/tests/pytests/meshio/TestXdmf.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/mpi/TestCommunicator.py
+++ b/tests/pytests/mpi/TestCommunicator.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/mpi/TestReduce.py
+++ b/tests/pytests/mpi/TestReduce.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/mpi/testmpi.py
+++ b/tests/pytests/mpi/testmpi.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 # @file tests/bc/testmpi.py
 

--- a/tests/pytests/problems/TestInitialCondition.py
+++ b/tests/pytests/problems/TestInitialCondition.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/problems/TestInitialConditionDomain.py
+++ b/tests/pytests/problems/TestInitialConditionDomain.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/problems/TestInitialConditionPatch.py
+++ b/tests/pytests/problems/TestInitialConditionPatch.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/problems/TestPhysics.py
+++ b/tests/pytests/problems/TestPhysics.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/problems/TestProblem.py
+++ b/tests/pytests/problems/TestProblem.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/problems/TestProblemDefaults.py
+++ b/tests/pytests/problems/TestProblemDefaults.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/problems/TestProgressMonitor.py
+++ b/tests/pytests/problems/TestProgressMonitor.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/problems/TestProgressMonitorTime.py
+++ b/tests/pytests/problems/TestProgressMonitorTime.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/problems/TestSingleObserver.py
+++ b/tests/pytests/problems/TestSingleObserver.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/problems/TestSolution.py
+++ b/tests/pytests/problems/TestSolution.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/problems/TestSolutionSubfields.py
+++ b/tests/pytests/problems/TestSolutionSubfields.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/problems/TestTimeDependent.py
+++ b/tests/pytests/problems/TestTimeDependent.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/test_pylith.py
+++ b/tests/pytests/test_pylith.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 """Script to run pylith Python test suite.

--- a/tests/pytests/topology/TestDistributor.py
+++ b/tests/pytests/topology/TestDistributor.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/topology/TestField.py
+++ b/tests/pytests/topology/TestField.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/topology/TestMesh.py
+++ b/tests/pytests/topology/TestMesh.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/topology/TestRefineUniform.py
+++ b/tests/pytests/topology/TestRefineUniform.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/topology/TestSubfield.py
+++ b/tests/pytests/topology/TestSubfield.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestCollectVersionInfo.py
+++ b/tests/pytests/utils/TestCollectVersionInfo.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestDependenciesVersion.py
+++ b/tests/pytests/utils/TestDependenciesVersion.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestDumpParameters.py
+++ b/tests/pytests/utils/TestDumpParameters.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestDumpParametersAscii.py
+++ b/tests/pytests/utils/TestDumpParametersAscii.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestDumpParametersJson.py
+++ b/tests/pytests/utils/TestDumpParametersJson.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestEmptyBin.py
+++ b/tests/pytests/utils/TestEmptyBin.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestEventLogger.py
+++ b/tests/pytests/utils/TestEventLogger.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestNullComponent.py
+++ b/tests/pytests/utils/TestNullComponent.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestPetscManager.py
+++ b/tests/pytests/utils/TestPetscManager.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestPetscVersion.py
+++ b/tests/pytests/utils/TestPetscVersion.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestProfiling.py
+++ b/tests/pytests/utils/TestProfiling.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/pytests/utils/TestPylithVersion.py
+++ b/tests/pytests/utils/TestPylithVersion.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 import unittest

--- a/tests/src/Makefile.am
+++ b/tests/src/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright (c) 2010-2026, University of California, Davis and the PyLith Development Team.
 # All rights reserved.
 #
-# See https://mit-license.org/ and LICENSE.md and for license information. 
+# See https://mit-license.org/ and LICENSE.md and for license information.
 # =================================================================================================
 
 


### PR DESCRIPTION
- Remove extraneous space from license line at the top of files.
- Remove `AM_MAKEFLAGS = --output-sync-target` due to incompatibility with older make versions.
- Increase tolerance (`tol3d=1.0`) and number of interations (`numIter=5`) in creation of top of slab surface in `examples/subduction-3d/generate_gmsh.py`.

Closes #897 