### PR TITLE
Remove manual marking of buried fault edges (use automatic marking).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ The version numbers are in the form `MAJOR.MINOR.PATCH`, where major releases in
 
 * **Changed**
   * Update default solver settings for incompressible elasticity for Schur factoriztion from `full` to `lower`.
+  * Set the default length scale to 1 km instead of 100 km for consistency with most quasi-static problem with faults. For simulations with faults, the length scale should be set to the discretization size on the fault; this is related to the preconditioner which links the length scale to the discretization size.
 * **Added**
   * `examples/subduction-3d`: Add expected Gmsh output for geometric operations.
 * **Fixed**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,9 @@ The version numbers are in the form `MAJOR.MINOR.PATCH`, where major releases in
   * Update default solver settings for incompressible elasticity for Schur factoriztion from `full` to `lower`.
   * Set the default length scale to 1 km instead of 100 km for consistency with most quasi-static problem with faults. For simulations with faults, the length scale should be set to the discretization size on the fault; this is related to the preconditioner which links the length scale to the discretization size.
 * **Added**
-  * `examples/subduction-3d`: Add expected Gmsh output for geometric operations.
+  * `examples/subduction-3d`: Add expected Gmsh output for geometric operations in documentation.
 * **Fixed**
-  * `examples/subduction-3d`: Increase tolerance for slab surface creation.
+  * `examples/subduction-3d`: Increase tolerance for slab surface creation. Fix setting mesh filename in parameter files using Cubit mesh.
 * **Developer Changes**
   * Remove flag (`--output-sync=target`) in top-level `Makefile.am` that is not backwards compatible.
 

--- a/benchmarks/linearelasticity/solver-faults-2d/pylithapp.cfg
+++ b/benchmarks/linearelasticity/solver-faults-2d/pylithapp.cfg
@@ -91,9 +91,6 @@ interfaces = [main_fault, west_branch, east_branch]
 label = fault_main
 label_value = 20
 
-edge = fault_main_ends
-edge_value = 30
-
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 
@@ -110,9 +107,6 @@ db_auxiliary_field.query_type = linear
 label =  fault_west
 label_value = 21
 
-edge = fault_west_ends 
-edge_value = 31
-
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 
@@ -127,9 +121,6 @@ db_auxiliary_field.query_type = linear
 ## physical group in the Gmsh Python script.
 label = fault_east
 label_value = 22
-
-edge = fault_east_ends
-edge_value = 32
 
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]

--- a/benchmarks/linearelasticity/solver-faults-3d/generate_gmsh.py
+++ b/benchmarks/linearelasticity/solver-faults-3d/generate_gmsh.py
@@ -158,15 +158,11 @@ class App(GenerateMesh):
         self.s_bottom = surfaces[4]
         self.s_east = surfaces[5]
 
-        # Get fault surfaces and edges using the GUI
+        # Get fault surfaces using the GUI
         self.s_fault_main_north = 17
         self.s_fault_main_south = 18
         self.s_fault_west = 16
         self.s_fault_east = 9
