### PR TITLE
FIX: Add configure argument to turn off pip build isolation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,13 @@ fi
 AM_CONDITIONAL([ENABLE_HDF5], [test "$enable_hdf5" = yes])
 AC_SUBST(PYLITH_SWIG_CPPFLAGS)
 
+dnl pip install with build isolation
+AC_ARG_WITH([build-isolation],
+    [AC_HELP_STRING([--with-build-isolation],
+        [run pip with build-isolation @<:@default=yes@:>@])],
+	[build_isolation=$withval],
+	[build_isolation="yes"])
+AM_CONDITIONAL([PIP_BUILD_ISOLATION], [test "$build_isolation" = yes])
 
 dnl ----------------------------------------------------------------------
 dnl C/C++/libtool/install

--- a/pylith/Makefile.am
+++ b/pylith/Makefile.am
@@ -16,8 +16,12 @@ make-manifest:
 	echo "exclude meshio/MeshIOCubit.py" > $@
 endif
 
+if PIP_BUILD_ISOLATION
+else
+PIP_ISOLATION_FLAG=--no-build-isolation
+endif
 install-exec-local: make-manifest
-	$(PYTHON) -m pip install --prefix=$(prefix) $(top_srcdir)
+	$(PYTHON) -m pip install --prefix=$(prefix) $(PIP_ISOLATION_FLAG) $(top_srcdir)
 
 EXTRA_DIST = \
 	__init__.py \


### PR DESCRIPTION
Closes #925 