### PR TITLE
FIX: Remove MPI call after MPI_Finalize() when running pylith_dumpparameters.

### DIFF
--- a/applications/pylith_dumpparameters
+++ b/applications/pylith_dumpparameters
@@ -56,7 +56,7 @@ class ParametersApp(object):
         dumper.inventory.filename = self.filename
         dumper._configure()
 
-        dumper.write(targetapp)
+        dumper.write(targetapp, using_mpi=False)
         return
 
 # ----------------------------------------------------------------------

--- a/pylith/apps/PyLithApp.py
+++ b/pylith/apps/PyLithApp.py
@@ -67,7 +67,7 @@ class PyLithApp(PetscApplication):
 
         # Dump parameters and version information
         self.parameters.preinitialize()
-        self.parameters.write(self)
+        self.parameters.write(self, using_mpi=True)
 
         from pylith.mpi.Communicator import mpi_is_root, mpi_comm_world
 

--- a/pylith/utils/DumpParameters.py
+++ b/pylith/utils/DumpParameters.py
@@ -28,11 +28,10 @@ class DumpParameters(Component):
         """Do minimal initialization."""
         return
 
-    def write(self, app):
-        """Write parameters to ASCII file.
+    def write(self, app, using_mpi):
+        """Write parameters to file.
         """
-        # Do nothing
-        return
+        raise NotImplementedError()
 
     def collect(self, app):
         """Collect version information and parameters.

--- a/pylith/utils/DumpParametersAscii.py
+++ b/pylith/utils/DumpParametersAscii.py
@@ -47,12 +47,13 @@ class DumpParametersAscii(DumpParameters):
         """
         DumpParameters.__init__(self, name)
 
-    def write(self, app):
+    def write(self, app, using_mpi):
         """Write parameters to ASCII file.
         """
-        from pylith.mpi.Communicator import mpi_is_root
-        if not mpi_is_root():
-            return
+        if using_mpi:
+            from pylith.mpi.Communicator import mpi_is_root
+            if not mpi_is_root():
+                return
 
         if self.info is None:
             self.collect(app)

--- a/pylith/utils/DumpParametersJson.py
+++ b/pylith/utils/DumpParametersJson.py
@@ -48,12 +48,13 @@ class DumpParametersJson(DumpParameters):
         """
         DumpParameters.__init__(self, name)
 
-    def write(self, app):
+    def write(self, app, using_mpi):
         """Write parameters to JSON file.
         """
-        from pylith.mpi.Communicator import mpi_is_root
-        if not mpi_is_root():
-            return
+        if using_mpi:
+            from pylith.mpi.Communicator import mpi_is_root
+            if not mpi_is_root():
+                return
 
         if self.info is None:
             self.collect(app)


### PR DESCRIPTION
Closes #906 