-
-        self.fault_main_edges = [20, 21, 22, 23]
-        self.fault_west_edges = [17, 18, 19]
-        self.fault_east_edges = [19, 24, 25]
 
     def mark(self):
         """Mark geometry for materials, boundary conditions, faults, etc.
@@ -210,15 +206,6 @@ class App(GenerateMesh):
             ),
             BoundaryGroup(
                 name="fault_east", tag=22, dim=2, entities=[self.s_fault_east]
-            ),
-            BoundaryGroup(
-                name="fault_main_edges", tag=30, dim=1, entities=self.fault_main_edges
-            ),
-            BoundaryGroup(
-                name="fault_west_edges", tag=31, dim=1, entities=self.fault_west_edges
-            ),
-            BoundaryGroup(
-                name="fault_east_edges", tag=32, dim=1, entities=self.fault_east_edges
             ),
         )
         for group in face_groups:

--- a/benchmarks/linearelasticity/solver-faults-3d/pylithapp.cfg
+++ b/benchmarks/linearelasticity/solver-faults-3d/pylithapp.cfg
@@ -103,9 +103,6 @@ interfaces = [main_fault, west_branch, east_branch]
 label = fault_main
 label_value = 20
 
-edge = fault_main_edges
-edge_value = 30
-
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 
@@ -122,9 +119,6 @@ db_auxiliary_field.query_type = linear
 label =  fault_west
 label_value = 21
 
-edge = fault_west_edges
-edge_value = 31
-
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 
@@ -140,9 +134,6 @@ db_auxiliary_field.query_type = linear
 ## physical group in the Gmsh Python script.
 label = fault_east
 label_value = 22
-
-edge = fault_east_edges
-edge_value = 32
 
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]

--- a/docs/user/components/faults/FaultCohesiveKin.md
+++ b/docs/user/components/faults/FaultCohesiveKin.md
@@ -61,7 +61,6 @@ Example of setting `FaultCohesiveKin` Pyre properties and facilities in a parame
 # Specify prescribed slip on a fault via two earthquakes in a 2D domain.
 [pylithapp.problem.interfaces.fault]
 label = fault
-edge = fault_edge
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/docs/user/components/scales/DynamicElasticity.md
+++ b/docs/user/components/scales/DynamicElasticity.md
@@ -33,7 +33,7 @@ Example of setting `DynamicElasticity` Pyre properties and facilities in a param
 
 :::{code-block} cfg
 [normalizer]
-length_scale = 100.0*km
+length_scale = 1.0*km
 displacement_scale = 50.0*km
 shear_modulus = 25.0*GPa
 velocity_scale = 3.0*km/s

--- a/docs/user/components/scales/QuasistaticElasticity.md
+++ b/docs/user/components/scales/QuasistaticElasticity.md
@@ -33,7 +33,7 @@ Example of setting `QuasistaticElasticity` Pyre properties and facilities in a p
 
 :::{code-block} cfg
 [normalizer]
-length_scale = 100.0*km
+length_scale = 1.0*km
 displacement_scale = 50.0*km
 shear_modulus = 25.0*GPa
 time_scale = 100.0*year

--- a/docs/user/components/scales/QuasistaticPoroelasticity.md
+++ b/docs/user/components/scales/QuasistaticPoroelasticity.md
@@ -37,7 +37,7 @@ Example of setting `QuasistaticPoroelasticity` Pyre properties and facilities in
 
 :::{code-block} cfg
 [normalizer]
-length_scale = 100.0*km
+length_scale = 1.0*km
 displacement_scale = 50.0*km
 shear_modulus = 25.0*GPa
 viscosity = 0.001*Pa*s

--- a/docs/user/examples/crustal-strikeslip-2d/common-information.md
+++ b/docs/user/examples/crustal-strikeslip-2d/common-information.md
@@ -100,9 +100,6 @@ interfaces = [main_fault, west_branch, east_branch]
 label = fault_main
 label_value = 20
 
-edge = fault_main_ends
-edge_value = 30
-
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 
@@ -113,9 +110,6 @@ observers.observer.data_fields = [slip, traction_change]
 label =  fault_west
 label_value = 21
 
-edge = fault_west_ends 
-edge_value = 31
-
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 
@@ -125,9 +119,6 @@ observers.observer.data_fields = [slip, traction_change]
 ## physical group in the Gmsh Python script.
 label = fault_east
 label_value = 22
-
-edge = fault_east_ends
-edge_value = 32
 
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]

--- a/docs/user/examples/crustal-strikeslip-3d/common-information.md
+++ b/docs/user/examples/crustal-strikeslip-3d/common-information.md
@@ -111,9 +111,6 @@ interfaces = [main_fault, west_branch, east_branch]
 label = fault_main
 label_value = 20
 
-edge = fault_main_edges
-edge_value = 30
-
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 
@@ -124,9 +121,6 @@ observers.observer.data_fields = [slip, traction_change]
 label =  fault_west
 label_value = 21
 
-edge = fault_west_edges 
-edge_value = 31
-
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 
@@ -136,9 +130,6 @@ observers.observer.data_fields = [slip, traction_change]
 ## physical group in the Gmsh Python script.
 label = fault_east
 label_value = 22
-
-edge = fault_east_edges
-edge_value = 32
 
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]

--- a/docs/user/examples/reverse-2d/step05-onefault.md
+++ b/docs/user/examples/reverse-2d/step05-onefault.md
@@ -51,8 +51,6 @@ solution = pylith.problems.SolnDispLagrange
 [pylithapp.problem.interfaces.fault]
 label = fault
 label_value = 20
-edge = fault_end
-edge_value = 21
 observers.observer.data_fields = [slip, traction_change]
 
 [pylithapp.problem.interfaces.fault.eq_ruptures.rupture]

--- a/docs/user/examples/reverse-2d/step06-twofaults-elastic.md
+++ b/docs/user/examples/reverse-2d/step06-twofaults-elastic.md
@@ -63,8 +63,6 @@ interfaces = [fault, splay]
 [pylithapp.problem.interfaces.fault]
 label = fault
 label_value = 20
-edge = fault_end
-edge_value = 21
 
 observers.observer.data_fields = [slip, traction_change]
 
@@ -77,8 +75,6 @@ db_auxiliary_field.data = [0.0*s, -2.0*m, 0.0*m]
 [pylithapp.problem.interfaces.splay]
 label = splay
 label_value = 22
-edge = splay_end
-edge_value = 23
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/docs/user/examples/subduction-2d/step01-coseismic.md
+++ b/docs/user/examples/subduction-2d/step01-coseismic.md
@@ -31,8 +31,6 @@ interfaces = [fault]
 [pylithapp.problem.interfaces.fault]
 label = fault_slabtop
 label_value = 21
-edge = fault_slabtop_edge
-edge_value = 31
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/docs/user/examples/subduction-2d/step02-interseismic.md
+++ b/docs/user/examples/subduction-2d/step02-interseismic.md
@@ -43,8 +43,6 @@ interfaces = [fault_slabtop, fault_slabbot]
 [pylithapp.problem.interfaces.fault_slabtop]
 label = fault_slabtop
 label_value = 21
-edge = fault_slabtop_edge
-edge_value = 31
 
 observers.observer.data_fields = [slip, traction_change]
 
@@ -61,8 +59,6 @@ db_auxiliary_field.query_type = linear
 [pylithapp.problem.interfaces.fault_slabbot]
 label = fault_slabbot
 label_value = 22
-edge = fault_slabbot_edge
-edge_value = 32
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/docs/user/examples/subduction-2d/step03-eqcycle.md
+++ b/docs/user/examples/subduction-2d/step03-eqcycle.md
@@ -31,8 +31,6 @@ interfaces = [fault_slabtop, fault_slabbot]
 [pylithapp.problem.interfaces.fault_slabtop]
 label = fault_slabtop
 label_value = 21
-edge = fault_slabtop_edge
-edge_value = 31
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/examples/crustal-strikeslip-2d/pylithapp.cfg
+++ b/examples/crustal-strikeslip-2d/pylithapp.cfg
@@ -95,9 +95,6 @@ interfaces = [main_fault, west_branch, east_branch]
 label = fault_main
 label_value = 20
 
-edge = fault_main_ends
-edge_value = 30
-
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 
@@ -108,9 +105,6 @@ observers.observer.data_fields = [slip, traction_change]
 label =  fault_west
 label_value = 21
 
-edge = fault_west_ends 
-edge_value = 31
-
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 
@@ -120,9 +114,6 @@ observers.observer.data_fields = [slip, traction_change]
 ## physical group in the Gmsh Python script.
 label = fault_east
 label_value = 22
-
-edge = fault_east_ends
-edge_value = 32
 
 # Output `slip` and `traction_changes` on the fault.
 observers.observer.data_fields = [slip, traction_change]

--- a/examples/crustal-strikeslip-2d/step01_slip_cubit.cfg
+++ b/examples/crustal-strikeslip-2d/step01_slip_cubit.cfg
@@ -44,13 +44,8 @@ bc_west.label_value = 1
 # PyLith uses the nodeset names not the ids from Cubit. Label values are 1.
 [pylithapp.problem.interfaces]
 main_fault.label_value = 1
-main_fault.edge_value = 1
-
 west_branch.label_value = 1
-west_branch.edge_value = 1
-
 east_branch.label_value = 1
-east_branch.edge_value = 1
 
 
 [pylithapp.problem.interfaces.main_fault.eq_ruptures.rupture]

--- a/examples/crustal-strikeslip-3d/generate_gmsh.py
+++ b/examples/crustal-strikeslip-3d/generate_gmsh.py
@@ -143,15 +143,11 @@ class App(GenerateMesh):
         self.s_bottom = surfaces[4]
         self.s_east = surfaces[5]
 
-        # Get fault surfaces and edges using the GUI
+        # Get fault surfaces using the GUI
         self.s_fault_main_north = 17
         self.s_fault_main_south = 18
         self.s_fault_west = 16
         self.s_fault_east = 9
-
-        self.fault_main_edges = [20, 21, 22, 23]
-        self.fault_west_edges = [17, 18, 19]
-        self.fault_east_edges = [19, 24, 25]
 
     def mark(self):
         """Mark geometry for materials, boundary conditions, faults, etc.
@@ -195,15 +191,6 @@ class App(GenerateMesh):
             ),
             BoundaryGroup(
                 name="fault_east", tag=22, dim=2, entities=[self.s_fault_east]
-            ),
-            BoundaryGroup(
-                name="fault_main_edges", tag=30, dim=1, entities=self.fault_main_edges
-            ),
-            BoundaryGroup(
-                name="fault_west_edges", tag=31, dim=1, entities=self.fault_west_edges
-            ),
-            BoundaryGroup(
-                name="fault_east_edges", tag=32, dim=1, entities=self.fault_east_edges
             ),
         )
         for group in face_groups:

--- a/examples/meshing-cubit/surface-nurbs/merge-surfs/pylithapp.cfg
+++ b/examples/meshing-cubit/surface-nurbs/merge-surfs/pylithapp.cfg
@@ -81,7 +81,6 @@ interfaces = [fault]
 [pylithapp.problem.interfaces.fault]
 id = 10
 label = fault
-edge = fault_edge
 
 observers.observer.writer.filename = output/faultslip-fault.h5
 observers.observer.data_fields = [slip, traction_change]

--- a/examples/poroelastic-outerrise-2d/generate_gmsh.py
+++ b/examples/poroelastic-outerrise-2d/generate_gmsh.py
@@ -132,8 +132,6 @@ class App(GenerateMesh):
             face_groups = np.append(face_groups, BoundaryGroup(name="fault_" + str(i), \
                                                                  tag=201 + i, dim=1, entities=[self.c_outer_rise_faults[i]]))
 
-            face_groups = np.append(face_groups, BoundaryGroup(name="edge_fault_" + str(i), tag=301 + i, dim=0, \
-                                                                 entities=[int(self.outer_rise_fault_buried_edges[i])]))
         for group in face_groups:
             group.create_physical_group()
 

--- a/examples/reverse-2d/step05b_onefault.cfg
+++ b/examples/reverse-2d/step05b_onefault.cfg
@@ -75,12 +75,10 @@ interfaces = [fault]
 
 [pylithapp.problem.interfaces.fault]
 # The `label` and `label_value` correspond to the name and tag of the physical group
-# for the fault in the Gmsh Python script. The `edge` and `edge_value` correspond to
-# the name and tag of the physical group for the fault end in the Gmsh Python script.
+# for the fault in the Gmsh Python script.
 label = fault
 label_value = 20
-edge = fault_end
-edge_value = 21
+
 observers.observer.data_fields = [slip, traction_change]
 
 [pylithapp.problem.interfaces.fault.eq_ruptures.rupture]

--- a/examples/reverse-2d/step05c_onefault.cfg
+++ b/examples/reverse-2d/step05c_onefault.cfg
@@ -89,12 +89,10 @@ interfaces = [fault]
 
 [pylithapp.problem.interfaces.fault]
 # The `label` and `label_value` correspond to the name and tag of the physical group
-# for the fault in the Gmsh Python script. The `edge` and `edge_value` correspond to
-# the name and tag of the physical group for the fault end in the Gmsh Python script.
+# for the fault in the Gmsh Python script.
 label = fault
 label_value = 20
-edge = fault_end
-edge_value = 21
+
 observers.observer.data_fields = [slip, traction_change]
 
 [pylithapp.problem.interfaces.fault.eq_ruptures.rupture]

--- a/examples/reverse-2d/step06_twofaults_elastic.cfg
+++ b/examples/reverse-2d/step06_twofaults_elastic.cfg
@@ -85,8 +85,7 @@ db_auxiliary_field.iohandler.filename = mat_elastic.spatialdb
 interfaces = [fault, splay]
 
 # The `label` and `label_value` correspond to the name and tag of the physical group
-# for the fault in the Gmsh Python script. The `edge` and `edge_value` correspond to
-# the name and tag of the physical group for the fault end in the Gmsh Python script.
+# for the fault in the Gmsh Python script.
 [pylithapp.problem.interfaces.fault]
 label = fault
 label_value = 20

--- a/examples/reverse-2d/step07_twofaults_maxwell.cfg
+++ b/examples/reverse-2d/step07_twofaults_maxwell.cfg
@@ -125,8 +125,6 @@ interfaces = [fault, splay]
 [pylithapp.problem.interfaces.fault]
 label = fault
 label_value = 20
-edge = fault_end
-edge_value = 21
 
 observers.observer.data_fields = [slip, traction_change]
 
@@ -140,8 +138,6 @@ db_auxiliary_field.data = [0.0*s, -2.0*m, 0.0*m]
 [pylithapp.problem.interfaces.splay]
 label = splay
 label_value = 22
-edge = splay_end
-edge_value = 23
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/examples/reverse-2d/step08_twofaults_powerlaw.cfg
+++ b/examples/reverse-2d/step08_twofaults_powerlaw.cfg
@@ -148,8 +148,6 @@ interfaces = [fault, splay]
 [pylithapp.problem.interfaces.fault]
 label = fault
 label_value = 20
-edge = fault_end
-edge_value = 21
 
 observers.observer.data_fields = [slip, traction_change]
 
@@ -163,8 +161,6 @@ db_auxiliary_field.data = [0.0*s, -2.0*m, 0.0*m]
 [pylithapp.problem.interfaces.splay]
 label = splay
 label_value = 22
-edge = splay_end
-edge_value = 23
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/examples/subduction-2d/generate_gmsh.py
+++ b/examples/subduction-2d/generate_gmsh.py
@@ -216,11 +216,8 @@ class App(GenerateMesh):
             BoundaryGroup(name="boundary_east_mantle_tmp", tag=113, dim=1, entities=[self.c_east_mantle]),
             BoundaryGroup(name="boundary_bot", tag=14, dim=1, entities=[self.c_bot]),
             BoundaryGroup(name="fault_coseismic", tag=20, dim=1, entities=[self.c_slabtop_mantle_upper, self.c_slabtop_crust]),
-            BoundaryGroup(name="fault_coseismic_edge", tag=30, dim=0, entities=[self.p_slabtop_coseismic]),
             BoundaryGroup(name="fault_slabtop", tag=21, dim=1, entities=[self.c_slabtop_mantle_lower, self.c_slabtop_mantle_upper, self.c_slabtop_crust]),
-            BoundaryGroup(name="fault_slabtop_edge", tag=31, dim=0, entities=[self.p_slabtop_west]),
             BoundaryGroup(name="fault_slabbot", tag=22, dim=1, entities=[self.c_slabbot]),
-            BoundaryGroup(name="fault_slabbot_edge", tag=32, dim=0, entities=[self.p_slabbot_west]),
         )
         for group in face_groups:
             group.create_physical_group()

--- a/examples/subduction-2d/step01_coseismic.cfg
+++ b/examples/subduction-2d/step01_coseismic.cfg
@@ -38,8 +38,6 @@ interfaces = [fault]
 # physical group in the Gmsh Python script.
 label = fault_slabtop
 label_value = 21
-edge = fault_slabtop_edge
-edge_value = 31
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/examples/subduction-2d/step02_interseismic.cfg
+++ b/examples/subduction-2d/step02_interseismic.cfg
@@ -51,8 +51,6 @@ interfaces = [fault_slabtop, fault_slabbot]
 # group in the Gmsh Python script.
 label = fault_slabtop
 label_value = 21
-edge = fault_slabtop_edge
-edge_value = 31
 
 observers.observer.data_fields = [slip, traction_change]
 
@@ -75,8 +73,6 @@ db_auxiliary_field.query_type = linear
 # group in the Gmsh Python script.
 label = fault_slabbot
 label_value = 22
-edge = fault_slabbot_edge
-edge_value = 32
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/examples/subduction-2d/step03_eqcycle.cfg
+++ b/examples/subduction-2d/step03_eqcycle.cfg
@@ -52,8 +52,6 @@ interfaces = [fault_slabtop, fault_slabbot]
 # group in the Gmsh Python script.
 label = fault_slabtop
 label_value = 21
-edge = fault_slabtop_edge
-edge_value = 31
 
 observers.observer.data_fields = [slip, traction_change]
 
@@ -91,8 +89,6 @@ db_auxiliary_field.query_type = linear
 [pylithapp.problem.interfaces.fault_slabbot]
 label = fault_slabbot
 label_value = 22
-edge = fault_slabbot_edge
-edge_value = 32
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/examples/subduction-3d/generate_gmsh.py
+++ b/examples/subduction-3d/generate_gmsh.py
@@ -160,20 +160,9 @@ class App(GenerateMesh):
 
         # Faults
         self.slab_top = [69, 71, 79, 83] + [70, 84]
-        # self.slab_top_edge = [118] # mac
-        self.slab_top_edge = [96]  # linux
-
         self.slab_bottom = [57, 66]
-        # self.slab_bottom_edge = [109] # mac
-        self.slab_bottom_edge = [87]  # linux
-
         self.slab_top_patch = [70, 84]
-        # self.slab_top_patch_edge = [200, 223, 182, 224, 203] # mac
-        self.slab_top_patch_edge = [160, 178, 181, 201, 202]  # linux
-
         self.surface_splay = [72]
-        # self.splay_edge = [201, 204, 205] # mac
-        self.splay_edge = [179, 182, 183]  # linux
 
     def mark(self):
         """Mark geometry for materials, boundary conditions, faults, etc."""
@@ -238,31 +227,13 @@ class App(GenerateMesh):
             ),
             BoundaryGroup(name="fault_slabtop", tag=30, dim=2, entities=self.slab_top),
             BoundaryGroup(
-                name="fault_slabtop_edge", tag=130, dim=1, entities=self.slab_top_edge
-            ),
-            BoundaryGroup(
                 name="fault_slabbot", tag=31, dim=2, entities=self.slab_bottom
-            ),
-            BoundaryGroup(
-                name="fault_slabbot_edge",
-                tag=131,
-                dim=1,
-                entities=self.slab_bottom_edge,
             ),
             BoundaryGroup(
                 name="fault_slabtop_patch", tag=32, dim=2, entities=self.slab_top_patch
             ),
             BoundaryGroup(
-                name="fault_slabtop_patch_edge",
-                tag=132,
-                dim=1,
-                entities=self.slab_top_patch_edge,
-            ),
-            BoundaryGroup(
                 name="fault_splay", tag=33, dim=2, entities=self.surface_splay
-            ),
-            BoundaryGroup(
-                name="fault_splay_edge", tag=133, dim=1, entities=self.splay_edge
             ),
         )
         for group in face_groups:

--- a/examples/subduction-3d/pylithapp.cfg
+++ b/examples/subduction-3d/pylithapp.cfg
@@ -23,7 +23,7 @@ features = [
 device = color-console
 
 # ----------------------------------------------------------------------
-# mesh_generator
+# mesh initialization
 # ----------------------------------------------------------------------
 # We use a mesh from Gmsh, so we need to change the reader
 # from the default (MeshIOAscii) and set the filename.

--- a/examples/subduction-3d/step01_axialdisp_cubit.cfg
+++ b/examples/subduction-3d/step01_axialdisp_cubit.cfg
@@ -16,7 +16,7 @@ features = [
 # output filenames. The default directory for output is 'output'.
 defaults.name = step01_axialdisp_cubit
 
-[pylithapp.mesh_generator]
+[pylithapp.problem.mesh_initializer.phases.read_mesh]
 reader = pylith.meshio.MeshIOCubit
 reader.filename = input/mesh_tet.exo
 

--- a/examples/subduction-3d/step02_coseismic.cfg
+++ b/examples/subduction-3d/step02_coseismic.cfg
@@ -81,14 +81,9 @@ interfaces = [fault_slabtop]
 
 [pylithapp.problem.interfaces.fault_slabtop]
 # The `label` corresponds to the name of the nodeset in the Cubit journal file.
-# Out fault patch has edges buried in the domain, so we need to specify the buried
-# using the `edge` properties, which corresponds to the name of the corresponding
-# nodeset in the Cubit journal file
+# Out fault patch has edges buried in the domain.
 label = fault_slabtop_patch
 label_value = 32
-
-edge = fault_slabtop_patch_edge
-edge_value = 132
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/examples/subduction-3d/step02_coseismic_cubit.cfg
+++ b/examples/subduction-3d/step02_coseismic_cubit.cfg
@@ -27,7 +27,6 @@ reader.filename = input/mesh_tet.exo
 
 [pylithapp.problem.interfaces.fault_slabtop]
 label_value = 1
-edge_value = 1
 
 [pylithapp.problem.solution_observers.groundsurf]
 label_value = 1

--- a/examples/subduction-3d/step02_coseismic_cubit.cfg
+++ b/examples/subduction-3d/step02_coseismic_cubit.cfg
@@ -21,7 +21,7 @@ version = 2.0.0
 # output filenames. The default directory for output is 'output'.
 defaults.name = step02_coseismic_cubit
 
-[pylithapp.mesh_generator]
+[pylithapp.problem.mesh_initializer.phases.read_mesh]
 reader = pylith.meshio.MeshIOCubit
 reader.filename = input/mesh_tet.exo
 

--- a/examples/subduction-3d/step03_interseismic.cfg
+++ b/examples/subduction-3d/step03_interseismic.cfg
@@ -85,9 +85,6 @@ interfaces = [fault_slabbot, fault_slabtop]
 label = fault_slabbot
 label_value = 31
 
-edge = fault_slabbot_edge
-edge_value = 131
-
 # Some portions of the bottom of the slab are perfectly horizontal, so
 # our procedure that uses the vertical direction and the fault normal
 # to set the along-strike and up-dip shear components breaks down. We
@@ -112,9 +109,6 @@ db_auxiliary_field.data = [+2.0*cm/year, -4.0*cm/year, 0.0*cm/year, 0.0*year]
 [pylithapp.problem.interfaces.fault_slabtop]
 label = fault_slabtop
 label_value = 30
-
-edge = fault_slabtop_edge
-edge_value = 130
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/examples/subduction-3d/step03_interseismic_cubit.cfg
+++ b/examples/subduction-3d/step03_interseismic_cubit.cfg
@@ -24,7 +24,7 @@ version = 2.0.0
 # output filenames. The default directory for output is 'output'.
 defaults.name = step03_interseismic_cubit
 
-[pylithapp.mesh_generator]
+[pylithapp.problem.mesh_initializer.phases.read_mesh]
 reader = pylith.meshio.MeshIOCubit
 reader.filename = input/mesh_tet.exo
 

--- a/examples/subduction-3d/step03_interseismic_cubit.cfg
+++ b/examples/subduction-3d/step03_interseismic_cubit.cfg
@@ -30,11 +30,9 @@ reader.filename = input/mesh_tet.exo
 
 [pylithapp.problem.interfaces.fault_slabbot]
 label_value = 1
-edge_value = 1
 
 [pylithapp.problem.interfaces.fault_slabtop]
 label_value = 1
-edge_value = 1
 
 [pylithapp.problem.solution_observers.groundsurf]
 label_value = 1

--- a/examples/subduction-3d/step04_eqcycle.cfg
+++ b/examples/subduction-3d/step04_eqcycle.cfg
@@ -87,9 +87,6 @@ interfaces = [fault_slabbot, fault_slabtop, splay]
 label = fault_slabbot
 label_value = 31
 
-edge = fault_slabbot_edge
-edge_value = 131
-
 # Some portions of the bottom of the slab are perfectly horizontal, so
 # our procedure that uses the vertical direction and the fault normal
 # to set the along-strike and up-dip shear components breaks down. We
@@ -114,9 +111,6 @@ db_auxiliary_field.data = [+2.0*cm/year, -4.0*cm/year, 0.0*cm/year, 0.0*year]
 [pylithapp.problem.interfaces.fault_slabtop]
 label = fault_slabtop
 label_value = 30
-
-edge = fault_slabtop_edge
-edge_value = 130
 
 observers.observer.data_fields = [slip, traction_change]
 
@@ -152,9 +146,6 @@ db_auxiliary_field.query_type = linear
 [pylithapp.problem.interfaces.splay]
 label = fault_splay
 label_value = 33
-
-edge = fault_splay_edge
-edge_value = 133
 
 observers.observer.data_fields = [slip, traction_change]
 

--- a/examples/subduction-3d/step04_eqcycle_cubit.cfg
+++ b/examples/subduction-3d/step04_eqcycle_cubit.cfg
@@ -29,15 +29,12 @@ reader.filename = input/mesh_tet.exo
 
 [pylithapp.problem.interfaces.fault_slabbot]
 label_value = 1
-edge_value = 1
 
 [pylithapp.problem.interfaces.fault_slabtop]
 label_value = 1
-edge_value = 1
 
 [pylithapp.problem.interfaces.splay]
 label_value = 1
-edge_value = 1
 
 [pylithapp.problem.solution_observers.groundsurf]
 label_value = 1

--- a/examples/subduction-3d/step04_eqcycle_cubit.cfg
+++ b/examples/subduction-3d/step04_eqcycle_cubit.cfg
@@ -23,7 +23,7 @@ version = 2.0.0
 # output filenames. The default directory for output is 'output'.
 defaults.name = step04_eqcycle_cubit
 
-[pylithapp.mesh_generator]
+[pylithapp.problem.mesh_initializer.phases.read_mesh]
 reader = pylith.meshio.MeshIOCubit
 reader.filename = input/mesh_tet.exo
 

--- a/examples/subduction-3d/step06_slowslip.cfg
+++ b/examples/subduction-3d/step06_slowslip.cfg
@@ -105,9 +105,6 @@ interfaces = [fault_slabtop]
 label = fault_slabtop_patch
 label_value = 32
 
-edge = fault_slabtop_patch_edge
-edge_value = 132
-
 observers.observer.data_fields = [slip, traction_change]
 
 # We use a time history slip function.

--- a/examples/subduction-3d/step06_slowslip_cubit.cfg
+++ b/examples/subduction-3d/step06_slowslip_cubit.cfg
@@ -34,7 +34,7 @@ pylith_version = [>3.0]
 # output filenames. The default directory for output is 'output'.
 defaults.name = step06_slowslip_cubit
 
-[pylithapp.mesh_generator]
+[pylithapp.problem.mesh_initializer.phases.read_mesh]
 reader = pylith.meshio.MeshIOCubit
 reader.filename = input/mesh_tet.exo
 

--- a/examples/subduction-3d/step06_slowslip_cubit.cfg
+++ b/examples/subduction-3d/step06_slowslip_cubit.cfg
@@ -44,7 +44,6 @@ reader.filename = cgnss_stations_flat.txt
 
 [pylithapp.problem.interfaces.fault_slabtop]
 label_value = 1
-edge_value = 1
 
 [pylithapp.problem.solution_observers.groundsurf]
 label_value = 1

--- a/examples/subduction-3d/step07a_leftlateral.cfg
+++ b/examples/subduction-3d/step07a_leftlateral.cfg
@@ -84,9 +84,6 @@ interfaces.fault_slabtop = pylith.faults.FaultCohesiveImpulses
 label = fault_slabtop_patch
 label_value = 32
 
-edge = fault_slabtop_patch_edge
-edge_value = 132
-
 # Output `slip` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 

--- a/examples/subduction-3d/step07a_leftlateral_cubit.cfg
+++ b/examples/subduction-3d/step07a_leftlateral_cubit.cfg
@@ -26,7 +26,7 @@ pylith_version = [>3.0]
 # output filenames. The default directory for output is 'output'.
 defaults.name = step07a_leftlateral_cubit
 
-[pylithapp.mesh_generator]
+[pylithapp.problem.mesh_initializer.phases.read_mesh]
 reader = pylith.meshio.MeshIOCubit
 reader.filename = input/mesh_tet.exo
 

--- a/examples/subduction-3d/step07a_leftlateral_cubit.cfg
+++ b/examples/subduction-3d/step07a_leftlateral_cubit.cfg
@@ -40,7 +40,6 @@ label_value = 1
 [pylithapp.problem.interfaces.fault_slabtop]
 # patch
 label_value = 1
-edge_value = 1
 
 [pylithapp.problem.solution_observers.groundsurf]
 label_value = 1

--- a/examples/subduction-3d/step07b_reverse.cfg
+++ b/examples/subduction-3d/step07b_reverse.cfg
@@ -84,9 +84,6 @@ interfaces.fault_slabtop = pylith.faults.FaultCohesiveImpulses
 label = fault_slabtop_patch
 label_value = 32
 
-edge = fault_slabtop_patch_edge
-edge_value = 132
-
 # Output `slip` on the fault.
 observers.observer.data_fields = [slip, traction_change]
 

--- a/examples/subduction-3d/step07b_reverse_cubit.cfg
+++ b/examples/subduction-3d/step07b_reverse_cubit.cfg
@@ -39,7 +39,6 @@ label_value = 1
 
 [pylithapp.problem.interfaces.fault_slabtop]
 label_value = 1
-edge_value = 1
 
 [pylithapp.problem.solution_observers.groundsurf]
 label_value = 1

--- a/examples/subduction-3d/step07b_reverse_cubit.cfg
+++ b/examples/subduction-3d/step07b_reverse_cubit.cfg
@@ -26,7 +26,7 @@ pylith_version = [>3.0]
 # output filenames. The default directory for output is 'output'.
 defaults.name = step07b_reverse_cubit
 
-[pylithapp.mesh_generator]
+[pylithapp.problem.mesh_initializer.phases.read_mesh]
 reader = pylith.meshio.MeshIOCubit
 reader.filename = input/mesh_tet.exo
 

--- a/examples/subduction-3d/step08a_gravity_refstate_cubit.cfg
+++ b/examples/subduction-3d/step08a_gravity_refstate_cubit.cfg
@@ -27,7 +27,7 @@ pylith_version = [>3.0]
 # output filenames. The default directory for output is 'output'.
 defaults.name = step08a_gravity_refstate_cubit
 
-[pylithapp.mesh_generator]
+[pylithapp.problem.mesh_initializer.phases.read_mesh]
 reader = pylith.meshio.MeshIOCubit
 reader.filename = input/mesh_tet.exo
 

--- a/examples/subduction-3d/step08b_gravity_incompressible_cubit.cfg
+++ b/examples/subduction-3d/step08b_gravity_incompressible_cubit.cfg
@@ -25,7 +25,7 @@ pylith_version = [>3.0]
 # output filenames. The default directory for output is 'output'.
 defaults.name = step08b_gravity_incompressible_cubit
 
-[pylithapp.mesh_generator]
+[pylithapp.problem.mesh_initializer.phases.read_mesh]
 reader = pylith.meshio.MeshIOCubit
 reader.filename = input/mesh_tet.exo
 

--- a/examples/subduction-3d/step08c_gravity_viscoelastic_cubit.cfg
+++ b/examples/subduction-3d/step08c_gravity_viscoelastic_cubit.cfg
@@ -25,7 +25,7 @@ pylith_version = [>3.0]
 # output filenames. The default directory for output is 'output'.
 defaults.name = step08c_gravity_viscoelastic_cubit
 
-[pylithapp.mesh_generator]
+[pylithapp.problem.mesh_initializer.phases.read_mesh]
 reader = pylith.meshio.MeshIOCubit
 reader.filename = input/mesh_tet.exo
 

--- a/examples/troubleshooting-2d/.err-step06_twofaults.cfg
+++ b/examples/troubleshooting-2d/.err-step06_twofaults.cfg
@@ -69,8 +69,7 @@ end_time = 40.0*year
 interfaces = [splay, fault]
 
 # The `label` and `label_value` correspond to the name and tag of the physical group
-# for the fault in the Gmsh Python script. The `edge` and `edge_value` correspond to
-# the name and tag of the physical group for the fault end in the Gmsh Python script.
+# for the fault in the Gmsh Python script.
 [pylithapp.problem.interfaces.fault]
 label = fault
 label_value = 20

--- a/examples/troubleshooting-2d/.step06-fix01-step06_twofaults.cfg
+++ b/examples/troubleshooting-2d/.step06-fix01-step06_twofaults.cfg
@@ -69,8 +69,7 @@ end_time = 40.0*year
 interfaces = [splay, fault]
 
 # The `label` and `label_value` correspond to the name and tag of the physical group
-# for the fault in the Gmsh Python script. The `edge` and `edge_value` correspond to
-# the name and tag of the physical group for the fault end in the Gmsh Python script.
+# for the fault in the Gmsh Python script.
 [pylithapp.problem.interfaces.fault]
 label = fault
 label_value = 20

--- a/examples/troubleshooting-2d/step06_twofaults.cfg
+++ b/examples/troubleshooting-2d/step06_twofaults.cfg
@@ -69,8 +69,7 @@ end_time = 40.0*year
 interfaces = [splay, fault]
 
 # The `label` and `label_value` correspond to the name and tag of the physical group
-# for the fault in the Gmsh Python script. The `edge` and `edge_value` correspond to
-# the name and tag of the physical group for the fault end in the Gmsh Python script.
+# for the fault in the Gmsh Python script.
 [pylithapp.problem.interfaces.fault]
 label = fault
 label_value = 20

--- a/pylith/scales/DynamicElasticity.py
+++ b/pylith/scales/DynamicElasticity.py
@@ -21,7 +21,7 @@ class DynamicElasticity(General):
     DOC_CONFIG = {
         "cfg": """
             [normalizer]
-            length_scale = 100.0*km
+            length_scale = 1.0*km
             displacement_scale = 50.0*km
             shear_modulus = 25.0*GPa
             velocity_scale = 3.0*km/s

--- a/pylith/scales/QuasistaticElasticity.py
+++ b/pylith/scales/QuasistaticElasticity.py
@@ -21,7 +21,7 @@ class QuasistaticElasticity(General):
     DOC_CONFIG = {
         "cfg": """
             [normalizer]
-            length_scale = 100.0*km
+            length_scale = 1.0*km
             displacement_scale = 50.0*km
             shear_modulus = 25.0*GPa
             time_scale = 100.0*year
@@ -34,10 +34,11 @@ class QuasistaticElasticity(General):
     from pythia.pyre.units.length import meter, km
     from pythia.pyre.units.time import year
 
-    lengthScale = pythia.pyre.inventory.dimensional("length_scale", default=100.0 * km)
+    lengthScale = pythia.pyre.inventory.dimensional("length_scale", default=1.0 * km)
     lengthScale.validator = pythia.pyre.inventory.greater(0.0 * meter)
     lengthScale.meta["tip"] = (
-        "Length scale in boundary value problem (size of feature controlling displacement, fault)."
+        "Length scale in boundary value problem (size of feature controlling displacement; "
+        "discretization size on fault for simulations with a fault)."
     )
 
     displacementScale = pythia.pyre.inventory.dimensional(

--- a/pylith/scales/QuasistaticPoroelasticity.py
+++ b/pylith/scales/QuasistaticPoroelasticity.py
@@ -21,7 +21,7 @@ class QuasistaticPoroelasticity(General):
     DOC_CONFIG = {
         "cfg": """
             [normalizer]
-            length_scale = 100.0*km
+            length_scale = 1.0*km
             displacement_scale = 50.0*km
             shear_modulus = 25.0*GPa
             viscosity = 0.001*Pa*s

--- a/tests/fullscale/linearelasticity/faults-3d-buried/generate_gmsh.py
+++ b/tests/fullscale/linearelasticity/faults-3d-buried/generate_gmsh.py
@@ -74,7 +74,6 @@ class App(GenerateMesh):
             BoundaryGroup(name="boundary_zneg", tag=14, dim=2, entities=[self.s_zneg]),
             BoundaryGroup(name="boundary_zpos", tag=15, dim=2, entities=[self.s_zpos]),
             BoundaryGroup(name="fault", tag=20, dim=2, entities=[self.s_fault]),
-            BoundaryGroup(name="fault_edges", tag=21, dim=1, entities=[self.c_fault_yneg, self.c_faultbot, self.c_fault_ypos]),
         )
         for group in face_groups:
             group.create_physical_group()

--- a/tests/manual/2d/faults_2d_buried/faulttest.cfg
+++ b/tests/manual/2d/faults_2d_buried/faulttest.cfg
@@ -25,7 +25,6 @@ interfaces = [fault]
 [pylithapp.problem.interfaces.fault]
 id = 10
 label = fault
-edge = fault_edge
 observers.observer.writer.filename = faultedge_test-fault.h5
 observers.observer.data_fields = [slip, traction_change]
 observers.observer.info_fields = []

--- a/tests/pytests/scales/TestQuasistaticElasticity.py
+++ b/tests/pytests/scales/TestQuasistaticElasticity.py
@@ -28,7 +28,7 @@ class TestElasticityScales(unittest.TestCase):
 
         # Default values
         displacementScale = 1.0 * meter
-        lengthScale = 100.0 * kilometer
+        lengthScale = 1.0 * kilometer
         rigidityScale = 1.0e10 * pascal
         timeScale = 1.0e2 * year
 


### PR DESCRIPTION
- Use automatic marking of buried edges
- Fix `examples/subduction-3d` CUBIT examples to set mesh filename using `mesh_initializer` instead of `mesh_generator`.

Closes #902 